### PR TITLE
fix(runtime): preserve named volumes across deployment deletion

### DIFF
--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -125,22 +125,11 @@ async fn remove_all_instances(deployment: &mut Deployment, docker: &Docker, kind
         }
     }
 
-    // Clean up named Docker volumes
-    let volumes: Vec<crate::api::dto::deployment::DeploymentVolume> =
-        serde_json::from_str(&deployment.volumes).unwrap_or_default();
-    for volume in volumes {
-        if volume.r#type == "volume" {
-            if let Some(name) = volume.source {
-                match docker
-                    .remove_volume(&name, None::<bollard::query_parameters::RemoveVolumeOptions>)
-                    .await
-                {
-                    Ok(_) => info!("Removed Docker volume '{}'", name),
-                    Err(e) => debug!("Failed to remove Docker volume '{}': {}", name, e),
-                }
-            }
-        }
-    }
+    // Named Docker volumes are intentionally preserved across deployment deletions.
+    // A volume's lifecycle is independent of any single deployment: deleting one
+    // deployment must never destroy data that other deployments (or future
+    // redeployments under the same name) may rely on. Volume removal is an
+    // explicit operation, not a side effect of deployment cleanup.
 }
 
 async fn handle_job_deployment(

--- a/tests/e2e/fixtures/nginx-named-volume.yaml
+++ b/tests/e2e/fixtures/nginx-named-volume.yaml
@@ -1,0 +1,13 @@
+deployments:
+  nginx-named-volume:
+    name: nginx-named-volume
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    volumes:
+      - type: volume
+        source: ring-e2e-named-vol
+        destination: /usr/share/nginx/html
+        driver: local
+        permission: rw

--- a/tests/e2e/t8_named_volume_persists.sh
+++ b/tests/e2e/t8_named_volume_persists.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# T8: a named Docker volume must survive deployment deletion. Deleting a
+# deployment must never destroy data the user explicitly asked to persist.
+# Regression test for the prior behavior where lifecycle.rs removed every
+# named volume referenced by a deployment marked Deleted.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+log "== T8: named volume persists across deployment deletion =="
+
+VOLUME_NAME="ring-e2e-named-vol"
+
+# Start from a clean slate so we can assert volume creation/persistence
+# without ambiguity if a previous run left state behind.
+docker volume rm -f "$VOLUME_NAME" > /dev/null 2>&1 || true
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-named-volume.yaml"
+
+wait_deployment_status "ring-e2e" "nginx-named-volume" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-named-volume")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+assert_docker_container_exists "$DEPLOYMENT_ID"
+
+if ! docker volume inspect "$VOLUME_NAME" > /dev/null 2>&1; then
+  fail "expected named volume '$VOLUME_NAME' to exist after deployment apply"
+fi
+log "named volume '$VOLUME_NAME' exists"
+
+# Write a marker file inside the volume so we can prove its contents
+# survive the deployment's deletion.
+CONTAINER_ID=$(docker ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+docker exec "$CONTAINER_ID" sh -c 'echo persist-me > /usr/share/nginx/html/marker.txt'
+log "wrote marker file inside volume"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+if ! docker volume inspect "$VOLUME_NAME" > /dev/null 2>&1; then
+  fail "named volume '$VOLUME_NAME' was deleted along with the deployment"
+fi
+log "named volume '$VOLUME_NAME' still exists after deployment deletion"
+
+# Mount the volume from a throwaway container and verify the marker is intact.
+CONTENT=$(docker run --rm -v "$VOLUME_NAME:/data" alpine cat /data/marker.txt 2>/dev/null || true)
+if [ "$CONTENT" != "persist-me" ]; then
+  fail "marker file content was lost: got '$CONTENT'"
+fi
+log "marker file content intact: '$CONTENT'"
+
+# Clean up the volume ourselves; the orchestrator must not do it.
+docker volume rm -f "$VOLUME_NAME" > /dev/null 2>&1 || true
+
+log "== T8: PASS =="


### PR DESCRIPTION
## Summary

- Stop removing named Docker volumes when a deployment is marked `Deleted`. A volume's lifecycle is independent of any single deployment: deleting one deployment must never destroy data that other deployments (or future redeployments under the same name) may rely on.
- Volume removal becomes an explicit operation, not a side effect of deployment cleanup.
- Temporary config volume files (`/tmp/ring_configs/<deployment_id>`) are still cleaned up — they are bound to a single deployment, unlike named volumes.

## Why

The previous behavior in `lifecycle.rs::remove_all_instances` iterated over `deployment.volumes` and called `docker.remove_volume(...)` on every entry of `type == "volume"`. Combined with the `Deleted` status being set on every replace/redeploy in `api/.../create.rs`, this meant any redeploy could destroy persistent data. In practice it only didn't because Docker refuses to remove a volume that is still mounted by a running container — so the removal failed silently (`debug!` log) most of the time. The day a container was stopped before the cleanup ran (crash, scale-to-zero, runtime restart), the data would be gone.

## Test plan

- [x] `cargo test` — 177 unit tests pass.
- [x] `bash tests/e2e/t1_create_delete.sh` — PASS.
- [x] `bash tests/e2e/t2_bind_volume.sh` — PASS.
- [x] `bash tests/e2e/t8_named_volume_persists.sh` — new regression test, PASS. Writes a marker file inside a named volume, deletes the deployment, asserts the volume still exists and the marker content is intact.