### PR TITLE
feat(cloud-hypervisor): publish ports via tap + socat

### DIFF
--- a/documentation/runtimes/cloud-hypervisor.md
+++ b/documentation/runtimes/cloud-hypervisor.md
@@ -286,6 +286,42 @@ Mapping:
 
 The virtiofsd process lives as long as its VM. When the VM is stopped (scale-down, delete, rolling update), Ring kills the daemon and removes the socket. Named volumes' on-disk content **survives** deployment deletion; bind sources belong to the operator. Config and `Content`-style payloads are wiped with the share directory on stop.
 
+## Port mapping
+
+Publish guest ports on the host with the same `ports:` field as the Docker runtime:
+
+```yaml
+deployments:
+  api:
+    runtime: cloud-hypervisor
+    image: /var/lib/ring/images/ubuntu-focal.raw
+    ports:
+      - { published: 8080, target: 80 }
+      - { published: 5432, target: 5432 }
+```
+
+### How it works
+
+For each VM with at least one declared port, Ring derives a deterministic /30 subnet under `10.42.0.0/16` from the instance id. Cloud Hypervisor creates a tap interface (`ring-<14-bit-hex>`) and brings up its host-side IP; cloud-init configures the matching guest-side IP on the primary NIC at first boot. Ring then spawns one `socat` process per port mapping that forwards `0.0.0.0:<published>` on the host to `<guest_ip>:<target>`.
+
+Why a userspace proxy and not iptables? `socat` runs without extra capabilities, surfaces port conflicts as a clean `bind: address already in use` and cleans up via plain SIGKILL — there's no leftover NAT rule to garbage-collect on a Ring crash. The throughput trade-off is negligible for the workloads the CH runtime targets (HTTP, dev databases). A future iteration may switch to `nftables` DNAT rules; tracked in the project roadmap.
+
+### Requirements
+
+- **`socat`** must be on the host. Install via `apt install socat` on Debian/Ubuntu.
+- The guest kernel needs the `virtio_net` driver (every standard cloud image ships it).
+- The guest's primary NIC must respond to `enp0s3`, `ens3` or `eth0` — Ring's cloud-init dropin probes those names in order.
+
+### Lifecycle
+
+Each `socat` lives as long as its VM. On `deployment delete` (or scaledown / rolling update / crashloop eviction), Ring sends SIGKILL to the matching socat processes and frees the listening ports. CH itself owns the tap device and removes it on VM shutdown.
+
+### Limitations
+
+- **No automatic conflict detection** — if `published` is already bound on the host, `socat` fails to start and the port silently does not become available; the VM still boots. Inspect `ring deployment events` if a port doesn't respond.
+- **TCP only** — `socat`'s configuration is `TCP4-LISTEN`/`TCP4`. UDP forwarding requires a separate config and is not wired up yet.
+- **No bandwidth shaping or connection limits** — the forwarder is permissive by design.
+
 ## Current Limitations
 
 The following features are **not yet available** on the Cloud Hypervisor runtime:
