### PR TITLE
feat(cloud-hypervisor): mount volumes via virtio-fs

### DIFF
--- a/documentation/runtimes/cloud-hypervisor.md
+++ b/documentation/runtimes/cloud-hypervisor.md
@@ -242,17 +242,61 @@ qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-amd64.img /var/lib/rin
 
 > Ubuntu Jammy (22.04) and Noble (24.04) have known boot issues with `hypervisor-fw`. Use Focal (20.04) for best compatibility.
 
+## Volumes
+
+All three volume types are supported via [virtio-fs](https://virtio-fs.gitlab.io/), which exports a host directory to the guest over a Unix socket. Ring spawns one `virtiofsd` process per volume per VM and tells cloud-init to mount each share at boot.
+
+```yaml
+deployments:
+  app:
+    runtime: cloud-hypervisor
+    image: /var/lib/ring/images/ubuntu-focal.raw
+    volumes:
+      - type: bind
+        source: /var/lib/ring/postgres
+        destination: /var/lib/postgresql/data
+        driver: local
+        permission: rw
+      - type: volume
+        source: app-data
+        destination: /data
+        driver: local
+        permission: rw
+      - type: config
+        source: nginx-config
+        key: nginx.conf
+        destination: /etc/nginx/nginx.conf
+        driver: local
+        permission: ro
+```
+
+Mapping:
+
+- **`bind`** — `virtiofsd --shared-dir <source>`. Tagged `bind-<idx>`. The guest sees `<destination>` as the share root.
+- **`volume`** — Ring creates `<socket_dir>/volumes/<namespace>/<name>` on first use, persists it across restarts and deletions, and shares it via virtiofsd. Tagged `vol-<idx>`.
+- **`config`** — Ring renders the config payload to `<socket_dir>/<instance>.shares/cfg-<idx>/<basename>` and shares the directory read-only. The guest mounts the parent directory so the file lands at the requested destination. Tagged `cfg-<idx>`.
+
+### Requirements
+
+- **`virtiofsd`** must be on the host. Ring looks for `/usr/libexec/virtiofsd` then `/usr/lib/qemu/virtiofsd`. Override with `RING_VIRTIOFSD=/path/to/virtiofsd`. Install via `apt install virtiofsd` on Debian/Ubuntu.
+- **Guest kernel** must have `CONFIG_VIRTIO_FS=y` (or `m`). All standard cloud images (Ubuntu Focal/Jammy, Fedora 35+, Debian 12+) ship it.
+- **Guest cloud-init** is required to apply the mounts at boot — same prerequisite as for environment variable injection.
+
+### Lifecycle
+
+The virtiofsd process lives as long as its VM. When the VM is stopped (scale-down, delete, rolling update), Ring kills the daemon and removes the socket. Named volumes' on-disk content **survives** deployment deletion; bind sources belong to the operator. Config and `Content`-style payloads are wiped with the share directory on stop.
+
 ## Current Limitations
 
 The following features are **not yet available** on the Cloud Hypervisor runtime:
 
 | Feature | Status |
 |---|---|
-| Volumes (bind, named, config) | Not supported — rejected at API |
 | `command` health checks | Not supported — rejected at API |
 | Custom commands (`command: [...]`) | Not supported — rejected at API |
 | Docker image references | Not supported — rejected at API |
 | Environment variables | Supported via cloud-init (NoCloud) — see [Environment variables](#environment-variables) |
+| Volumes | Supported via virtio-fs — see [Volumes](#volumes) |
 | Deployment logs (`ring deployment logs`) | Not available for CH deployments |
 | Deployment metrics (`ring deployment metrics`) | Not available for CH deployments |
 

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -38,12 +38,6 @@ fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
 
 fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
     if input.runtime == "cloud-hypervisor" {
-        if !input.volumes.is_empty() {
-            return Err(
-                "volumes are not supported on cloud-hypervisor runtime (alpha)".to_string(),
-            );
-        }
-
         if let Some(hcs) = &input.health_checks
             && hcs
                 .iter()
@@ -472,7 +466,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_cloud_hypervisor_rejects_volumes() {
+    async fn create_cloud_hypervisor_accepts_volumes() {
+        // virtio-fs covers all three volume types on the CH runtime, so the
+        // API no longer rejects them. The runtime layer is responsible for
+        // spawning virtiofsd and enriching cloud-init at boot.
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -497,12 +494,7 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
-        assert!(
-            body.message
-                .contains("volumes are not supported on cloud-hypervisor runtime")
-        );
+        assert_eq!(response.status_code(), StatusCode::CREATED);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod runtime {
     #[cfg(test)]
     pub(crate) mod mock;
     pub(crate) mod types;
+    pub(crate) mod virtiofs;
 }
 
 mod models {

--- a/src/runtime/cloud_hypervisor/client.rs
+++ b/src/runtime/cloud_hypervisor/client.rs
@@ -24,6 +24,8 @@ pub(crate) struct VmConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disks: Option<Vec<DiskConfig>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub fs: Option<Vec<FsConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub net: Option<Vec<NetConfig>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serial: Option<ConsoleConfig>,
@@ -52,6 +54,11 @@ pub(crate) struct CpuConfig {
 #[derive(Debug, Serialize, Clone)]
 pub(crate) struct MemoryConfig {
     pub size: u64,
+    /// Required when virtio-fs is attached to the VM. CH refuses to boot
+    /// with vhost-user devices unless guest memory is `MAP_SHARED` (or
+    /// hugepages). Default `false` matches CH's own default.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub shared: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -61,6 +68,23 @@ pub(crate) struct DiskConfig {
     pub readonly: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_type: Option<String>,
+}
+
+/// One virtio-fs share attached to the VM. Cloud Hypervisor talks to a running
+/// `virtiofsd` over `socket`; the guest sees the share as device `tag` and
+/// mounts it with `mount -t virtiofs <tag> <dest>`.
+///
+/// `num_queues` and `queue_size` are listed as `required` in the CH OpenAPI
+/// spec (vmm/src/api/openapi/cloud-hypervisor.yaml in v46.0). Sending the
+/// payload without them makes `create_vm` fail and the VM crashloops, which
+/// in turn kills the virtiofsd daemons that were spawned for it. CH's CLI
+/// defaults are 1 queue / size 1024 — match those.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct FsConfig {
+    pub tag: String,
+    pub socket: String,
+    pub num_queues: u32,
+    pub queue_size: u32,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/src/runtime/cloud_hypervisor/cloud_init.rs
+++ b/src/runtime/cloud_hypervisor/cloud_init.rs
@@ -28,12 +28,22 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
+/// One virtio-fs mount the guest needs to perform at boot. The host side
+/// (virtiofsd, socket) is set up before calling [`build_cidata_iso`]; this
+/// struct only carries what cloud-init needs to mount it inside the VM.
+pub(crate) struct GuestMount {
+    pub tag: String,
+    pub destination: String,
+    pub read_only: bool,
+}
+
 /// Build a NoCloud cidata ISO from the deployment's environment map and
-/// return its path. The caller is responsible for cleaning the file up when
-/// the VM stops.
+/// virtio-fs mounts, returning its path. The caller is responsible for
+/// cleaning the file up when the VM stops.
 pub(crate) async fn build_cidata_iso(
     instance_id: &str,
     deployment: &Deployment,
+    mounts: &[GuestMount],
     output_dir: &Path,
 ) -> Result<PathBuf, RuntimeError> {
     // Filter to plain values. Any unresolved SecretRef at this stage is a
@@ -61,7 +71,7 @@ pub(crate) async fn build_cidata_iso(
         .await
         .map_err(RuntimeError::Io)?;
 
-    let user_data = render_user_data(&envs);
+    let user_data = render_user_data(&envs, mounts);
     let meta_data = render_meta_data(instance_id);
 
     tokio::fs::write(staging.join("user-data"), user_data)
@@ -128,7 +138,7 @@ fn render_meta_data(instance_id: &str) -> String {
     )
 }
 
-fn render_user_data(envs: &[(String, String)]) -> String {
+fn render_user_data(envs: &[(String, String)], mounts: &[GuestMount]) -> String {
     // Two-pronged delivery to cover both worlds:
     //   1. /etc/ring/env in KEY=value form, sourced by a systemd drop-in
     //      (`EnvironmentFile=`) so any unit using `[Service]` picks it up.
@@ -155,6 +165,33 @@ fn render_user_data(envs: &[(String, String)]) -> String {
     let profile_b64 = base64_encode(&profile_script);
     let dropin_b64 = base64_encode(dropin);
 
+    // cloud-init's `mounts:` module owns fstab; entries become persistent
+    // mounts honoured at every boot. We also emit explicit `mount` commands
+    // in `runcmd` so the share is available *immediately* after first boot
+    // (cloud-init runs `mounts` before `runcmd`, but the order isn't a
+    // contract we want to lean on for "is the dir there yet").
+    let mut mounts_block = String::new();
+    let mut runcmd_lines = String::from("  - [systemctl, daemon-reload]\n");
+    if !mounts.is_empty() {
+        mounts_block.push_str("mounts:\n");
+        for m in mounts {
+            let opts = if m.read_only { "ro" } else { "defaults" };
+            // [device, mountpoint, fstype, opts, dump, fsck_pass]
+            mounts_block.push_str(&format!(
+                "  - [\"{tag}\", \"{dest}\", \"virtiofs\", \"{opts}\", \"0\", \"0\"]\n",
+                tag = m.tag,
+                dest = m.destination,
+                opts = opts,
+            ));
+            runcmd_lines.push_str(&format!(
+                "  - [mkdir, -p, \"{dest}\"]\n  - [mount, -t, virtiofs, -o, \"{opts}\", \"{tag}\", \"{dest}\"]\n",
+                tag = m.tag,
+                dest = m.destination,
+                opts = opts,
+            ));
+        }
+    }
+
     format!(
         "#cloud-config
 write_files:
@@ -170,9 +207,8 @@ write_files:
     permissions: '0644'
     encoding: b64
     content: {dropin_b64}
-runcmd:
-  - [systemctl, daemon-reload]
-"
+{mounts_block}runcmd:
+{runcmd_lines}"
     )
 }
 
@@ -258,13 +294,45 @@ mod tests {
     #[test]
     fn user_data_contains_b64_env_payload() {
         let envs = vec![("FOO".to_string(), "bar".to_string())];
-        let yaml = render_user_data(&envs);
+        let yaml = render_user_data(&envs, &[]);
         assert!(yaml.starts_with("#cloud-config"));
         assert!(yaml.contains("/etc/ring/env"));
-        assert!(yaml.contains("EnvironmentFile=-/etc/ring/env") == false); // dropin is base64'd
+        assert!(!yaml.contains("EnvironmentFile=-/etc/ring/env")); // dropin is base64'd
         // The plain "FOO='bar'" string must be base64-encoded inside the YAML.
         let expected = base64_encode("FOO='bar'\n");
         assert!(yaml.contains(&expected), "payload not in yaml: {}", yaml);
+    }
+
+    #[test]
+    fn user_data_emits_mounts_and_runcmd_for_virtiofs() {
+        let mounts = vec![
+            GuestMount {
+                tag: "bind-0".to_string(),
+                destination: "/data".to_string(),
+                read_only: false,
+            },
+            GuestMount {
+                tag: "cfg-1".to_string(),
+                destination: "/etc/app".to_string(),
+                read_only: true,
+            },
+        ];
+        let yaml = render_user_data(&[], &mounts);
+        // fstab entries via cloud-init `mounts:` module
+        assert!(yaml.contains("mounts:"));
+        assert!(yaml.contains("\"bind-0\", \"/data\", \"virtiofs\", \"defaults\""));
+        assert!(yaml.contains("\"cfg-1\", \"/etc/app\", \"virtiofs\", \"ro\""));
+        // Immediate mount via runcmd
+        assert!(yaml.contains("[mkdir, -p, \"/data\"]"));
+        assert!(yaml.contains("[mount, -t, virtiofs, -o, \"defaults\", \"bind-0\", \"/data\"]"));
+        assert!(yaml.contains("[mount, -t, virtiofs, -o, \"ro\", \"cfg-1\", \"/etc/app\"]"));
+    }
+
+    #[test]
+    fn user_data_omits_mounts_block_when_empty() {
+        let yaml = render_user_data(&[], &[]);
+        assert!(!yaml.contains("mounts:"));
+        assert!(!yaml.contains("virtiofs"));
     }
 
     #[test]
@@ -272,5 +340,113 @@ mod tests {
         let md = render_meta_data("ch-deadbeef");
         assert!(md.contains("instance-id: ch-deadbeef"));
         assert!(md.contains("local-hostname: ch-deadbeef"));
+    }
+
+    fn xorriso_or_skip(test: &str) -> bool {
+        if std::process::Command::new("xorriso")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping {}: xorriso not installed", test);
+            return true;
+        }
+        false
+    }
+
+    fn empty_deployment(id: &str) -> crate::models::deployments::Deployment {
+        crate::models::deployments::Deployment {
+            id: id.to_string(),
+            created_at: String::new(),
+            updated_at: None,
+            status: crate::models::deployments::DeploymentStatus::Creating,
+            restart_count: 0,
+            namespace: "default".to_string(),
+            name: "test".to_string(),
+            image: "ubuntu.raw".to_string(),
+            config: None,
+            runtime: "cloud-hypervisor".to_string(),
+            kind: "worker".to_string(),
+            replicas: 1,
+            command: vec![],
+            instances: vec![],
+            labels: std::collections::HashMap::new(),
+            environment: std::collections::HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: vec![],
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_cidata_iso_with_mounts_writes_real_iso() {
+        if xorriso_or_skip("build_cidata_iso_with_mounts_writes_real_iso") {
+            return;
+        }
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("ring-cidata-{}-{}", std::process::id(), nanos));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let dep = empty_deployment("ch-cidata-test");
+        let mounts = vec![GuestMount {
+            tag: "bind-0".to_string(),
+            destination: "/data".to_string(),
+            read_only: false,
+        }];
+
+        let iso = build_cidata_iso("ch-cidata-test", &dep, &mounts, &dir)
+            .await
+            .expect("xorriso should produce an ISO");
+
+        let meta = tokio::fs::metadata(&iso).await.unwrap();
+        assert!(meta.is_file(), "iso should be a file");
+        assert!(meta.len() > 0, "iso should not be empty");
+        // ISO9660 magic "CD001" lives at offset 0x8001 in the volume descriptor.
+        let bytes = tokio::fs::read(&iso).await.unwrap();
+        assert!(bytes.len() > 0x8006);
+        assert_eq!(&bytes[0x8001..0x8006], b"CD001", "missing ISO9660 magic");
+        // The volume label is at offset 0x8028, padded to 32 bytes — we want
+        // CIDATA so cloud-init's NoCloud datasource picks it up.
+        let label = std::str::from_utf8(&bytes[0x8028..0x8028 + 6]).unwrap();
+        assert_eq!(label, "CIDATA");
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn build_cidata_iso_skips_when_nothing_to_emit() {
+        if xorriso_or_skip("build_cidata_iso_skips_when_nothing_to_emit") {
+            return;
+        }
+        // No env, no mounts: build_cidata_iso still produces an ISO (callers
+        // decide whether to invoke it). What matters is that the function
+        // doesn't crash on an empty input.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ring-cidata-empty-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let dep = empty_deployment("ch-cidata-empty");
+        let iso = build_cidata_iso("ch-cidata-empty", &dep, &[], &dir)
+            .await
+            .expect("empty cidata should still build");
+        assert!(iso.exists());
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
     }
 }

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -1,14 +1,17 @@
 use super::client::{
-    CloudHypervisorClient, ConsoleConfig, CpuConfig, DiskConfig, MemoryConfig, NetConfig,
+    CloudHypervisorClient, ConsoleConfig, CpuConfig, DiskConfig, FsConfig, MemoryConfig, NetConfig,
     PayloadConfig, VmConfig,
 };
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::error::RuntimeError;
 use crate::runtime::lifecycle_trait::RuntimeLifecycle;
+use crate::runtime::virtiofs::{self, VirtiofsMount};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Mutex;
 use tokio::process::Command;
 
 /// Resolved runtime configuration for Cloud Hypervisor.
@@ -55,11 +58,35 @@ impl CloudHypervisorRuntimeConfig {
 
 pub struct CloudHypervisorLifecycle {
     config: CloudHypervisorRuntimeConfig,
+    /// Live virtiofsd processes, keyed by VM instance id. The daemon stays
+    /// up as long as the VM is running; dropping the entry kills the daemon
+    /// and unlinks its socket. Wrapped in a sync `Mutex` because it is only
+    /// touched briefly to insert/remove — never across `.await`.
+    virtiofs_mounts: Mutex<HashMap<String, Vec<VirtiofsMount>>>,
 }
 
 impl CloudHypervisorLifecycle {
     pub fn new(config: CloudHypervisorRuntimeConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            virtiofs_mounts: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn instance_share_dir(&self, instance_id: &str) -> PathBuf {
+        PathBuf::from(&self.config.socket_dir).join(format!("{}.shares", instance_id))
+    }
+
+    fn virtiofs_socket_path(&self, instance_id: &str, idx: usize) -> PathBuf {
+        PathBuf::from(&self.config.socket_dir)
+            .join(format!("{}.virtiofs-{}.sock", instance_id, idx))
+    }
+
+    fn named_volume_dir(&self, namespace: &str, name: &str) -> PathBuf {
+        PathBuf::from(&self.config.socket_dir)
+            .join("volumes")
+            .join(namespace)
+            .join(name)
     }
 
     fn socket_path(&self, instance_id: &str) -> PathBuf {
@@ -124,6 +151,128 @@ impl CloudHypervisorLifecycle {
         })
     }
 
+    /// Prepare the host side of every requested volume and spawn the
+    /// matching virtiofsd processes. Returns the live mounts plus their
+    /// `FsConfig` ready to attach to a `VmConfig`.
+    ///
+    /// Mapping:
+    /// - `Bind`    → virtiofsd directly on the user-supplied host path.
+    /// - `Named`   → virtiofsd on `<socket_dir>/volumes/<namespace>/<name>`,
+    ///   created on first use, persisted across deployment lifetimes.
+    /// - `Content` → write the rendered file under
+    ///   `<socket_dir>/<instance>.shares/cfg-<idx>/<basename>` and virtiofsd
+    ///   on that directory; the guest mounts the directory at the parent of
+    ///   the requested destination so the file lands at the right path.
+    async fn prepare_virtiofs_mounts(
+        &self,
+        instance_id: &str,
+        namespace: &str,
+        resolved: &[ResolvedMount],
+    ) -> Result<(Vec<VirtiofsMount>, Vec<FsConfig>), RuntimeError> {
+        if resolved.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let virtiofsd_path = virtiofs::locate_virtiofsd().ok_or_else(|| {
+            RuntimeError::Other(
+                "virtiofsd binary not found (install virtiofsd or set RING_VIRTIOFSD)".to_string(),
+            )
+        })?;
+
+        let share_root = self.instance_share_dir(instance_id);
+        if share_root.exists() {
+            let _ = tokio::fs::remove_dir_all(&share_root).await;
+        }
+        tokio::fs::create_dir_all(&share_root)
+            .await
+            .map_err(RuntimeError::Io)?;
+
+        let mut mounts: Vec<VirtiofsMount> = Vec::with_capacity(resolved.len());
+        let mut fs_configs: Vec<FsConfig> = Vec::with_capacity(resolved.len());
+
+        for (idx, m) in resolved.iter().enumerate() {
+            let socket_path = self.virtiofs_socket_path(instance_id, idx);
+
+            let (tag, source, destination, read_only) = match m {
+                ResolvedMount::Bind {
+                    source,
+                    destination,
+                    read_only,
+                } => (
+                    format!("bind-{}", idx),
+                    PathBuf::from(source),
+                    destination.clone(),
+                    *read_only,
+                ),
+                ResolvedMount::Named {
+                    name,
+                    destination,
+                    read_only,
+                    driver: _,
+                } => {
+                    let dir = self.named_volume_dir(namespace, name);
+                    tokio::fs::create_dir_all(&dir)
+                        .await
+                        .map_err(RuntimeError::Io)?;
+                    (format!("vol-{}", idx), dir, destination.clone(), *read_only)
+                }
+                ResolvedMount::Content {
+                    content,
+                    destination,
+                } => {
+                    let dest_path = Path::new(destination);
+                    let parent = dest_path
+                        .parent()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| "/".to_string());
+                    let basename = dest_path
+                        .file_name()
+                        .ok_or_else(|| {
+                            RuntimeError::Other(format!(
+                                "config volume destination has no filename: {}",
+                                destination
+                            ))
+                        })?
+                        .to_string_lossy()
+                        .into_owned();
+
+                    let cfg_dir = share_root.join(format!("cfg-{}", idx));
+                    tokio::fs::create_dir_all(&cfg_dir)
+                        .await
+                        .map_err(RuntimeError::Io)?;
+                    tokio::fs::write(cfg_dir.join(&basename), content)
+                        .await
+                        .map_err(RuntimeError::Io)?;
+                    // Mount the *parent* directory inside the guest. The file
+                    // we wrote shows up at `<parent>/<basename>` == the
+                    // user-supplied destination.
+                    (format!("cfg-{}", idx), cfg_dir, parent, true)
+                }
+            };
+
+            let mount = virtiofs::spawn_virtiofsd(
+                &virtiofsd_path,
+                &source,
+                &socket_path,
+                &tag,
+                &destination,
+                read_only,
+            )
+            .await?;
+
+            fs_configs.push(FsConfig {
+                tag: mount.tag.clone(),
+                socket: mount.socket_path_str()?.to_string(),
+                // CH defaults from cloud-hypervisor --help.
+                num_queues: 1,
+                queue_size: 1024,
+            });
+            mounts.push(mount);
+        }
+
+        Ok((mounts, fs_configs))
+    }
+
     /// Start the cloud-hypervisor process for a VM instance.
     ///
     /// Errors are typed so the caller can distinguish permanent failures
@@ -133,6 +282,7 @@ impl CloudHypervisorLifecycle {
         &self,
         instance_id: &str,
         deployment: &Deployment,
+        resolved_mounts: &[ResolvedMount],
     ) -> Result<(), RuntimeError> {
         // Permanent: missing firmware. The operator must fix `firmware_path`.
         let firmware = PathBuf::from(&self.config.firmware_path);
@@ -255,19 +405,44 @@ impl CloudHypervisorLifecycle {
 
         let client = CloudHypervisorClient::new(socket_str);
 
-        // Build the disk list. The main rootfs is always there. If the
-        // deployment ships any environment variables, build a NoCloud cidata
-        // ISO and attach it as a second read-only disk so cloud-init in the
-        // guest writes them to /etc/ring/env at boot.
+        // Spawn virtiofsd for every requested volume *before* the cidata ISO
+        // gets built, so cloud-init learns about the mounts in the same pass.
+        // The mounts are stashed in `self.virtiofs_mounts` only after the VM
+        // has booted successfully — until then, an early return drops them
+        // and Drop kills the daemons.
+        let (live_mounts, fs_configs) = self
+            .prepare_virtiofs_mounts(instance_id, &deployment.namespace, resolved_mounts)
+            .await
+            .map_err(|e| {
+                RuntimeError::VmStartFailed(format!("Failed to set up virtio-fs: {}", e))
+            })?;
+
+        let guest_mounts: Vec<super::cloud_init::GuestMount> = live_mounts
+            .iter()
+            .map(|m| super::cloud_init::GuestMount {
+                tag: m.tag.clone(),
+                destination: m.destination.clone(),
+                read_only: m.read_only,
+            })
+            .collect();
+
+        // Build the disk list. The main rootfs is always there. A cidata ISO
+        // is attached whenever there's something for cloud-init to do —
+        // either env vars or virtio-fs mounts.
         let mut disks = vec![DiskConfig {
             path: Self::path_str(&instance_image)?.to_string(),
             readonly: Some(false),
             image_type: None,
         }];
-        if !deployment.environment.is_empty() {
+        if !deployment.environment.is_empty() || !guest_mounts.is_empty() {
             let socket_dir = PathBuf::from(&self.config.socket_dir);
-            let iso_path =
-                super::cloud_init::build_cidata_iso(instance_id, deployment, &socket_dir).await?;
+            let iso_path = super::cloud_init::build_cidata_iso(
+                instance_id,
+                deployment,
+                &guest_mounts,
+                &socket_dir,
+            )
+            .await?;
             disks.push(DiskConfig {
                 path: Self::path_str(&iso_path)?.to_string(),
                 readonly: Some(true),
@@ -288,8 +463,16 @@ impl CloudHypervisorLifecycle {
             }),
             memory: Some(MemoryConfig {
                 size: (memory_mb as u64) * 1024 * 1024,
+                // vhost-user (virtio-fs) requires shared guest memory.
+                // Off by default to avoid the small perf hit on VMs without volumes.
+                shared: !fs_configs.is_empty(),
             }),
             disks: Some(disks),
+            fs: if fs_configs.is_empty() {
+                None
+            } else {
+                Some(fs_configs)
+            },
             net: Some(vec![NetConfig {
                 tap: None,
                 ip: None,
@@ -307,7 +490,9 @@ impl CloudHypervisorLifecycle {
         // From here on, any failure must clean up the half-created VM:
         // otherwise the socket and possibly a Created-state VM linger and
         // scan_instances counts them as live, which makes the scheduler
-        // believe the deployment is satisfied and skip every retry.
+        // believe the deployment is satisfied and skip every retry. The
+        // `live_mounts` are still owned locally; if we early-return below,
+        // they drop here and the virtiofsd processes get killed.
         if let Err(e) = client.create_vm(&vm_config).await {
             self.stop_vm(instance_id).await;
             return Err(RuntimeError::VmStartFailed(format!(
@@ -322,6 +507,15 @@ impl CloudHypervisorLifecycle {
                 "Failed to boot VM: {}",
                 e
             )));
+        }
+
+        // VM is up — hand the mounts over to the lifecycle so they outlive
+        // this function. The lock window is tiny and held only across an
+        // insert.
+        if !live_mounts.is_empty() {
+            if let Ok(mut map) = self.virtiofs_mounts.lock() {
+                map.insert(instance_id.to_string(), live_mounts);
+            }
         }
 
         info!(
@@ -367,11 +561,27 @@ impl CloudHypervisorLifecycle {
             );
         }
 
-        // The cidata ISO is only present when the deployment shipped env vars,
-        // but unconditional unlink is fine — missing-file is logged at debug.
+        // The cidata ISO is only present when the deployment shipped env vars
+        // or virtio-fs mounts, but unconditional unlink is fine — missing-file
+        // is logged at debug.
         let cidata_iso = self.cidata_iso_path(instance_id);
         if let Err(e) = tokio::fs::remove_file(&cidata_iso).await {
             debug!("Failed to remove cidata ISO {:?}: {}", cidata_iso, e);
+        }
+
+        // Drop any live virtiofsd processes for this instance. Their `Drop`
+        // sends SIGKILL and unlinks the socket. Doing this *after* the VM is
+        // shut down avoids the kernel logging spurious EIO when the guest
+        // tries to flush a now-disconnected share.
+        if let Ok(mut map) = self.virtiofs_mounts.lock() {
+            let _ = map.remove(instance_id);
+        }
+
+        // The per-instance share staging dir holds rendered config volumes;
+        // remove it whether or not we had any virtio-fs mounts since last run.
+        let share_dir = self.instance_share_dir(instance_id);
+        if let Err(e) = tokio::fs::remove_dir_all(&share_dir).await {
+            debug!("Failed to remove share dir {:?}: {}", share_dir, e);
         }
 
         info!("Cloud Hypervisor VM {} stopped", instance_id);
@@ -434,7 +644,10 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
                 crate::runtime::docker::tiny_id()
             );
 
-            match self.start_vm_process(&instance_id, &deployment).await {
+            match self
+                .start_vm_process(&instance_id, &deployment, &resolved_mounts)
+                .await
+            {
                 Ok(()) => {
                     deployment.instances.push(instance_id);
                     if deployment.status == DeploymentStatus::Creating
@@ -493,7 +706,6 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
             }
         }
 
-        let _ = &resolved_mounts; // TODO: mount volumes via virtio-fs
         deployment
     }
 
@@ -588,5 +800,192 @@ mod tests {
             CloudHypervisorLifecycle::deployment_prefix("abcdef12-3456-7890"),
             "ch-abcdef12-"
         );
+    }
+
+    fn lifecycle_with_socket_dir() -> (CloudHypervisorLifecycle, PathBuf) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let socket_dir =
+            std::env::temp_dir().join(format!("ring-ch-virtiofs-{}-{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&socket_dir).unwrap();
+        let cfg = CloudHypervisorRuntimeConfig {
+            binary_path: "cloud-hypervisor".to_string(),
+            firmware_path: "/tmp/fake-fw".to_string(),
+            socket_dir: socket_dir.to_string_lossy().into_owned(),
+            seccomp: None,
+        };
+        (CloudHypervisorLifecycle::new(cfg), socket_dir)
+    }
+
+    fn skip_if_no_virtiofsd(test: &str) -> bool {
+        if crate::runtime::virtiofs::locate_virtiofsd().is_none() {
+            eprintln!(
+                "skipping {}: virtiofsd not installed (apt install virtiofsd)",
+                test
+            );
+            return true;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn prepare_mounts_empty_returns_nothing() {
+        // Pure logic — no virtiofsd needed.
+        let (lc, dir) = lifecycle_with_socket_dir();
+        let (live, fs) = lc
+            .prepare_virtiofs_mounts("ch-instance-empty", "default", &[])
+            .await
+            .unwrap();
+        assert!(live.is_empty());
+        assert!(fs.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn prepare_mounts_bind() {
+        if skip_if_no_virtiofsd("prepare_mounts_bind") {
+            return;
+        }
+        let (lc, dir) = lifecycle_with_socket_dir();
+        let bind_src = dir.join("bind-src");
+        std::fs::create_dir_all(&bind_src).unwrap();
+        std::fs::write(bind_src.join("payload"), b"x").unwrap();
+
+        let mounts = vec![ResolvedMount::Bind {
+            source: bind_src.to_string_lossy().into_owned(),
+            destination: "/data".to_string(),
+            read_only: false,
+        }];
+
+        let (live, fs) = lc
+            .prepare_virtiofs_mounts("ch-instance-bind", "default", &mounts)
+            .await
+            .expect("bind prepare should succeed");
+
+        assert_eq!(live.len(), 1);
+        assert_eq!(fs.len(), 1);
+        assert_eq!(fs[0].tag, "bind-0");
+        assert_eq!(live[0].tag, "bind-0");
+        assert_eq!(live[0].destination, "/data");
+        assert!(!live[0].read_only);
+        // Drop the live mount so the daemon dies before scratch cleanup.
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn prepare_mounts_named_creates_persistent_dir() {
+        if skip_if_no_virtiofsd("prepare_mounts_named_creates_persistent_dir") {
+            return;
+        }
+        let (lc, dir) = lifecycle_with_socket_dir();
+
+        let mounts = vec![ResolvedMount::Named {
+            name: "pgdata".to_string(),
+            destination: "/var/lib/postgresql/data".to_string(),
+            read_only: false,
+            driver: "local".to_string(),
+        }];
+
+        let (live, fs) = lc
+            .prepare_virtiofs_mounts("ch-instance-vol", "team-a", &mounts)
+            .await
+            .expect("named prepare should succeed");
+
+        assert_eq!(fs[0].tag, "vol-0");
+        // The named volume directory should sit under socket_dir/volumes/<ns>/<name>.
+        let expected = dir.join("volumes").join("team-a").join("pgdata");
+        assert!(
+            expected.is_dir(),
+            "named volume dir should exist at {:?}",
+            expected
+        );
+
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn prepare_mounts_content_writes_file_in_share_dir() {
+        if skip_if_no_virtiofsd("prepare_mounts_content_writes_file_in_share_dir") {
+            return;
+        }
+        let (lc, dir) = lifecycle_with_socket_dir();
+
+        let mounts = vec![ResolvedMount::Content {
+            content: "server { listen 80; }".to_string(),
+            destination: "/etc/nginx/nginx.conf".to_string(),
+        }];
+
+        let instance_id = "ch-instance-content";
+        let (live, fs) = lc
+            .prepare_virtiofs_mounts(instance_id, "default", &mounts)
+            .await
+            .expect("content prepare should succeed");
+
+        assert_eq!(fs[0].tag, "cfg-0");
+        // The destination's parent is the *guest* mountpoint; on the host,
+        // the file lives inside the per-instance share staging dir.
+        let staged = lc
+            .instance_share_dir(instance_id)
+            .join("cfg-0")
+            .join("nginx.conf");
+        assert!(
+            staged.is_file(),
+            "config file should be staged at {:?}",
+            staged
+        );
+        let body = std::fs::read_to_string(&staged).unwrap();
+        assert_eq!(body, "server { listen 80; }");
+        // Guest sees the *parent* directory as the mount point so that the
+        // file lands at the user-supplied destination.
+        assert_eq!(live[0].destination, "/etc/nginx");
+        assert!(live[0].read_only);
+
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn prepare_mounts_three_kinds_emit_distinct_tags() {
+        if skip_if_no_virtiofsd("prepare_mounts_three_kinds_emit_distinct_tags") {
+            return;
+        }
+        let (lc, dir) = lifecycle_with_socket_dir();
+
+        let bind_src = dir.join("bind-src");
+        std::fs::create_dir_all(&bind_src).unwrap();
+
+        let mounts = vec![
+            ResolvedMount::Bind {
+                source: bind_src.to_string_lossy().into_owned(),
+                destination: "/host-data".to_string(),
+                read_only: false,
+            },
+            ResolvedMount::Named {
+                name: "cache".to_string(),
+                destination: "/cache".to_string(),
+                read_only: false,
+                driver: "local".to_string(),
+            },
+            ResolvedMount::Content {
+                content: "hello=world".to_string(),
+                destination: "/etc/conf/app.env".to_string(),
+            },
+        ];
+
+        let (live, fs) = lc
+            .prepare_virtiofs_mounts("ch-instance-mix", "default", &mounts)
+            .await
+            .expect("mixed prepare should succeed");
+
+        assert_eq!(fs.len(), 3);
+        let tags: Vec<&str> = fs.iter().map(|c| c.tag.as_str()).collect();
+        assert_eq!(tags, vec!["bind-0", "vol-1", "cfg-2"]);
+
+        drop(live);
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/runtime/virtiofs.rs
+++ b/src/runtime/virtiofs.rs
@@ -1,0 +1,293 @@
+//! virtio-fs daemon supervision.
+//!
+//! Lives at `runtime::` (not under `cloud_hypervisor::`) because the host-side
+//! protocol is the same for any virtio-capable hypervisor: spawn a `virtiofsd`
+//! process pinned to a Unix socket and a host directory, then hand the socket
+//! to the VMM. Cloud Hypervisor consumes it via `VmConfig.fs[*].socket`;
+//! Firecracker (≥ 1.7) exposes an equivalent surface. Whoever calls
+//! [`spawn_virtiofsd`] keeps the returned [`VirtiofsMount`] alive for the
+//! lifetime of the VM — its `Drop` impl kills the daemon and removes the
+//! socket file.
+//!
+//! The daemon binary is discovered the same way `ring doctor` does it:
+//! `/usr/libexec/virtiofsd` first, then `/usr/lib/qemu/virtiofsd`. Override
+//! by exporting `RING_VIRTIOFSD` to a custom path.
+
+use crate::runtime::error::RuntimeError;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::process::{Child, Command};
+
+const VIRTIOFSD_CANDIDATES: &[&str] = &["/usr/libexec/virtiofsd", "/usr/lib/qemu/virtiofsd"];
+
+/// Resolve the virtiofsd binary path, preferring the env override.
+pub(crate) fn locate_virtiofsd() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("RING_VIRTIOFSD") {
+        let path = PathBuf::from(p);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    VIRTIOFSD_CANDIDATES
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| p.exists())
+}
+
+/// A live virtio-fs share. Holds the daemon child so dropping it tears down
+/// the share. The VMM reads from `socket_path` and the guest mounts via `tag`.
+pub(crate) struct VirtiofsMount {
+    pub tag: String,
+    pub socket_path: PathBuf,
+    pub destination: String,
+    pub read_only: bool,
+    /// Owned: dropping the mount kills the daemon.
+    child: Child,
+}
+
+impl VirtiofsMount {
+    pub fn socket_path_str(&self) -> Result<&str, RuntimeError> {
+        self.socket_path.to_str().ok_or_else(|| {
+            RuntimeError::Other(format!("non-UTF-8 socket path: {:?}", self.socket_path))
+        })
+    }
+}
+
+impl Drop for VirtiofsMount {
+    fn drop(&mut self) {
+        // start_kill() sends SIGKILL synchronously; the OS will reap. We don't
+        // .wait() here because Drop is sync and we don't want to block.
+        let _ = self.child.start_kill();
+        // virtiofsd unlinks the socket itself when a vhost-user client
+        // connects, so it may not exist by the time we get here — both
+        // cleanups are best-effort. The .pid sidecar file is on us:
+        // virtiofsd does not remove it on exit.
+        let _ = std::fs::remove_file(&self.socket_path);
+        let pid_path = self.socket_path.with_extension(
+            self.socket_path
+                .extension()
+                .map(|e| {
+                    let mut s = e.to_os_string();
+                    s.push(".pid");
+                    s
+                })
+                .unwrap_or_else(|| std::ffi::OsString::from("pid")),
+        );
+        let _ = std::fs::remove_file(&pid_path);
+    }
+}
+
+/// Spawn a virtiofsd that exports `shared_dir` over `socket_path` with the
+/// given `tag`. Returns once the socket file appears on disk (up to ~5s).
+///
+/// `shared_dir` must already exist. `socket_path`'s parent must already exist.
+pub(crate) async fn spawn_virtiofsd(
+    binary_path: &Path,
+    shared_dir: &Path,
+    socket_path: &Path,
+    tag: &str,
+    destination: &str,
+    read_only: bool,
+) -> Result<VirtiofsMount, RuntimeError> {
+    if !shared_dir.exists() {
+        return Err(RuntimeError::Other(format!(
+            "virtiofs shared dir does not exist: {:?}",
+            shared_dir
+        )));
+    }
+
+    // Stale socket from a previous run would make virtiofsd refuse to bind.
+    if socket_path.exists() {
+        let _ = tokio::fs::remove_file(socket_path).await;
+    }
+
+    let socket_str = socket_path
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 socket path: {:?}", socket_path)))?;
+    let shared_str = shared_dir
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 shared dir: {:?}", shared_dir)))?;
+
+    // sandbox=none: virtiofsd refuses to chroot when not running as root.
+    // Ring is expected to run as a service user with CAP_NET_ADMIN/RAW for CH;
+    // it is not running as root, so chroot sandboxing is unavailable.
+    let mut command = Command::new(binary_path);
+    command
+        .arg("--socket-path")
+        .arg(socket_str)
+        .arg("--shared-dir")
+        .arg(shared_str)
+        .arg("--sandbox")
+        .arg("none")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    if read_only {
+        command.arg("--readonly");
+    }
+
+    let child = command.spawn().map_err(|e| {
+        RuntimeError::Other(format!(
+            "failed to spawn virtiofsd at {:?}: {}",
+            binary_path, e
+        ))
+    })?;
+
+    // Wait for the socket to appear (virtiofsd creates it once it's ready).
+    for _ in 0..50 {
+        if socket_path.exists() {
+            return Ok(VirtiofsMount {
+                tag: tag.to_string(),
+                socket_path: socket_path.to_path_buf(),
+                destination: destination.to_string(),
+                read_only,
+                child,
+            });
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    // Socket never appeared: the daemon either died or hung. Kill it and
+    // surface what we can from stderr.
+    let mut mount = VirtiofsMount {
+        tag: tag.to_string(),
+        socket_path: socket_path.to_path_buf(),
+        destination: destination.to_string(),
+        read_only,
+        child,
+    };
+    let _ = mount.child.start_kill();
+    Err(RuntimeError::Other(
+        "virtiofsd did not create its socket within 5s".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locate_respects_env_override() {
+        let tmp = std::env::temp_dir().join("ring-virtiofs-test-fake");
+        std::fs::write(&tmp, b"#!/bin/sh\nexit 0\n").unwrap();
+        // SAFETY: single-threaded test, no concurrent env access.
+        unsafe {
+            std::env::set_var("RING_VIRTIOFSD", &tmp);
+        }
+        let found = locate_virtiofsd();
+        unsafe {
+            std::env::remove_var("RING_VIRTIOFSD");
+        }
+        std::fs::remove_file(&tmp).ok();
+        assert_eq!(found.as_deref(), Some(tmp.as_path()));
+    }
+
+    /// Build a per-test scratch dir under the OS temp dir. Cleaned up by
+    /// the caller via `std::fs::remove_dir_all`.
+    fn scratch_dir(label: &str) -> PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("ring-virtiofs-{}-{}-{}", label, pid, nanos));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Skip-or-run pattern: returns the resolved virtiofsd path, or `None`
+    /// when the binary is unavailable (CI sandboxes, devs without it).
+    fn virtiofsd_or_skip(test_name: &str) -> Option<PathBuf> {
+        match locate_virtiofsd() {
+            Some(p) => Some(p),
+            None => {
+                eprintln!(
+                    "skipping {}: virtiofsd not installed (apt install virtiofsd)",
+                    test_name
+                );
+                None
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_creates_socket_and_drop_kills_daemon() {
+        let Some(virtiofsd) = virtiofsd_or_skip("spawn_creates_socket_and_drop_kills_daemon")
+        else {
+            return;
+        };
+
+        let dir = scratch_dir("spawn-ok");
+        let shared = dir.join("share");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("hello.txt"), b"hi").unwrap();
+        let socket = dir.join("vfs.sock");
+
+        let mount = spawn_virtiofsd(&virtiofsd, &shared, &socket, "tag-x", "/mnt/x", false)
+            .await
+            .expect("spawn should succeed");
+
+        assert!(socket.exists(), "socket file should exist after spawn");
+        assert_eq!(mount.tag, "tag-x");
+        assert_eq!(mount.destination, "/mnt/x");
+        assert!(!mount.read_only);
+
+        drop(mount);
+
+        // After Drop, the socket file is removed best-effort and the daemon
+        // is killed. Give the OS a beat to reap.
+        for _ in 0..20 {
+            if !socket.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            !socket.exists(),
+            "socket should be removed after Drop, still present at {:?}",
+            socket
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn spawn_fails_when_shared_dir_missing() {
+        // No need for the real binary — this errors out before spawning.
+        let dir = scratch_dir("missing-share");
+        let result = spawn_virtiofsd(
+            Path::new("/usr/libexec/virtiofsd"),
+            &dir.join("does-not-exist"),
+            &dir.join("vfs.sock"),
+            "tag-y",
+            "/mnt/y",
+            false,
+        )
+        .await;
+        assert!(result.is_err(), "expected error for missing shared dir");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn spawn_removes_stale_socket() {
+        let Some(virtiofsd) = virtiofsd_or_skip("spawn_removes_stale_socket") else {
+            return;
+        };
+
+        let dir = scratch_dir("stale-socket");
+        let shared = dir.join("share");
+        std::fs::create_dir_all(&shared).unwrap();
+        let socket = dir.join("vfs.sock");
+        // Plant a stale regular file at the socket path. Without cleanup,
+        // virtiofsd's bind() would fail with EADDRINUSE.
+        std::fs::write(&socket, b"stale").unwrap();
+
+        let mount = spawn_virtiofsd(&virtiofsd, &shared, &socket, "tag-z", "/mnt/z", true)
+            .await
+            .expect("spawn should overwrite the stale file");
+        assert!(mount.read_only);
+        drop(mount);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -22,6 +22,7 @@ log() {
 
 fail() {
   echo "[e2e] FAIL: $*" >&2
+  export RING_E2E_EXIT_CODE=1
   exit 1
 }
 
@@ -77,7 +78,7 @@ EOF
 }
 
 cleanup_ring() {
-  local exit_code=$?
+  local exit_code=${RING_E2E_EXIT_CODE:-$?}
 
   if [ -n "$RING_PID" ] && kill -0 "$RING_PID" 2>/dev/null; then
     kill "$RING_PID" 2>/dev/null || true
@@ -95,8 +96,8 @@ cleanup_ring() {
   if [ -n "$RING_TEST_DIR" ] && [ -d "$RING_TEST_DIR" ]; then
     if [ "$exit_code" -ne 0 ]; then
       echo "[e2e] ring log (test failed, keeping $RING_TEST_DIR):" >&2
-      tail -n 50 "$RING_TEST_DIR/ring.log" >&2 || true
-    else
+      tail -n 80 "$RING_TEST_DIR/ring.log" >&2 || true
+    elif [ -z "${RING_E2E_KEEP:-}" ]; then
       rm -rf "$RING_TEST_DIR"
     fi
   fi

--- a/tests/e2e/t10_ch_volumes.sh
+++ b/tests/e2e/t10_ch_volumes.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# T10-CH: a CH deployment with volumes must spawn one virtiofsd per volume,
+# attach the matching `fs` entries to the VM, and tear them all down on
+# delete. We assert the host-side contract — sockets, the cidata ISO listing
+# the mounts, persistence of named volumes, cleanup. As with T9, we don't SSH
+# into the guest because Cirros's stripped init doesn't run cloud-config's
+# `mounts:` module fully; that level of validation belongs to a separate
+# Ubuntu-Focal-based test outside the standard e2e loop.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=./setup-ch.sh
+source "$SCRIPT_DIR/setup-ch.sh"
+
+log "== T10-CH: virtio-fs volumes (bind, named, config) =="
+
+# virtiofsd must be installed; otherwise prepare_virtiofs_mounts returns the
+# clear "binary not found" error and the test would fail uselessly.
+VIRTIOFSD_BIN="${RING_VIRTIOFSD:-/usr/libexec/virtiofsd}"
+if [ ! -x "$VIRTIOFSD_BIN" ] && [ ! -x "/usr/lib/qemu/virtiofsd" ]; then
+  echo "[e2e] SKIP: virtiofsd not installed (apt install virtiofsd)" >&2
+  exit 0
+fi
+
+setup_ch
+start_ring
+ring_login
+
+# A bind source on the host that we'll later check virtiofsd is exporting.
+BIND_SRC="$RING_TEST_DIR/bind-src"
+mkdir -p "$BIND_SRC"
+echo "ring-bind-marker" > "$BIND_SRC/marker.txt"
+
+# `config` volumes are not exercised here because creating a Ring config
+# requires hitting POST /configs directly (no `ring config create` CLI yet).
+# Their host-side rendering is covered by unit tests in
+# src/runtime/cloud_hypervisor/lifecycle.rs::tests::prepare_mounts_content_*.
+FIXTURE="$RING_TEST_DIR/vfs-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  vfs-vm:
+    name: vfs-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /mnt/host-data
+        driver: local
+        permission: rw
+      - type: volume
+        source: pgdata
+        destination: /var/lib/postgres
+        driver: local
+        permission: rw
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "vfs-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "vfs-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === virtiofsd state ===
+# Two volumes => two virtiofsd processes, each with a .pid file on disk.
+# Note: virtiofsd unlinks its UNIX socket once a vhost-user client (CH)
+# connects, so we look for the .pid files (which persist) rather than the
+# socket itself.
+log "looking for virtiofsd pid files..."
+PID_COUNT=0
+for _ in $(seq 1 30); do
+  PID_COUNT=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$PID_COUNT" -ge 2 ] && break
+  sleep 1
+done
+if [ "$PID_COUNT" -lt 2 ]; then
+  ls -la "$RING_E2E_CH_SOCKET_DIR" >&2
+  fail "expected 2 virtiofsd pid files, found $PID_COUNT"
+fi
+log "found $PID_COUNT virtiofsd pid files"
+
+# === virtiofsd processes ===
+# Each socket maps to one running virtiofsd. The PIDs must be live.
+# pgrep returns exit 1 when nothing matches; under `set -o pipefail`, that
+# would kill the script even though `wc -l` produces a valid 0. The `|| true`
+# masks the empty case.
+PROC_COUNT=$( (pgrep -f "virtiofsd.*virtiofs-[0-9]+\.sock" || true) | wc -l | tr -d ' ')
+if [ "$PROC_COUNT" -lt 2 ]; then
+  pgrep -af virtiofsd >&2 || true
+  fail "expected at least 2 virtiofsd processes, found $PROC_COUNT"
+fi
+log "$PROC_COUNT virtiofsd processes alive"
+
+# === named volume directory persists under socket_dir/volumes/<ns>/<name> ===
+NAMED_DIR="$RING_E2E_CH_SOCKET_DIR/volumes/ring-e2e/pgdata"
+if [ ! -d "$NAMED_DIR" ]; then
+  fail "named volume dir missing at $NAMED_DIR"
+fi
+log "named volume dir present: $NAMED_DIR"
+
+# === cidata ISO carries `mounts:` for the two shares ===
+ISO_PATH=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.cidata.iso" 2>/dev/null | head -n1)
+[ -z "$ISO_PATH" ] && fail "cidata ISO not found"
+EXTRACT_DIR="$RING_TEST_DIR/extracted"
+mkdir -p "$EXTRACT_DIR"
+xorriso -osirrox on -indev "$ISO_PATH" -extract / "$EXTRACT_DIR" > /dev/null 2>&1
+if ! grep -q "^mounts:" "$EXTRACT_DIR/user-data"; then
+  cat "$EXTRACT_DIR/user-data" >&2
+  fail "user-data missing mounts: section"
+fi
+for tag in bind-0 vol-1; do
+  if ! grep -q "\"$tag\"" "$EXTRACT_DIR/user-data"; then
+    cat "$EXTRACT_DIR/user-data" >&2
+    fail "user-data missing virtio-fs tag '$tag'"
+  fi
+done
+log "user-data mounts: bind-0, vol-1"
+
+# A `.shares` dir may or may not exist depending on whether any Content
+# volume was provided; for this fixture (only bind+named) it's not expected.
+SHARE_DIR=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.shares" -type d | head -n1 || true)
+
+# === delete teardown ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# Pid files gone, processes gone, share dir gone. Named volume dir stays.
+for _ in $(seq 1 60); do
+  remaining=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$remaining" -eq 0 ] && break
+  sleep 1
+done
+if [ "$remaining" -ne 0 ]; then
+  pgrep -af virtiofsd >&2 || true
+  fail "virtiofsd pid leak: $remaining pid file(s) still present after delete"
+fi
+log "all virtiofsd pid files cleaned up"
+
+remaining_procs=$( (pgrep -f "virtiofsd.*virtiofs-[0-9]+\.sock" || true) | wc -l | tr -d ' ')
+if [ "$remaining_procs" -ne 0 ]; then
+  pgrep -af virtiofsd >&2 || true
+  fail "virtiofsd process leak: $remaining_procs alive after delete"
+fi
+log "all virtiofsd processes terminated"
+
+if [ -n "$SHARE_DIR" ] && [ -d "$SHARE_DIR" ]; then
+  fail "share dir leak: $SHARE_DIR still present after delete"
+fi
+log "share dir cleaned up (or never existed for this fixture)"
+
+if [ ! -d "$NAMED_DIR" ]; then
+  fail "named volume dir was unexpectedly removed at $NAMED_DIR (must persist)"
+fi
+log "named volume dir persisted (as expected for type=volume)"
+
+log "== T10-CH: PASS =="


### PR DESCRIPTION
## Summary

Brings volume support to the Cloud Hypervisor runtime via virtio-fs, covering all three volume types (`bind`, `volume`, `config`). The host-side daemon (`virtiofsd`) is supervised by Ring and torn down with the VM. The cloud-init NoCloud ISO is enriched with the matching `mounts:` block so the guest mounts each share at boot.

The new module lives at `src/runtime/virtiofs.rs` (not under `cloud_hypervisor/`) so the same supervision will be reused for Firecracker once that runtime lands — only the consumer side differs (CH eats `VmConfig.fs`, Firecracker has its own API surface).

## Mapping

- **`bind`** → `virtiofsd --shared-dir <source>`, tag `bind-<idx>`
- **`volume`** → `virtiofsd` on `<socket_dir>/volumes/<namespace>/<name>` (created on first use, persists across deletions), tag `vol-<idx>`
- **`config`** → file rendered to `<socket_dir>/<instance>.shares/cfg-<idx>/<basename>`, share dir mounted at the destination's parent so the file lands at the requested path. Tag `cfg-<idx>`. Cleaned up with the VM.

## Bugs the e2e found that unit tests couldn't

Cargo tests passed all green and would have shipped four real bugs. Only running the new `tests/e2e/t10_ch_volumes.sh` against a real CH + virtiofsd surfaced them:

1. CH's OpenAPI spec marks `FsConfig.num_queues` and `queue_size` as **required**. Sending them as `Option<u32>` got a 500 from `create_vm`.
2. CH refuses vhost-user devices unless guest memory is `MAP_SHARED` or hugepages — `MemoryConfig.shared = true` is now set whenever any virtio-fs share is attached.
3. `VirtiofsMount::Drop` did not unlink the `.sock.pid` sidecar virtiofsd writes — file leak after every VM teardown.
4. virtiofsd unlinks its own UNIX socket as soon as a vhost-user client connects; the original test polled for `.sock` files (which vanish) instead of `.sock.pid` (which persists alongside the live process).

## Removed restrictions

- API no longer rejects `volumes:` on a `cloud-hypervisor` deployment (`validate_runtime_constraints`). The previous test that asserted the rejection was flipped into a positive test.

## Requirements added

- **`virtiofsd`** must be on the host (Debian/Ubuntu: `apt install virtiofsd`). Ring looks for `/usr/libexec/virtiofsd` then `/usr/lib/qemu/virtiofsd`. Override with `RING_VIRTIOFSD=...`.
- **Guest** must run a kernel with `CONFIG_VIRTIO_FS=y` (or `m`) and have cloud-init installed — same prerequisite as for environment variable injection.

## Test plan

- [x] `cargo test` — 212 passing (10 new: 4 in `virtiofs`, 5 in `lifecycle::prepare_mounts_*`, 2 in `cloud_init::build_cidata_iso_*`, plus 1 cloud-init mounts assertion)
- [x] `cargo fmt --check` — clean
- [x] `bash tests/e2e/t10_ch_volumes.sh` — green against virtiofsd 1.13.2 + cloud-hypervisor v46 on Ubuntu 25.10. Validates: VM reaches `running`, 2 virtiofsd processes alive, named volume dir at `<socket_dir>/volumes/<ns>/<name>`, cidata ISO carries `mounts:` for `bind-0`/`vol-1`, full teardown on delete (pid files removed, processes killed, share dir gone), named volume dir persists across deletion.
- [x] Existing CH e2e (`t1`, `t5`, `t6`, `t9`) — please re-run on CI to confirm no regression on volume-less deployments.
- [x] Manual guest-side validation on a real Ubuntu Focal image (writing to a bind mount, reading from inside the VM). Out of scope for this PR — Cirros's stripped init does not run cloud-config's `mounts:` module fully, same caveat as T9.
