### PR TITLE
feat(cloud-hypervisor): expose serial console via ring deployment logs

### DIFF
--- a/documentation/runtimes/cloud-hypervisor.md
+++ b/documentation/runtimes/cloud-hypervisor.md
@@ -322,6 +322,33 @@ Each `socat` lives as long as its VM. On `deployment delete` (or scaledown / rol
 - **TCP only** — `socat`'s configuration is `TCP4-LISTEN`/`TCP4`. UDP forwarding requires a separate config and is not wired up yet.
 - **No bandwidth shaping or connection limits** — the forwarder is permissive by design.
 
+## Logs
+
+`ring deployment logs <id>` works on Cloud Hypervisor deployments. Cloud Hypervisor is started with `serial.mode = "File"` and writes everything the guest emits on `/dev/console` — kernel messages, cloud-init progress, and any application output redirected to the console — to a per-instance file at `<socket_dir>/<instance>.console.log`.
+
+```bash
+# Last 100 lines (default)
+ring deployment logs <deployment-id>
+
+# Tail a specific number of lines
+ring deployment logs <deployment-id> --tail 500
+
+# Stream as new lines arrive
+ring deployment logs <deployment-id> --follow
+
+# Filter to a single instance (when you have replicas)
+ring deployment logs <deployment-id> --container <instance-id>
+```
+
+### Limitations
+
+- **Append-only, no rotation** — Cloud Hypervisor never truncates the file. For long-running VMs the file grows unbounded; rotate it externally (logrotate) or recreate the deployment to start fresh. Tracked in the project roadmap.
+- **No native timestamps** — the serial console is a raw byte stream. Ring's `--since <duration>` is best-effort: if the file's last-modified time is older than the cutoff, the output is empty; otherwise the whole window is returned.
+- **`level` classification is heuristic** — same regex as the Docker runtime: `[error]`, `[warning]`, `[info]`/`[notice]` substring matches. The kernel and cloud-init don't follow this convention, so most lines come back as `unknown`.
+- **Binary bytes** — early kernel output may include non-UTF-8 bytes; Ring lossy-decodes and serves them as-is. Some shells warn on null bytes when piping the output.
+
+To get application logs into this stream, redirect them to `/dev/console` from inside the guest (e.g. systemd `StandardOutput=tty TTYPath=/dev/console`).
+
 ## Current Limitations
 
 The following features are **not yet available** on the Cloud Hypervisor runtime:
@@ -334,7 +361,7 @@ The following features are **not yet available** on the Cloud Hypervisor runtime
 | Environment variables | Supported via cloud-init (NoCloud) — see [Environment variables](#environment-variables) |
 | Volumes | Supported via virtio-fs — see [Volumes](#volumes) |
 | Port mapping | Supported via socat userspace forwarders — see [Port mapping](#port-mapping) |
-| Deployment logs (`ring deployment logs`) | Not available for CH deployments |
+| Deployment logs (`ring deployment logs`) | Supported via the serial console — see [Logs](#logs) |
 | Deployment metrics (`ring deployment metrics`) | Not available for CH deployments |
 
 These limitations will be addressed in future releases. See the project roadmap for details.

--- a/src/runtime/cloud_hypervisor/client.rs
+++ b/src/runtime/cloud_hypervisor/client.rs
@@ -102,6 +102,11 @@ pub(crate) struct NetConfig {
 #[derive(Debug, Serialize, Clone)]
 pub(crate) struct ConsoleConfig {
     pub mode: String,
+    /// Path to the file CH appends serial output to when `mode == "File"`.
+    /// Cloud Hypervisor opens it in append mode and never rotates it; the
+    /// caller is responsible for cleanup when the VM is torn down.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/runtime/cloud_hypervisor/console_logs.rs
+++ b/src/runtime/cloud_hypervisor/console_logs.rs
@@ -1,0 +1,279 @@
+//! Read and stream the per-VM serial console log file.
+//!
+//! Cloud Hypervisor's `serial.mode = "File"` makes the VMM append every byte
+//! the guest writes to `/dev/console` (cloud-init banner, kernel messages,
+//! systemd journal when redirected, app stdout when configured) to a single
+//! file. This module turns that file into the line-oriented stream the
+//! `RuntimeLifecycle` trait expects:
+//!
+//! - [`read_lines`] — synchronous one-shot read with `tail` (last N lines)
+//!   and `since` (drop lines older than N seconds, best-effort: the console
+//!   has no native timestamps so we fall back to file mtime windowing).
+//! - [`stream_lines`] — async streaming reader that follows the file as CH
+//!   appends to it, equivalent to `tail -f`.
+//!
+//! Lines are returned raw — callers (`get_logs` / `stream_logs` in
+//! `lifecycle.rs`) wrap them in a `Log` with `classify_log` / `extract_date`.
+
+use futures::stream::{self, Stream, StreamExt};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, SeekFrom};
+
+/// Read the console log for a single instance into a vector of lines.
+///
+/// `tail`: parsed as `"<n>"` (last N lines) or `"all"` / unset for the whole
+/// file. Anything that doesn't parse falls back to the whole file.
+///
+/// `since`: number of seconds; drops lines whose age (estimated from the
+/// file mtime relative to "now", with all lines treated as appended at the
+/// same moment for now) is older. Approximate by design — the serial
+/// console has no native timestamps.
+pub(crate) async fn read_lines(path: &Path, tail: Option<&str>, since: Option<i32>) -> Vec<String> {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(b) => b,
+        Err(_) => return Vec::new(),
+    };
+
+    // The serial console is not guaranteed to be UTF-8 (early kernel output
+    // may carry stray bytes). Lossy conversion keeps us robust.
+    let text = String::from_utf8_lossy(&bytes);
+    let mut lines: Vec<String> = text.lines().map(|s| s.to_string()).collect();
+
+    if let Some(n_str) = tail {
+        if n_str != "all"
+            && let Ok(n) = n_str.parse::<usize>()
+            && lines.len() > n
+        {
+            lines = lines.split_off(lines.len() - n);
+        }
+    }
+
+    if let Some(secs) = since
+        && secs > 0
+    {
+        // Best-effort: if the whole file's mtime is older than `secs` ago,
+        // drop everything. We do not try to date individual lines because
+        // the console output has no built-in timestamps.
+        if let Ok(meta) = tokio::fs::metadata(path).await
+            && let Ok(mtime) = meta.modified()
+            && let Ok(elapsed) = mtime.elapsed()
+            && elapsed.as_secs() as i32 > secs
+        {
+            return Vec::new();
+        }
+    }
+
+    lines
+}
+
+/// Stream new lines as Cloud Hypervisor appends them to the console log.
+///
+/// The implementation polls the file on a short interval rather than using
+/// inotify because the test surface is simpler and the volume of console
+/// output is low (kernel + cloud-init + occasional app stderr — far below
+/// what would warrant edge-triggered I/O).
+///
+/// On startup, we honor `tail` by seeking to the last N lines before
+/// streaming new ones. `since` is applied identically to [`read_lines`]
+/// (best-effort: if the file's mtime is older than the cutoff, we start
+/// from end-of-file).
+pub(crate) async fn stream_lines(
+    path: PathBuf,
+    tail: Option<String>,
+    since: Option<i32>,
+) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+    // Replay tail synchronously, then poll for growth.
+    let initial = read_lines(&path, tail.as_deref(), since).await;
+    let initial_stream = stream::iter(initial);
+
+    // State carried by the `unfold` follower:
+    // - `path`: the file we're tailing
+    // - `last_size`: how many bytes we've already streamed
+    // - `carry`: leftover bytes from a partial line at EOF that should be
+    //   prepended to the next read once a newline arrives
+    // - `pending`: lines we've parsed but not yet yielded (so each `next`
+    //   call returns one line)
+    struct FollowState {
+        path: PathBuf,
+        last_size: u64,
+        carry: String,
+        pending: std::collections::VecDeque<String>,
+    }
+
+    let init_size = tokio::fs::metadata(&path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let state = FollowState {
+        path,
+        last_size: init_size,
+        carry: String::new(),
+        pending: std::collections::VecDeque::new(),
+    };
+
+    let follow = stream::unfold(state, |mut s| async move {
+        loop {
+            // Drain anything we've already buffered.
+            if let Some(line) = s.pending.pop_front() {
+                return Some((line, s));
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+            let size = match tokio::fs::metadata(&s.path).await {
+                Ok(m) => m.len(),
+                Err(_) => continue,
+            };
+
+            // Truncation (e.g. operator deleted the file mid-stream): reset.
+            if size < s.last_size {
+                s.last_size = 0;
+                s.carry.clear();
+            }
+            if size == s.last_size {
+                continue;
+            }
+
+            let mut file = match tokio::fs::File::open(&s.path).await {
+                Ok(f) => f,
+                Err(_) => continue,
+            };
+            if file.seek(SeekFrom::Start(s.last_size)).await.is_err() {
+                continue;
+            }
+
+            let mut reader = BufReader::new(file);
+            let mut buf = String::new();
+            loop {
+                buf.clear();
+                let n = match reader.read_line(&mut buf).await {
+                    Ok(n) => n,
+                    Err(_) => break,
+                };
+                if n == 0 {
+                    break;
+                }
+                if buf.ends_with('\n') {
+                    let mut full = std::mem::take(&mut s.carry);
+                    full.push_str(buf.trim_end_matches('\n'));
+                    s.pending.push_back(full);
+                } else {
+                    // Partial line at EOF — wait for more bytes next tick.
+                    s.carry.push_str(&buf);
+                }
+            }
+            s.last_size = size;
+        }
+    });
+
+    Box::pin(initial_stream.chain(follow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn scratch_file(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "ring-console-{}-{}-{}.log",
+            label,
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    #[tokio::test]
+    async fn read_lines_returns_all_when_no_tail() {
+        let path = scratch_file("all");
+        tokio::fs::write(&path, b"line-1\nline-2\nline-3\n")
+            .await
+            .unwrap();
+        let lines = read_lines(&path, None, None).await;
+        assert_eq!(lines, vec!["line-1", "line-2", "line-3"]);
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn read_lines_respects_tail_n() {
+        let path = scratch_file("tail-n");
+        tokio::fs::write(&path, b"a\nb\nc\nd\ne\n").await.unwrap();
+        let lines = read_lines(&path, Some("2"), None).await;
+        assert_eq!(lines, vec!["d", "e"]);
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn read_lines_tail_all_returns_everything() {
+        let path = scratch_file("tail-all");
+        tokio::fs::write(&path, b"a\nb\nc\n").await.unwrap();
+        let lines = read_lines(&path, Some("all"), None).await;
+        assert_eq!(lines, vec!["a", "b", "c"]);
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn read_lines_handles_missing_file() {
+        let path = scratch_file("missing");
+        let lines = read_lines(&path, None, None).await;
+        assert!(lines.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_lines_lossy_decodes_non_utf8() {
+        let path = scratch_file("non-utf8");
+        // 0xff is invalid UTF-8 — must not panic, must produce a lossy line.
+        tokio::fs::write(&path, b"hello\n\xffworld\n")
+            .await
+            .unwrap();
+        let lines = read_lines(&path, None, None).await;
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "hello");
+        assert!(lines[1].contains("world"));
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn stream_lines_replays_tail_then_follows_appends() {
+        let path = scratch_file("follow");
+        tokio::fs::write(&path, b"hello\n").await.unwrap();
+
+        let mut s = stream_lines(path.clone(), None, None).await;
+        // First: initial replay.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), s.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first, "hello");
+
+        // Now append two more lines and confirm the follower picks them up.
+        let mut f = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        use tokio::io::AsyncWriteExt;
+        f.write_all(b"world\nbye\n").await.unwrap();
+        drop(f);
+
+        let second = tokio::time::timeout(std::time::Duration::from_secs(3), s.next())
+            .await
+            .expect("stream should yield within 3s after append")
+            .unwrap();
+        assert_eq!(second, "world");
+
+        let third = tokio::time::timeout(std::time::Duration::from_secs(3), s.next())
+            .await
+            .expect("stream should yield third line")
+            .unwrap();
+        assert_eq!(third, "bye");
+
+        drop(s);
+        tokio::fs::remove_file(&path).await.ok();
+    }
+}

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -107,6 +107,17 @@ impl CloudHypervisorLifecycle {
         PathBuf::from(&self.config.socket_dir).join(format!("{}.cidata.iso", instance_id))
     }
 
+    fn console_log_path(&self, instance_id: &str) -> PathBuf {
+        PathBuf::from(&self.config.socket_dir).join(format!("{}.console.log", instance_id))
+    }
+
+    /// Public for the e2e test only — production callers go through
+    /// `get_logs` / `stream_logs`.
+    #[cfg(test)]
+    pub(crate) fn console_log_path_for_test(&self, instance_id: &str) -> PathBuf {
+        self.console_log_path(instance_id)
+    }
+
     fn deployment_prefix(deployment_id: &str) -> String {
         format!("ch-{}-", &deployment_id[..8.min(deployment_id.len())])
     }
@@ -513,11 +524,18 @@ impl CloudHypervisorLifecycle {
                 Some(fs_configs)
             },
             net: Some(vec![net_config]),
+            // Append serial output to a per-instance file so `ring deployment
+            // logs` can read it back. CH never rotates this file; cleanup is
+            // tied to the VM lifetime via stop_vm. Anything the guest writes
+            // to /dev/console (cloud-init banner, kernel messages, app stdout
+            // when redirected) lands here.
             serial: Some(ConsoleConfig {
-                mode: "Tty".to_string(),
+                mode: "File".to_string(),
+                file: Some(Self::path_str(&self.console_log_path(instance_id))?.to_string()),
             }),
             console: Some(ConsoleConfig {
                 mode: "Off".to_string(),
+                file: None,
             }),
         };
 
@@ -626,6 +644,11 @@ impl CloudHypervisorLifecycle {
         let cidata_iso = self.cidata_iso_path(instance_id);
         if let Err(e) = tokio::fs::remove_file(&cidata_iso).await {
             debug!("Failed to remove cidata ISO {:?}: {}", cidata_iso, e);
+        }
+
+        let console_log = self.console_log_path(instance_id);
+        if let Err(e) = tokio::fs::remove_file(&console_log).await {
+            debug!("Failed to remove console log {:?}: {}", console_log, e);
         }
 
         // Drop any live virtiofsd processes for this instance. Their `Drop`
@@ -780,6 +803,98 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
 
     async fn remove_instance(&self, instance_id: String) -> bool {
         self.stop_vm(&instance_id).await
+    }
+
+    async fn get_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> Vec<crate::runtime::lifecycle_trait::Log> {
+        // Read every state CH knows about: a crashed VM still has a console
+        // log file the operator wants to see, even after the VM is gone.
+        let instances = self.scan_instances(deployment_id, &[]).await;
+
+        let mut logs = Vec::new();
+        for instance_id in instances {
+            if let Some(want) = instance_filter
+                && instance_id != want
+            {
+                continue;
+            }
+            let path = self.console_log_path(&instance_id);
+            let lines = super::console_logs::read_lines(&path, tail, since).await;
+            for message in lines {
+                logs.push(crate::runtime::lifecycle_trait::Log {
+                    instance: instance_id.clone(),
+                    level: crate::runtime::lifecycle_trait::classify_log(&message),
+                    timestamp: crate::runtime::lifecycle_trait::extract_date(&message),
+                    message,
+                });
+            }
+        }
+        logs
+    }
+
+    async fn stream_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn futures::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>
+                + Send,
+        >,
+    > {
+        use futures::stream::{self, StreamExt};
+
+        let instances = self.scan_instances(deployment_id, &[]).await;
+        let filtered: Vec<String> = instances
+            .into_iter()
+            .filter(|id| match instance_filter {
+                Some(want) => id == want,
+                None => true,
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            return Box::pin(stream::empty());
+        }
+
+        let mut streams: Vec<
+            std::pin::Pin<
+                Box<
+                    dyn futures::Stream<
+                            Item = Result<axum::response::sse::Event, std::convert::Infallible>,
+                        > + Send,
+                >,
+            >,
+        > = Vec::new();
+
+        for instance_id in filtered {
+            let path = self.console_log_path(&instance_id);
+            let owned_id = instance_id.clone();
+            let raw =
+                super::console_logs::stream_lines(path, tail.map(|s| s.to_string()), since).await;
+
+            let mapped = raw.map(move |line| {
+                let log = crate::runtime::lifecycle_trait::Log {
+                    instance: owned_id.clone(),
+                    level: crate::runtime::lifecycle_trait::classify_log(&line),
+                    timestamp: crate::runtime::lifecycle_trait::extract_date(&line),
+                    message: line,
+                };
+                let json = serde_json::to_string(&log).unwrap_or_default();
+                Ok(axum::response::sse::Event::default().data(json))
+            });
+
+            streams.push(Box::pin(mapped));
+        }
+
+        Box::pin(stream::select_all(streams))
     }
 }
 

--- a/src/runtime/cloud_hypervisor/mod.rs
+++ b/src/runtime/cloud_hypervisor/mod.rs
@@ -4,6 +4,7 @@ mod client;
 // to `src/runtime/cloud_init.rs` and adjust the `use` paths — the contents are
 // runtime-agnostic on purpose. See comment at the top of cloud_init.rs.
 mod cloud_init;
+mod console_logs;
 mod lifecycle;
 
 pub(crate) use lifecycle::{CloudHypervisorLifecycle, CloudHypervisorRuntimeConfig};

--- a/tests/e2e/t12_ch_logs.sh
+++ b/tests/e2e/t12_ch_logs.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# T12-CH: a CH deployment must produce a serial console log file that
+# `ring deployment logs` can read back. We verify the host-side contract:
+#   1. CH writes to <socket_dir>/<instance>.console.log,
+#   2. the file grows as the guest boots (kernel banner, cloud-init, etc.),
+#   3. `ring deployment logs <id>` returns non-empty output,
+#   4. cleanup removes the log file on delete.
+#
+# We don't assert specific guest-side content beyond "non-empty" because
+# what the kernel/firmware prints over /dev/console varies between images
+# (Cirros versus Ubuntu Focal versus Fedora). Any byte that reached the
+# console is enough to prove the wiring works end-to-end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=./setup-ch.sh
+source "$SCRIPT_DIR/setup-ch.sh"
+
+log "== T12-CH: serial console logs =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/logs-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  logs-vm:
+    name: logs-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "logs-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "logs-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === log file is created by CH and grows ===
+log "looking for console log file..."
+LOG_FILE=""
+for _ in $(seq 1 30); do
+  LOG_FILE=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.console.log" 2>/dev/null | head -n1 || true)
+  [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ] && break
+  sleep 1
+done
+if [ -z "$LOG_FILE" ]; then
+  ls -la "$RING_E2E_CH_SOCKET_DIR" >&2
+  fail "no console log file found in $RING_E2E_CH_SOCKET_DIR"
+fi
+INITIAL_SIZE=$(stat -c %s "$LOG_FILE")
+if [ "$INITIAL_SIZE" -le 0 ]; then
+  fail "console log $LOG_FILE is empty after 30s of boot"
+fi
+log "console log: $LOG_FILE ($INITIAL_SIZE bytes)"
+
+# === ring deployment logs returns non-empty output ===
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 50 2>&1 || true)
+if [ -z "$LOGS_OUT" ]; then
+  echo "$LOGS_OUT" >&2
+  fail "ring deployment logs returned no output"
+fi
+LINE_COUNT=$(printf '%s\n' "$LOGS_OUT" | grep -c .)
+if [ "$LINE_COUNT" -lt 1 ]; then
+  fail "expected at least one log line, got $LINE_COUNT"
+fi
+log "ring deployment logs returned $LINE_COUNT line(s)"
+
+# === --tail caps the output ===
+TAIL_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 5 2>&1 || true)
+TAIL_LINES=$(printf '%s\n' "$TAIL_OUT" | grep -c . || true)
+if [ "$TAIL_LINES" -gt 8 ]; then
+  # Allow some slack: the CLI may print a header/footer line in addition to
+  # the 5 log lines. 8 is generous; anything bigger means tail is ignored.
+  fail "--tail 5 returned $TAIL_LINES lines (expected ≤ 8)"
+fi
+log "--tail 5 returned $TAIL_LINES line(s) (within bounds)"
+
+# === delete teardown removes the log file ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+for _ in $(seq 1 60); do
+  if ! [ -f "$LOG_FILE" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -f "$LOG_FILE" ]; then
+  fail "console log $LOG_FILE still exists after delete"
+fi
+log "console log cleaned up"
+
+log "== T12-CH: PASS =="


### PR DESCRIPTION
## Summary

`ring deployment logs <id>` now works on Cloud Hypervisor deployments. The VMM is started with `serial.mode = "File"` and appends every byte the guest writes to `/dev/console` (kernel banner, cloud-init progress, anything redirected from the guest) to a per-instance file at `<socket_dir>/<instance>.console.log`. Reads and follow-mode streams go through that file.

```bash
ring deployment logs <id>                # last 100 lines
ring deployment logs <id> --tail 500
ring deployment logs <id> --follow       # SSE stream
ring deployment logs <id> --container <instance-id>
```

## What's new

- **`src/runtime/cloud_hypervisor/console_logs.rs`** — pure module. `read_lines(path, tail, since)` and `stream_lines(path, tail, since)`; the streamer uses `stream::unfold` polling at 500 ms (no extra crate). `since` is best-effort (the serial console has no native timestamps; we window on file mtime).
- **`client::ConsoleConfig`** — gains an optional `file: Option<String>` so we can ask CH for `serial.mode = "File"` with a target path.
- **`lifecycle.rs`** —
  - allocates the per-instance log path next to the existing socket / image / cidata files,
  - sets `serial.mode = "File"` with that path on every VM,
  - implements `RuntimeLifecycle::get_logs` and `stream_logs` over `console_logs::read_lines` / `stream_lines`,
  - cleans the file in `stop_vm`.
- **Doc** — flips the "Deployment logs: not available" line in the limitations table and adds a `## Logs` section that documents the wiring + caveats (append-only, heuristic level classification, possibly non-UTF-8 bytes).

## Bugs the e2e found

Zero this time. The e2e (`t12_ch_logs.sh`) passed on the first run after I had fixed the small things `cargo test` already caught (a `chain` import, a few tests to update). The host-side surface is simple enough that a unit-test pass is most of the way home.

What did need real-VM validation: the `--tail 5` line count, since the CLI's framing is what comes out of the API (one `Log` per line).

## Test plan

- [x] `cargo test` — 228 passing (6 new in `console_logs::tests` covering read with/without tail, missing file, non-UTF-8 lossy decode, and the streaming follower picking up appends within the polling window).
- [x] `cargo fmt --check` — clean.
- [x] `tests/e2e/t12_ch_logs.sh` — green against cloud-hypervisor v46. Validates: log file appears under `socket_dir`, grows past zero bytes during boot (~45 KB after the kernel/cloud-init boot on Cirros), `ring deployment logs` returns ≥1 line, `--tail 5` caps the output, `deployment delete` removes the file.
- [x] `t1_ch_boot_delete.sh`, `t9_ch_environment.sh`, `t10_ch_volumes.sh`, `t11_ch_ports.sh` — all green. No regression on the existing CH paths.

## Out of scope (follow-ups)

- **Log rotation / size cap** — CH appends forever. For long-running VMs, log to a tmpfs or rotate externally with logrotate. Tracked in ROADMAP.
- **Native timestamps** — would require running a journald sidecar in the guest. Out of scope here; `--since` stays best-effort.
- **Metrics endpoint** — separate item, the next CH ROADMAP entry to clear.