@@ -297,6 +333,7 @@ The following features are **not yet available** on the Cloud Hypervisor runtime
 | Docker image references | Not supported — rejected at API |
 | Environment variables | Supported via cloud-init (NoCloud) — see [Environment variables](#environment-variables) |
 | Volumes | Supported via virtio-fs — see [Volumes](#volumes) |
+| Port mapping | Supported via socat userspace forwarders — see [Port mapping](#port-mapping) |
 | Deployment logs (`ring deployment logs`) | Not available for CH deployments |
 | Deployment metrics (`ring deployment metrics`) | Not available for CH deployments |
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -77,6 +77,15 @@ struct Deployment {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     health_checks: Vec<HealthCheck>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ports: Vec<Port>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct Port {
+    published: u16,
+    target: u16,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -603,6 +612,7 @@ mod tests {
             command: Vec::new(),
             resources: None,
             health_checks: Vec::new(),
+            ports: Vec::new(),
         };
 
         assert!(deployment.validate().is_ok());
@@ -822,6 +832,7 @@ deployments:
             ],
             resources: None,
             health_checks: Vec::new(),
+            ports: Vec::new(),
         };
 
         let mut env_vars = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,11 @@ mod runtime {
     pub(crate) mod cloud_hypervisor;
     pub(crate) mod docker;
     pub(crate) mod error;
+    pub(crate) mod host_net;
     pub(crate) mod lifecycle_trait;
     #[cfg(test)]
     pub(crate) mod mock;
+    pub(crate) mod port_forwarder;
     pub(crate) mod types;
     pub(crate) mod virtiofs;
 }

--- a/src/runtime/cloud_hypervisor/cloud_init.rs
+++ b/src/runtime/cloud_hypervisor/cloud_init.rs
@@ -37,13 +37,25 @@ pub(crate) struct GuestMount {
     pub read_only: bool,
 }
 
-/// Build a NoCloud cidata ISO from the deployment's environment map and
-/// virtio-fs mounts, returning its path. The caller is responsible for
-/// cleaning the file up when the VM stops.
+/// Static network config Ring asks the guest to apply on its primary NIC.
+/// All values come from `runtime::host_net::InstanceNet`, propagated through
+/// the runtime layer so cloud-init can write a netplan/networkd dropin.
+pub(crate) struct GuestNet {
+    pub guest_ip: String,
+    pub host_ip: String,
+    pub prefix_len: u8,
+    pub mac: String,
+}
+
+/// Build a NoCloud cidata ISO from the deployment's environment map,
+/// virtio-fs mounts and (optionally) a static network configuration,
+/// returning its path. The caller is responsible for cleaning the file up
+/// when the VM stops.
 pub(crate) async fn build_cidata_iso(
     instance_id: &str,
     deployment: &Deployment,
     mounts: &[GuestMount],
+    net: Option<&GuestNet>,
     output_dir: &Path,
 ) -> Result<PathBuf, RuntimeError> {
     // Filter to plain values. Any unresolved SecretRef at this stage is a
@@ -71,7 +83,7 @@ pub(crate) async fn build_cidata_iso(
         .await
         .map_err(RuntimeError::Io)?;
 
-    let user_data = render_user_data(&envs, mounts);
+    let user_data = render_user_data(&envs, mounts, net);
     let meta_data = render_meta_data(instance_id);
 
     tokio::fs::write(staging.join("user-data"), user_data)
@@ -138,7 +150,11 @@ fn render_meta_data(instance_id: &str) -> String {
     )
 }
 
-fn render_user_data(envs: &[(String, String)], mounts: &[GuestMount]) -> String {
+fn render_user_data(
+    envs: &[(String, String)],
+    mounts: &[GuestMount],
+    net: Option<&GuestNet>,
+) -> String {
     // Two-pronged delivery to cover both worlds:
     //   1. /etc/ring/env in KEY=value form, sourced by a systemd drop-in
     //      (`EnvironmentFile=`) so any unit using `[Service]` picks it up.
@@ -172,6 +188,23 @@ fn render_user_data(envs: &[(String, String)], mounts: &[GuestMount]) -> String 
     // contract we want to lean on for "is the dir there yet").
     let mut mounts_block = String::new();
     let mut runcmd_lines = String::from("  - [systemctl, daemon-reload]\n");
+
+    // Static network configuration on the primary NIC. We avoid declarative
+    // formats (netplan, NetworkManager keyfiles, systemd-networkd dropins)
+    // because each Linux distro ships a different one — the only thing
+    // every modern guest reliably ships is `ip` from iproute2. We assume
+    // the kernel exposes the NIC under a predictable name; on Cloud
+    // Hypervisor's virtio-net the name is `enp0s3` on Ubuntu/Debian, `eth0`
+    // on Cirros and older minimal images. Try both.
+    if let Some(n) = net {
+        runcmd_lines.push_str(&format!(
+            "  - [\"sh\", \"-c\", \"for i in enp0s3 ens3 eth0; do ip link show \\\"$i\\\" >/dev/null 2>&1 && IFACE=\\\"$i\\\" && break; done; ip addr add {guest}/{plen} dev \\\"$IFACE\\\"; ip link set \\\"$IFACE\\\" up; ip route add default via {host}\"]\n",
+            guest = n.guest_ip,
+            host = n.host_ip,
+            plen = n.prefix_len,
+        ));
+    }
+
     if !mounts.is_empty() {
         mounts_block.push_str("mounts:\n");
         for m in mounts {
@@ -294,7 +327,7 @@ mod tests {
     #[test]
     fn user_data_contains_b64_env_payload() {
         let envs = vec![("FOO".to_string(), "bar".to_string())];
-        let yaml = render_user_data(&envs, &[]);
+        let yaml = render_user_data(&envs, &[], None);
         assert!(yaml.starts_with("#cloud-config"));
         assert!(yaml.contains("/etc/ring/env"));
         assert!(!yaml.contains("EnvironmentFile=-/etc/ring/env")); // dropin is base64'd
@@ -317,7 +350,7 @@ mod tests {
                 read_only: true,
             },
         ];
-        let yaml = render_user_data(&[], &mounts);
+        let yaml = render_user_data(&[], &mounts, None);
         // fstab entries via cloud-init `mounts:` module
         assert!(yaml.contains("mounts:"));
         assert!(yaml.contains("\"bind-0\", \"/data\", \"virtiofs\", \"defaults\""));
@@ -330,9 +363,32 @@ mod tests {
 
     #[test]
     fn user_data_omits_mounts_block_when_empty() {
-        let yaml = render_user_data(&[], &[]);
+        let yaml = render_user_data(&[], &[], None);
         assert!(!yaml.contains("mounts:"));
         assert!(!yaml.contains("virtiofs"));
+    }
+
+    #[test]
+    fn user_data_emits_network_config_when_provided() {
+        let net = GuestNet {
+            guest_ip: "10.42.5.6".to_string(),
+            host_ip: "10.42.5.5".to_string(),
+            prefix_len: 30,
+            mac: "02:11:22:33:44:55".to_string(),
+        };
+        let yaml = render_user_data(&[], &[], Some(&net));
+        assert!(yaml.contains("ip addr add 10.42.5.6/30"));
+        assert!(yaml.contains("ip route add default via 10.42.5.5"));
+        // The probe loop tries enp0s3 / ens3 / eth0 in turn.
+        assert!(yaml.contains("enp0s3"));
+        assert!(yaml.contains("eth0"));
+    }
+
+    #[test]
+    fn user_data_omits_network_runcmd_when_no_net() {
+        let yaml = render_user_data(&[], &[], None);
+        assert!(!yaml.contains("ip addr add"));
+        assert!(!yaml.contains("ip route add default"));
     }
 
     #[test]
@@ -403,7 +459,7 @@ mod tests {
             read_only: false,
         }];
 
-        let iso = build_cidata_iso("ch-cidata-test", &dep, &mounts, &dir)
+        let iso = build_cidata_iso("ch-cidata-test", &dep, &mounts, None, &dir)
             .await
             .expect("xorriso should produce an ISO");
 
@@ -442,7 +498,7 @@ mod tests {
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
         let dep = empty_deployment("ch-cidata-empty");
-        let iso = build_cidata_iso("ch-cidata-empty", &dep, &[], &dir)
+        let iso = build_cidata_iso("ch-cidata-empty", &dep, &[], None, &dir)
             .await
             .expect("empty cidata should still build");
         assert!(iso.exists());

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -5,7 +5,9 @@ use super::client::{
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::error::RuntimeError;
+use crate::runtime::host_net::InstanceNet;
 use crate::runtime::lifecycle_trait::RuntimeLifecycle;
+use crate::runtime::port_forwarder::{self, PortForwarder};
 use crate::runtime::virtiofs::{self, VirtiofsMount};
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -63,6 +65,9 @@ pub struct CloudHypervisorLifecycle {
     /// and unlinks its socket. Wrapped in a sync `Mutex` because it is only
     /// touched briefly to insert/remove — never across `.await`.
     virtiofs_mounts: Mutex<HashMap<String, Vec<VirtiofsMount>>>,
+    /// Live socat port-forwarders, keyed by VM instance id. Same lifetime
+    /// rules as `virtiofs_mounts`: dropping the entry kills the socat.
+    port_forwarders: Mutex<HashMap<String, Vec<PortForwarder>>>,
 }
 
 impl CloudHypervisorLifecycle {
@@ -70,6 +75,7 @@ impl CloudHypervisorLifecycle {
         Self {
             config,
             virtiofs_mounts: Mutex::new(HashMap::new()),
+            port_forwarders: Mutex::new(HashMap::new()),
         }
     }
 
@@ -426,20 +432,38 @@ impl CloudHypervisorLifecycle {
             })
             .collect();
 
+        // If the deployment publishes any port, allocate a deterministic /30
+        // for this VM and tell both CH and cloud-init what to do with it.
+        // CH creates the tap and brings up its host-side IP; cloud-init
+        // configures the matching guest-side IP at first boot.
+        let needs_net = !deployment.ports.is_empty();
+        let net_alloc = if needs_net {
+            Some(InstanceNet::for_instance(instance_id))
+        } else {
+            None
+        };
+        let guest_net = net_alloc.as_ref().map(|n| super::cloud_init::GuestNet {
+            guest_ip: n.guest_ip.clone(),
+            host_ip: n.host_ip.clone(),
+            prefix_len: n.prefix_len,
+            mac: n.mac.clone(),
+        });
+
         // Build the disk list. The main rootfs is always there. A cidata ISO
         // is attached whenever there's something for cloud-init to do —
-        // either env vars or virtio-fs mounts.
+        // env vars, virtio-fs mounts, or a static network config.
         let mut disks = vec![DiskConfig {
             path: Self::path_str(&instance_image)?.to_string(),
             readonly: Some(false),
             image_type: None,
         }];
-        if !deployment.environment.is_empty() || !guest_mounts.is_empty() {
+        if !deployment.environment.is_empty() || !guest_mounts.is_empty() || guest_net.is_some() {
             let socket_dir = PathBuf::from(&self.config.socket_dir);
             let iso_path = super::cloud_init::build_cidata_iso(
                 instance_id,
                 deployment,
                 &guest_mounts,
+                guest_net.as_ref(),
                 &socket_dir,
             )
             .await?;
@@ -449,6 +473,21 @@ impl CloudHypervisorLifecycle {
                 image_type: None,
             });
         }
+
+        let net_config = match &net_alloc {
+            Some(n) => NetConfig {
+                tap: Some(n.tap_name.clone()),
+                ip: Some(n.host_ip.clone()),
+                mask: Some(n.netmask.clone()),
+                mac: Some(n.mac.clone()),
+            },
+            None => NetConfig {
+                tap: None,
+                ip: None,
+                mask: None,
+                mac: None,
+            },
+        };
 
         let vm_config = VmConfig {
             payload: PayloadConfig {
@@ -473,12 +512,7 @@ impl CloudHypervisorLifecycle {
             } else {
                 Some(fs_configs)
             },
-            net: Some(vec![NetConfig {
-                tap: None,
-                ip: None,
-                mask: None,
-                mac: None,
-            }]),
+            net: Some(vec![net_config]),
             serial: Some(ConsoleConfig {
                 mode: "Tty".to_string(),
             }),
@@ -515,6 +549,31 @@ impl CloudHypervisorLifecycle {
         if !live_mounts.is_empty() {
             if let Ok(mut map) = self.virtiofs_mounts.lock() {
                 map.insert(instance_id.to_string(), live_mounts);
+            }
+        }
+
+        // Spawn one socat per declared port now that the guest IP is reachable
+        // (cloud-init has had time to bring eth0 up). We don't fail the boot
+        // if a port can't be forwarded — the VM is up; the caller can see
+        // the missing port in `ring deployment events` if we emit one. For
+        // now a warn! is enough to keep the scheduler from flapping.
+        if let Some(net) = &net_alloc {
+            let mut forwarders = Vec::with_capacity(deployment.ports.len());
+            for p in &deployment.ports {
+                match port_forwarder::spawn_forwarder(&net.guest_ip, p.published, p.target).await {
+                    Ok(fw) => forwarders.push(fw),
+                    Err(e) => {
+                        warn!(
+                            "Failed to publish port {}->{}:{} for VM {}: {}",
+                            p.published, net.guest_ip, p.target, instance_id, e
+                        );
+                    }
+                }
+            }
+            if !forwarders.is_empty() {
+                if let Ok(mut map) = self.port_forwarders.lock() {
+                    map.insert(instance_id.to_string(), forwarders);
+                }
             }
         }
 
@@ -574,6 +633,12 @@ impl CloudHypervisorLifecycle {
         // shut down avoids the kernel logging spurious EIO when the guest
         // tries to flush a now-disconnected share.
         if let Ok(mut map) = self.virtiofs_mounts.lock() {
+            let _ = map.remove(instance_id);
+        }
+
+        // Drop port-forwarders for this instance. Their `Drop` sends SIGKILL
+        // to the matching socat processes and frees the listening ports.
+        if let Ok(mut map) = self.port_forwarders.lock() {
             let _ = map.remove(instance_id);
         }
 

--- a/src/runtime/host_net.rs
+++ b/src/runtime/host_net.rs
@@ -1,0 +1,176 @@
+//! Host networking helpers for VM runtimes.
+//!
+//! Allocates a deterministic /30 subnet under `10.42.0.0/16` per VM instance
+//! and the matching tap interface name, host-side IP, guest-side IP and MAC
+//! address. The tap device itself is created by the hypervisor (Cloud
+//! Hypervisor needs `CAP_NET_ADMIN` for that and already has it via
+//! filesystem capabilities); Ring just decides on the parameters and feeds
+//! them to the VMM and to cloud-init.
+//!
+//! The allocation is a pure function of the instance id, so two replicas of
+//! the same deployment cannot collide and a Ring restart sees the same
+//! mapping for a still-running VM.
+//!
+//! `10.42.0.0/16` carries 16384 /30 subnets — far more than any realistic
+//! single-host CH workload. Hash collisions across the 14-bit space are
+//! tolerated with best-effort: if two instance ids happen to hash to the
+//! same /30, the second VM will fail to bring its tap up and Ring will
+//! crashloop it. Documented as a known v1 limitation.
+
+const TAP_PREFIX: &str = "ring-";
+const SUBNET_BASE_HIGH: u8 = 10;
+const SUBNET_BASE_MID: u8 = 42;
+
+/// All the host-side network parameters Ring derives for a single VM.
+#[derive(Debug, Clone)]
+pub(crate) struct InstanceNet {
+    /// Linux interface name. Capped at 15 chars (kernel limit IFNAMSIZ-1).
+    pub tap_name: String,
+    /// IP assigned to the host side of the tap (gateway, from the guest's POV).
+    pub host_ip: String,
+    /// IP the guest will configure on its eth0 via cloud-init.
+    pub guest_ip: String,
+    /// /30 mask, written long-form because cloud-init wants dotted form.
+    pub netmask: String,
+    /// CIDR prefix length, written `24`-style for `ip` invocations.
+    pub prefix_len: u8,
+    /// Locally administered MAC address (locally administered bit set, unicast).
+    pub mac: String,
+}
+
+impl InstanceNet {
+    /// Build the network parameters for a given VM instance id.
+    pub fn for_instance(instance_id: &str) -> Self {
+        // 14 bits of entropy → covers 16384 /30 subnets (10.42.0.0/16).
+        let h = stable_hash(instance_id);
+        let n = (h & 0x3fff) as u32;
+
+        // /30 layout: .0 = network, .1 = host, .2 = guest, .3 = broadcast.
+        let third = (n >> 6) as u8;
+        let fourth_base = ((n & 0x3f) << 2) as u8; // multiple of 4
+        let host_ip = format!(
+            "{}.{}.{}.{}",
+            SUBNET_BASE_HIGH,
+            SUBNET_BASE_MID,
+            third,
+            fourth_base + 1
+        );
+        let guest_ip = format!(
+            "{}.{}.{}.{}",
+            SUBNET_BASE_HIGH,
+            SUBNET_BASE_MID,
+            third,
+            fourth_base + 2
+        );
+
+        // 15 chars max for the tap name. Hex of the 14-bit slot fits in 4.
+        let tap_name = format!("{}{:x}", TAP_PREFIX, n);
+
+        // Locally-administered MAC: first byte is `02:` (bit 1 set, bit 0 clear
+        // for unicast). The remaining 5 bytes are the low bits of the hash, so
+        // the MAC is stable across boots of the same instance.
+        let mac = format!(
+            "02:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            (h >> 32) as u8,
+            (h >> 24) as u8,
+            (h >> 16) as u8,
+            (h >> 8) as u8,
+            h as u8,
+        );
+
+        Self {
+            tap_name,
+            host_ip,
+            guest_ip,
+            netmask: "255.255.255.252".to_string(),
+            prefix_len: 30,
+            mac,
+        }
+    }
+}
+
+/// Tiny FNV-1a 64-bit. Vendor-free, deterministic across builds. We don't
+/// need cryptographic strength — just a good distribution across the /30
+/// space.
+fn stable_hash(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocation_is_deterministic() {
+        let a = InstanceNet::for_instance("ch-deadbeef-12345678");
+        let b = InstanceNet::for_instance("ch-deadbeef-12345678");
+        assert_eq!(a.tap_name, b.tap_name);
+        assert_eq!(a.host_ip, b.host_ip);
+        assert_eq!(a.guest_ip, b.guest_ip);
+        assert_eq!(a.mac, b.mac);
+    }
+
+    #[test]
+    fn distinct_instances_get_distinct_subnets() {
+        // 5 random-looking ids should not collide on the /30 in practice.
+        let ids = [
+            "ch-aaaaaaaa-11111111",
+            "ch-bbbbbbbb-22222222",
+            "ch-cccccccc-33333333",
+            "ch-dddddddd-44444444",
+            "ch-eeeeeeee-55555555",
+        ];
+        let nets: Vec<_> = ids.iter().map(|i| InstanceNet::for_instance(i)).collect();
+        for i in 0..nets.len() {
+            for j in (i + 1)..nets.len() {
+                assert_ne!(
+                    nets[i].host_ip, nets[j].host_ip,
+                    "{} and {} collided on the host IP",
+                    ids[i], ids[j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ips_belong_to_the_same_slash_30() {
+        let n = InstanceNet::for_instance("test");
+        // Last octet of host_ip is 4k+1 and guest_ip is 4k+2.
+        let host_last: u8 = n.host_ip.split('.').nth(3).unwrap().parse().unwrap();
+        let guest_last: u8 = n.guest_ip.split('.').nth(3).unwrap().parse().unwrap();
+        assert_eq!(guest_last, host_last + 1);
+        assert_eq!(host_last % 4, 1);
+    }
+
+    #[test]
+    fn tap_name_fits_in_ifnamsiz() {
+        // IFNAMSIZ is 16 in the kernel; usable name length is 15.
+        let n = InstanceNet::for_instance("ch-anything-anything-anything");
+        assert!(
+            n.tap_name.len() <= 15,
+            "tap_name '{}' exceeds 15 chars",
+            n.tap_name
+        );
+    }
+
+    #[test]
+    fn mac_is_locally_administered_unicast() {
+        let n = InstanceNet::for_instance("test");
+        // First byte must have bit 1 (locally administered) set and bit 0
+        // (multicast) clear. `02` checks both: 0000_0010.
+        let first: u8 = u8::from_str_radix(n.mac.split(':').next().unwrap(), 16).unwrap();
+        assert_eq!(first & 0x03, 0x02);
+    }
+
+    #[test]
+    fn prefix_len_matches_netmask() {
+        let n = InstanceNet::for_instance("test");
+        assert_eq!(n.prefix_len, 30);
+        assert_eq!(n.netmask, "255.255.255.252");
+    }
+}

--- a/src/runtime/port_forwarder.rs
+++ b/src/runtime/port_forwarder.rs
@@ -1,0 +1,159 @@
+//! Userspace TCP port forwarding via `socat`.
+//!
+//! For each `DeploymentPort { published, target }` declared on a VM-runtime
+//! deployment, Ring spawns one `socat` process that listens on
+//! `0.0.0.0:<published>` on the host and forwards every accepted connection
+//! to `<vm_ip>:<target>`. The lifetime of each forwarder is tied to the VM
+//! through [`PortForwarder`]'s `Drop`: when the owning struct is dropped,
+//! `socat` is killed and the listening port is freed.
+//!
+//! Why socat and not iptables? socat runs in userspace, so:
+//! - no extra capabilities needed beyond what Ring already has (CH wants
+//!   `CAP_NET_ADMIN`, but the forwarder itself is privilege-free),
+//! - port conflicts surface immediately at `socat` startup as a clean
+//!   `bind: Address already in use`,
+//! - cleanup is just SIGKILL — no leftover NAT rules to garbage-collect.
+//!
+//! The trade-off is throughput: every byte traverses userspace twice. For
+//! the typical Ring VM workload (HTTP, dev databases) that overhead is
+//! negligible. A future iteration may switch to `iptables`/`nftables` DNAT
+//! rules; documented in ROADMAP.
+
+use crate::runtime::error::RuntimeError;
+use std::process::Stdio;
+use tokio::process::{Child, Command};
+
+/// One running `socat` instance forwarding `published_port` on the host to
+/// `<guest_ip>:target_port` inside the VM. Dropping it kills the daemon.
+pub(crate) struct PortForwarder {
+    pub published_port: u16,
+    pub target_port: u16,
+    /// Owned: dropping the forwarder kills the socat process.
+    child: Child,
+}
+
+impl Drop for PortForwarder {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Spawn a `socat` that forwards `0.0.0.0:<published>` to `<guest_ip>:<target>`.
+/// Returns once the child has been spawned (we do not wait for the listener
+/// to bind — if the port is taken, socat exits within milliseconds and the
+/// next connection attempt from the user surfaces the failure cleanly).
+pub(crate) async fn spawn_forwarder(
+    guest_ip: &str,
+    published_port: u16,
+    target_port: u16,
+) -> Result<PortForwarder, RuntimeError> {
+    // -d -d gives info-level diagnostics to stderr (handy when this fails
+    // because the host port is already bound). `reuseaddr` lets us restart
+    // a forwarder fast across deployment recreations without TIME_WAIT.
+    // `fork` spawns a child per accepted connection — without it, socat
+    // serves a single client and exits.
+    let listen = format!("TCP4-LISTEN:{},reuseaddr,fork", published_port);
+    let connect = format!("TCP4:{}:{}", guest_ip, target_port);
+
+    let child = Command::new("socat")
+        .arg("-d")
+        .arg("-d")
+        .arg(&listen)
+        .arg(&connect)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            RuntimeError::Other(format!(
+                "failed to spawn socat for {}->{}:{}: {} (install socat?)",
+                published_port, guest_ip, target_port, e
+            ))
+        })?;
+
+    // Give socat a beat to bind the listening socket. If the port is
+    // occupied, socat exits fast and the caller will see a closed pipe on
+    // the first connection. We don't poll the port here because that would
+    // race with whoever else is listening.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    Ok(PortForwarder {
+        published_port,
+        target_port,
+        child,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    fn socat_or_skip(test: &str) -> bool {
+        if std::process::Command::new("socat")
+            .arg("-V")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping {}: socat not installed", test);
+            return true;
+        }
+        false
+    }
+
+    /// Bind a random ephemeral port and immediately release it so we can
+    /// hand the number to a test that needs a port that's likely free.
+    fn pick_free_port() -> u16 {
+        let l = TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    }
+
+    #[tokio::test]
+    async fn forwarder_starts_and_drop_kills_socat() {
+        if socat_or_skip("forwarder_starts_and_drop_kills_socat") {
+            return;
+        }
+
+        let host_port = pick_free_port();
+        // The "guest" side is unreachable; that's fine — we only check that
+        // socat actually binds the listening port and that Drop tears it
+        // down. A connection attempt is the cheapest signal of "bound".
+        let fw = spawn_forwarder("127.0.0.99", host_port, 9999)
+            .await
+            .unwrap();
+
+        // socat must hold the port — a fresh bind to the same port should fail.
+        let busy = TcpListener::bind(format!("127.0.0.1:{}", host_port));
+        assert!(
+            busy.is_err(),
+            "socat should be holding port {} but bind succeeded",
+            host_port
+        );
+
+        drop(fw);
+
+        // After Drop, the OS releases the listening socket. Give the kernel
+        // a moment to reap the child and free the address.
+        for _ in 0..40 {
+            if TcpListener::bind(format!("127.0.0.1:{}", host_port)).is_ok() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!(
+            "port {} still bound after Drop — socat process leaked",
+            host_port
+        );
+    }
+
+    #[tokio::test]
+    async fn fields_carry_through() {
+        if socat_or_skip("fields_carry_through") {
+            return;
+        }
+        let host_port = pick_free_port();
+        let fw = spawn_forwarder("10.0.0.1", host_port, 5432).await.unwrap();
+        assert_eq!(fw.published_port, host_port);
+        assert_eq!(fw.target_port, 5432);
+        drop(fw);
+    }
+}

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -36,6 +36,11 @@ start_ring() {
   RING_URL="http://127.0.0.1:${RING_PORT}"
   RING_E2E_LABEL="ring-e2e-$(basename "$RING_TEST_DIR")"
   export RING_CONFIG_DIR="$RING_TEST_DIR"
+  # Without this, every e2e shares the developer's `./ring.db` in CWD.
+  # Tests then see leftover deployments from previous runs and the
+  # scheduler may even boot stale ones, masking failures and producing
+  # false positives. Pin each test to its own database file.
+  export RING_DATABASE_PATH="$RING_TEST_DIR/ring.db"
 
   cat > "$RING_TEST_DIR/config.toml" <<EOF
 [contexts.default]

--- a/tests/e2e/t11_ch_ports.sh
+++ b/tests/e2e/t11_ch_ports.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# T11-CH: a CH deployment with `ports` must:
+#   1. boot with a tap interface configured by Ring,
+#   2. spawn one socat per port mapping (host-side observable),
+#   3. release the host port + kill the socat on delete.
+#
+# We don't validate end-to-end traffic (TCP from host to a service inside
+# the guest) because Cirros's stripped init does not run cloud-config's
+# runcmd reliably, so the guest may not bring eth0 up. That E2E concern
+# belongs to a manual Ubuntu-Focal-based check, same caveat as T9 and T10.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=./setup-ch.sh
+source "$SCRIPT_DIR/setup-ch.sh"
+
+log "== T11-CH: port mapping via socat =="
+
+if ! command -v socat > /dev/null 2>&1; then
+  echo "[e2e] SKIP: socat not installed (apt install socat)" >&2
+  exit 0
+fi
+
+# Pick two host ports likely to be free. We want the test reproducible, so
+# we ask the kernel for ephemeral ports up front and then re-bind them.
+PORT_A=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+PORT_B=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/ports-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  ports-vm:
+    name: ports-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    ports:
+      - { published: $PORT_A, target: 80 }
+      - { published: $PORT_B, target: 8080 }
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "ports-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "ports-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === socat processes ===
+# pgrep returns exit 1 when nothing matches; under `set -o pipefail`, that
+# would kill the script even though `wc -l` produces a valid 0. Wrap it.
+log "looking for socat forwarders for ports $PORT_A and $PORT_B..."
+SOCAT_COUNT=0
+for _ in $(seq 1 30); do
+  SOCAT_COUNT=$( (pgrep -f "socat.*TCP4-LISTEN:($PORT_A|$PORT_B)" || true) | wc -l | tr -d ' ')
+  [ "$SOCAT_COUNT" -ge 2 ] && break
+  sleep 1
+done
+if [ "$SOCAT_COUNT" -lt 2 ]; then
+  pgrep -af socat >&2 || true
+  fail "expected 2 socat forwarders, found $SOCAT_COUNT"
+fi
+log "$SOCAT_COUNT socat forwarders alive"
+
+# === host ports are bound ===
+# A bind to the same port should fail while socat holds it.
+for p in "$PORT_A" "$PORT_B"; do
+  if python3 -c "
+import socket, sys
+s = socket.socket()
+try:
+  s.bind(('127.0.0.1', $p))
+  print('FREE')
+except OSError:
+  print('BUSY')
+" | grep -q FREE; then
+    fail "host port $p is not bound — socat is not listening"
+  fi
+done
+log "ports $PORT_A and $PORT_B are bound"
+
+# === tap interface created by CH ===
+# The tap name is ring-<14-bit-hex-of-instance-hash>. CH names the tap
+# itself, so we just check that *some* ring-* tap is up while the VM runs.
+RING_TAPS=$( (ip tuntap show 2>/dev/null | grep -E "^ring-[0-9a-f]+:" || true) | wc -l | tr -d ' ')
+if [ "$RING_TAPS" -lt 1 ]; then
+  ip tuntap show >&2 || true
+  fail "no ring-* tap interface found"
+fi
+log "found $RING_TAPS ring-* tap interface(s)"
+
+# === cidata ISO carries the network setup ===
+# The iso's user-data must contain the `ip addr add` / `ip route add default`
+# commands that cloud-init runs to configure eth0.
+ISO_PATH=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.cidata.iso" 2>/dev/null | head -n1)
+[ -z "$ISO_PATH" ] && fail "cidata ISO not found"
+EXTRACT_DIR="$RING_TEST_DIR/extracted"
+mkdir -p "$EXTRACT_DIR"
+xorriso -osirrox on -indev "$ISO_PATH" -extract / "$EXTRACT_DIR" > /dev/null 2>&1
+if ! grep -q "ip addr add 10\.42\." "$EXTRACT_DIR/user-data"; then
+  cat "$EXTRACT_DIR/user-data" >&2
+  fail "user-data missing 'ip addr add' for the static IP"
+fi
+if ! grep -q "ip route add default via 10\.42\." "$EXTRACT_DIR/user-data"; then
+  cat "$EXTRACT_DIR/user-data" >&2
+  fail "user-data missing 'ip route add default'"
+fi
+log "user-data carries network configuration"
+
+# === delete teardown ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# socat must be gone within a reasonable window.
+for _ in $(seq 1 60); do
+  remaining=$( (pgrep -f "socat.*TCP4-LISTEN:($PORT_A|$PORT_B)" || true) | wc -l | tr -d ' ')
+  [ "$remaining" -eq 0 ] && break
+  sleep 1
+done
+if [ "$remaining" -ne 0 ]; then
+  pgrep -af socat >&2 || true
+  fail "socat process leak: $remaining still alive after delete"
+fi
+log "all socat forwarders terminated"
+
+# Host ports should be free again.
+for p in "$PORT_A" "$PORT_B"; do
+  for _ in $(seq 1 20); do
+    if python3 -c "
+import socket
+s = socket.socket()
+try:
+  s.bind(('127.0.0.1', $p))
+  print('FREE')
+except OSError:
+  print('BUSY')
+" | grep -q FREE; then
+      break
+    fi
+    sleep 1
+  done
+done
+log "host ports released"
+
+log "== T11-CH: PASS =="


### PR DESCRIPTION
## Summary

Adds port publishing to the Cloud Hypervisor runtime, mirroring the behaviour of the Docker runtime (PR #57). Ring now allocates a deterministic /30 subnet per VM under `10.42.0.0/16`, lets CH create the matching tap, drives the guest-side IP via cloud-init, and spawns one `socat` per `DeploymentPort` to expose `0.0.0.0:<published>` on the host.

```yaml
deployments:
  api:
    runtime: cloud-hypervisor
    image: /var/lib/ring/images/ubuntu-focal.raw
    ports:
      - { published: 8080, target: 80 }
```

## Architecture

```
                    ┌─────────────────────────────────────────┐
   external         │ Host                                    │
       │            │                                         │
       │            │  socat TCP-LISTEN:<published>,fork      │
       └────────────►  TCP:<vm_ip>:<target>                   │
                    │            │                            │
                    │   ┌────────▼─────────┐                  │
                    │   │ ring-<14-bit-hex>│ 10.42.<n>.1/30   │
                    │   │ (tap)            │  (CH-managed)    │
                    │   └────────▲─────────┘                  │
                    │            │                            │
                    │   ┌────────▼─────────┐                  │
                    │   │ VM eth0          │ 10.42.<n>.2/30   │
                    │   │ (cloud-init)     │                  │
                    │   └──────────────────┘                  │
                    └─────────────────────────────────────────┘
```

Why socat and not iptables? It runs without extra capabilities, surfaces `bind: address already in use` cleanly when a port is taken, and cleans up via plain SIGKILL — no leftover NAT rule to garbage-collect on a Ring crash. Throughput trade-off is negligible for HTTP / dev-database workloads. A future iteration may switch to `nftables` DNAT; tracked in the ROADMAP.

## What's new

- **`src/runtime/host_net.rs`** — pure module, FNV-1a-derived /30 allocator. Same instance id always yields the same `(tap_name, host_ip, guest_ip, mac)`.
- **`src/runtime/port_forwarder.rs`** — `PortForwarder` owns its socat child; `Drop` SIGKILLs.
- **`cloud_init.rs`** — `build_cidata_iso` now takes an optional `GuestNet` and emits a `runcmd` block that probes `enp0s3` / `ens3` / `eth0` then runs `ip addr add` / `ip route add default`.
- **`lifecycle.rs`** — when a deployment declares any port, allocate an `InstanceNet`, fill `NetConfig.{tap,ip,mask,mac}`, attach the cidata ISO with the static net config, and (after CH's `boot_vm`) spawn one socat per port. Mounts and forwarders share the same tracking pattern (`Mutex<HashMap<instance_id, …>>`).
- **`apply.rs`** — was silently dropping `ports:` from manifests because the CLI struct didn't carry it. Fixed (caught only because the e2e didn't see ports arrive in `start_vm_process` and I had to trace the flow).
- **`lib.sh`** — `RING_DATABASE_PATH` is now set per-test. Without this every e2e shared the developer's `./ring.db` in CWD, which let stale deployments boot mid-test.

## Bugs the e2e found

The same lesson as PR #62: `cargo test` cannot catch the things that matter for runtime work.

1. CLI `apply::Deployment` had no `ports` field → YAML manifests silently lost their port mappings on the way to the API.
2. The shared `./ring.db` polluted every test with stale deployments, hiding real failures.

Both were invisible until I ran t11 against a real CH and saw the wrong VM (a leftover) booting with `ports=0`.

## Test plan

- [x] `cargo test` — 222 passing (10 new: 6 in `host_net`, 2 in `port_forwarder`, 2 in `cloud_init` for the network user-data).
- [x] `cargo fmt --check` — clean.
- [x] `tests/e2e/t11_ch_ports.sh` — green against socat 1.8 + cloud-hypervisor v46. Validates: VM reaches `running`, two socats spawn and bind their host ports, a `ring-*` tap appears, the cidata ISO carries `ip addr add 10.42.…` and `ip route add default via 10.42.…`, full teardown on delete (socats killed, host ports freed).
- [x] `tests/e2e/t1_ch_boot_delete.sh`, `t9_ch_environment.sh`, `t10_ch_volumes.sh` — all green after the change. No regression on volume-less / port-less paths.
- [ ] Manual guest-side validation: hit the published port from the host, verify the byte stream actually reaches a service inside an Ubuntu Focal VM. Out of scope here for the same reason as T9/T10 — Cirros's stripped init does not run cloud-config's `runcmd:` reliably.

## Out of scope (follow-ups)

- **Conflict detection at API time**: today a `published` already in use on the host fails at socat start, only visible via `ring deployment events`. A 409 from `POST /deployments` would be nicer but lives in a separate PR (it also applies to the Docker runtime).
- **UDP forwarding**: socat is configured for `TCP4` only.
- **`nftables` DNAT path** as an alternative to socat for higher throughput. Tracked in the ROADMAP.