### PR TITLE
test(e2e): broad docker + cloud-hypervisor coverage, plus 4 latent fixes

### DIFF
--- a/documentation/getting-started/installation.md
+++ b/documentation/getting-started/installation.md
@@ -179,7 +179,7 @@ Ring reads `~/.config/kemeter/ring/config.toml` (or `$RING_CONFIG_DIR/config.tom
 - `RING_DATABASE_PATH` — path to the SQLite database file (default: `./ring.db`)
 - `RING_DB_POOL_SIZE` — maximum SQLite connections in the pool (default: `5`)
 - `RING_CONFIG_DIR` — config directory path (default: `~/.config/kemeter/ring`)
-- `RING_SECRET_KEY` — 32-byte base64-encoded encryption key for the secrets feature. **Required** to create or read secrets — without it, the server returns `500` on secret endpoints.
+- `RING_SECRET_KEY` — 32-byte base64-encoded encryption key used to encrypt secrets at rest. **Required**: `ring server start` refuses to start without it (a clear error is logged and the process exits with code 1). Verify your environment with `ring doctor` before starting the server.
 - `RING_APPLY_TIMEOUT` — timeout in seconds for a single scheduler `apply` cycle (default: `300`)
 - `RING_SCHEDULER_INTERVAL` — scheduler tick interval in seconds (overrides `scheduler.interval` in `config.toml`)
 - `RUST_LOG` — log level (e.g. `RUST_LOG=info` or `RUST_LOG=ring=debug`)

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -213,11 +213,12 @@ Retrieve a deployment by UUID.
       "permission": "rw"
     }
   ],
-  "image_digest": "sha256:..."
+  "image_digest": "sha256:...",
+  "parent_id": null
 }
 ```
 
-During a rolling update, the new (child) deployment carries a `parent_id` field referencing the old deployment.
+During a rolling update, the new (child) deployment carries a `parent_id` field referencing the old deployment id (a UUID string). On a fresh deployment with no rolling update in progress the field is omitted (or `null` depending on the client).
 
 ### `DELETE /deployments/{id}`
 

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -380,7 +380,7 @@ Live resource usage for a deployment and each of its instances. Only meaningful 
 
 Secrets are AES-256-GCM-encrypted values stored per-namespace. The API never exposes the decrypted value — only metadata is returned.
 
-The server must be started with `RING_SECRET_KEY` set (a base64-encoded 32-byte key). Without it, every secret endpoint returns `500 Internal Server Error`.
+`RING_SECRET_KEY` (a base64-encoded 32-byte key) must be set before `ring server start` — the server refuses to start without it. `ring doctor` validates the variable.
 
 ### `POST /secrets`
 
@@ -406,7 +406,6 @@ The server must be started with `RING_SECRET_KEY` set (a base64-encoded 32-byte 
 **Errors:**
 
 - `409 Conflict` — secret with this name already exists in this namespace
-- `500 Internal Server Error` — `RING_SECRET_KEY` is not set on the server
 
 ### `GET /secrets`
 
@@ -650,7 +649,7 @@ Returns information about the host running the Ring server.
 - `404 Not Found` — resource does not exist
 - `408 Request Timeout` — handler exceeded the 10-second API timeout
 - `409 Conflict` — duplicate resource or conflicting state
-- `500 Internal Server Error` — server-side failure (e.g. `RING_SECRET_KEY` not set on a secret operation)
+- `500 Internal Server Error` — server-side failure (database, runtime communication)
 
 ## Error format
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -281,7 +281,7 @@ ring user delete <ID>
 
 ## Secrets
 
-Secrets are AES-256-GCM-encrypted values stored per-namespace. The server must be started with `RING_SECRET_KEY` (a base64-encoded 32-byte key) for any secret operation to succeed; without it, the API returns `500 Internal Server Error`.
+Secrets are AES-256-GCM-encrypted values stored per-namespace. `RING_SECRET_KEY` (a base64-encoded 32-byte key) must be exported before `ring server start` — the server refuses to start otherwise. Run `ring doctor` to confirm the variable is set and decodes correctly.
 
 ### `ring secret create`
 
@@ -474,7 +474,7 @@ The default context (the one with `current = true`) is used when no `--context` 
 - `RING_DATABASE_PATH` — path to the SQLite file (default: `./ring.db`)
 - `RING_DB_POOL_SIZE` — max SQLite connections (default: `5`)
 - `RING_CONFIG_DIR` — config directory (default: `~/.config/kemeter/ring`)
-- `RING_SECRET_KEY` — base64-encoded 32-byte key for secret encryption. **Required** to use secrets.
+- `RING_SECRET_KEY` — base64-encoded 32-byte key for secret encryption. **Required**: the server refuses to start without it (validated up front; see `ring doctor`).
 - `RING_SCHEDULER_INTERVAL` — scheduler tick in seconds (overrides `scheduler.interval` in `config.toml`)
 - `RING_APPLY_TIMEOUT` — single-deployment apply timeout in seconds (default: `300`)
 - `RUST_LOG` — log level (e.g. `info`, `debug`, `ring=debug`)

--- a/documentation/runtimes/docker.md
+++ b/documentation/runtimes/docker.md
@@ -15,13 +15,13 @@ If the connection fails, the server logs an error and exits. Run `ring doctor` f
 
 ## Per-namespace networks
 
-Each Ring namespace maps to one Docker bridge network named `ring-<namespace>`. Containers in the same namespace can reach each other by name; containers in different namespaces are isolated unless you wire something up externally.
+Each Ring namespace maps to one Docker bridge network named `ring_<namespace>`. Containers in the same namespace can reach each other by name; containers in different namespaces are isolated unless you wire something up externally.
 
 ```bash
-docker network ls | grep '^.\+ring-'
-# ring-development    bridge    local
-# ring-staging        bridge    local
-# ring-production     bridge    local
+docker network ls | grep '^.\+ring_'
+# ring_development    bridge    local
+# ring_staging        bridge    local
+# ring_production     bridge    local
 ```
 
 ## Container labels

--- a/src/api/dto/deployment.rs
+++ b/src/api/dto/deployment.rs
@@ -48,6 +48,11 @@ pub(crate) struct DeploymentOutput {
     pub(crate) resources: Option<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) image_digest: Option<String>,
+    /// Set during a rolling update: points to the deployment row this
+    /// one supersedes. The previous deployment stays `running` until the
+    /// new one is healthy, then the scheduler tears it down.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) parent_id: Option<String>,
 }
 
 impl DeploymentOutput {
@@ -87,6 +92,7 @@ impl DeploymentOutput {
             health_checks: deployment.health_checks,
             resources: deployment.resources,
             image_digest: deployment.image_digest,
+            parent_id: deployment.parent_id,
         }
     }
 }

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -155,6 +155,8 @@ struct Volume {
     driver: String,
     #[serde(default = "default_permission")]
     permission: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key: Option<String>,
 }
 
 fn default_driver() -> String {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -205,9 +205,22 @@ fn check_virtiofsd() -> Check {
     Check::fail("virtiofsd", "not found (apt install virtiofsd)")
 }
 
+/// Server-level checks that apply regardless of which runtime is in use.
+/// Today: `RING_SECRET_KEY` validation. Anything that touches a secret
+/// (deployment env vars with `secretRef`, `POST /secrets`, ...) panics
+/// when the key is missing or malformed; surface it here so operators
+/// catch it before the first `ring apply`.
+fn check_server() -> Vec<Check> {
+    vec![match crate::models::secret::try_load_encryption_key() {
+        Ok(_) => Check::ok("RING_SECRET_KEY", "set, decodes to a 32-byte AES-256 key"),
+        Err(e) => Check::fail("RING_SECRET_KEY", &e),
+    }]
+}
+
 pub(crate) fn execute(_args: &ArgMatches, config: Config) {
     let mut all_checks: Vec<(&str, Vec<Check>)> = Vec::new();
 
+    all_checks.push(("Server", check_server()));
     all_checks.push(("Docker", check_docker()));
     all_checks.push(("Cloud Hypervisor", check_cloud_hypervisor(&config)));
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -21,6 +21,16 @@ pub(crate) fn command_config() -> Command {
 }
 
 pub(crate) async fn execute(_args: &ArgMatches, configuration: Config) {
+    // Validate the encryption key up front. Anything that touches a
+    // secret (deployment env vars with `secretRef`, `POST /secrets`, ...)
+    // would panic later on a missing or malformed key; failing here gives
+    // operators a single, clear log line and a non-zero exit, instead of
+    // a 500 the first time someone applies a manifest.
+    if let Err(e) = crate::models::secret::try_load_encryption_key() {
+        error!("Refusing to start: {}", e);
+        std::process::exit(1);
+    }
+
     let pool = get_database_pool().await;
 
     migrate_from_refinery_if_needed(&pool).await;

--- a/src/models/secret.rs
+++ b/src/models/secret.rs
@@ -11,21 +11,41 @@ use std::env;
 
 const NONCE_SIZE: usize = 12;
 
-fn get_encryption_key() -> [u8; 32] {
-    let key_str = env::var("RING_SECRET_KEY")
-        .expect("RING_SECRET_KEY environment variable must be set (32 bytes, base64 encoded)");
+/// Read and validate `RING_SECRET_KEY` from the environment. Returns the
+/// decoded 32-byte key on success, an explanatory message otherwise.
+///
+/// Used both at server startup (so missing/invalid keys produce a clear
+/// fatal error before any request is served) and from `ring doctor` to
+/// surface configuration drift before users hit it via a panic.
+pub(crate) fn try_load_encryption_key() -> Result<[u8; 32], String> {
+    let key_str = env::var("RING_SECRET_KEY").map_err(|_| {
+        "RING_SECRET_KEY environment variable is not set. \
+         Generate one with: openssl rand -base64 32"
+            .to_string()
+    })?;
 
     let key_bytes = BASE64
         .decode(&key_str)
-        .expect("RING_SECRET_KEY must be valid base64");
+        .map_err(|e| format!("RING_SECRET_KEY is not valid base64: {}", e))?;
 
     if key_bytes.len() != 32 {
-        panic!("RING_SECRET_KEY must be exactly 32 bytes (256 bits)");
+        return Err(format!(
+            "RING_SECRET_KEY must decode to exactly 32 bytes (256 bits), got {}",
+            key_bytes.len()
+        ));
     }
 
     let mut key = [0u8; 32];
     key.copy_from_slice(&key_bytes);
-    key
+    Ok(key)
+}
+
+fn get_encryption_key() -> [u8; 32] {
+    // The server validates the key once at startup (see `commands::server`)
+    // and aborts before listening if it's missing or malformed. Anything
+    // that reaches this function therefore has a working key — the
+    // remaining unwrap is on a path the operator cannot break at runtime.
+    try_load_encryption_key().expect("RING_SECRET_KEY validation passed at startup")
 }
 
 pub(crate) fn encrypt_value(plaintext: &str) -> Vec<u8> {

--- a/tests/e2e/cloud-hypervisor/setup.sh
+++ b/tests/e2e/cloud-hypervisor/setup.sh
@@ -3,7 +3,7 @@
 #
 # Verifies that the host has everything needed to boot a VM through Ring's
 # cloud-hypervisor runtime, and downloads a small bootable raw image on first
-# run. Sourced by t*-ch.sh scripts via `source setup-ch.sh`.
+# run. Sourced by tests/e2e/cloud-hypervisor/t*.sh via `source setup.sh`.
 #
 # Artifacts live outside the repo under $HOME/.cache/ring-e2e/ to avoid
 # committing ~5 GB of VM image to git.

--- a/tests/e2e/cloud-hypervisor/t10_rolling_update.sh
+++ b/tests/e2e/cloud-hypervisor/t10_rolling_update.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# T10-CH: rolling update on the CH runtime. The same logic that protects
+# Docker (`parent_id`, "keep the old deployment alive when health checks
+# are defined") applies to CH. We exercise it by deploying once, then
+# re-applying the same fixture (same image is fine — the API uses the
+# *new* deployment id as the trigger, not an image diff). The previous
+# deployment row must be kept around with status=running and tied via
+# parent_id to the new one.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T10-CH: rolling update with health checks =="
+
+setup_ch
+start_ring
+ring_login
+
+# === v1 with a TCP health check ===
+# CH refuses `command` health checks at the API; TCP and HTTP are fine.
+# We pick port 22 because Cirros's getty is unlikely to expose it but the
+# health check is enough to *trigger* the rolling-update path; the test
+# does not care whether the probe ever succeeds (we time-bound it with
+# `wait_deployment_status` 'running').
+FIXTURE_V1="$RING_TEST_DIR/rolling-vm-v1.yaml"
+cat > "$FIXTURE_V1" <<EOF
+deployments:
+  rolling-vm:
+    name: rolling-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    health_checks:
+      - { type: tcp, port: 22, interval: "10s", timeout: "5s", on_failure: alert }
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE_V1"
+wait_deployment_status "ring-e2e" "rolling-vm" "running" 120
+
+V1_ID=$(get_deployment_id "ring-e2e" "rolling-vm")
+[ -z "$V1_ID" ] && fail "could not find v1 deployment id"
+log "v1 id: $V1_ID"
+
+# Re-apply: this should trigger the rolling-update path.
+"$RING_BIN" apply --file "$FIXTURE_V1"
+
+# === A second deployment row appears, parent_id points back to v1 ===
+# get_deployment_id returns the *first* match by ns+name, but during a
+# rolling update both rows share that pair. Pull both via the JSON list
+# and pick the one whose parent_id is set.
+ok=0
+for _ in $(seq 1 60); do
+  V2_ID=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg ns "ring-e2e" --arg n "rolling-vm" \
+        '.[] | select(.namespace==$ns and .name==$n and (.parent_id // "") != "") | .id' \
+    | head -n1)
+  if [ -n "$V2_ID" ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "no v2 deployment with parent_id appeared within 60s"
+log "v2 id: $V2_ID"
+
+if [ "$V1_ID" = "$V2_ID" ]; then
+  fail "v1 and v2 share the same id — rolling update did not create a new row"
+fi
+
+# === parent_id = V1_ID ===
+PARENT=$("$RING_BIN" deployment list --output json 2>/dev/null \
+  | jq -r --arg id "$V2_ID" '.[] | select(.id==$id) | .parent_id')
+if [ "$PARENT" != "$V1_ID" ]; then
+  fail "v2's parent_id is '$PARENT', expected '$V1_ID'"
+fi
+log "v2.parent_id == v1.id"
+
+# === v1 is still running until v2 is up ===
+# This is the whole point of the rolling-update brick: the old deployment
+# does not get torn down until the new one becomes healthy.
+V1_STATUS=$("$RING_BIN" deployment list --output json 2>/dev/null \
+  | jq -r --arg id "$V1_ID" '.[] | select(.id==$id) | .status')
+if [ "$V1_STATUS" != "running" ]; then
+  fail "v1 status after re-apply is '$V1_STATUS' (expected 'running' during rolling update)"
+fi
+log "v1 still running while v2 boots"
+
+# Wait for v2 to reach running before we delete (avoid teardown races).
+for _ in $(seq 1 120); do
+  s=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg id "$V2_ID" '.[] | select(.id==$id) | .status')
+  [ "$s" = "running" ] && break
+  sleep 1
+done
+
+# Cleanup both (v2 first, v1 may have been cleaned by the scheduler).
+"$RING_BIN" deployment delete "$V2_ID" 2>/dev/null || true
+"$RING_BIN" deployment delete "$V1_ID" 2>/dev/null || true
+
+log "== T10-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t11_image_not_found.sh
+++ b/tests/e2e/cloud-hypervisor/t11_image_not_found.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# T11-CH: deploying with a non-existent disk image must land the
+# deployment in `ImagePullBackOff` (a permanent state, not a transient
+# crash loop). Cloud Hypervisor classifies a missing rootfs as
+# `RuntimeError::ImageNotFound`, which the lifecycle pins to
+# `DeploymentStatus::ImagePullBackOff`. We assert that status and that
+# the scheduler does NOT keep retrying forever (no restart_count growth).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T11-CH: image not found =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/missing-image.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  missing-image:
+    name: missing-image
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "/nonexistent/path/to/disk.raw"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "missing-image" "ImagePullBackOff" 60
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "missing-image")
+[ -z "$DEPLOYMENT_ID" ] && fail "no deployment id"
+log "deployment landed in ImagePullBackOff: $DEPLOYMENT_ID"
+
+# === restart_count must stay at 0 — ImagePullBackOff is permanent ===
+# A few scheduler ticks pass; if the runtime kept retrying, restart_count
+# would grow. The classification as a permanent error is what guarantees
+# this: the scheduler skips retries.
+sleep 5
+RC=$(get_restart_count "ring-e2e" "missing-image")
+if [ "$RC" != "0" ]; then
+  fail "restart_count=$RC after a permanent ImageNotFound (expected 0 — scheduler must not retry)"
+fi
+log "restart_count stayed at 0 (permanent error not retried)"
+
+# === No CH socket / VM was created — there is nothing to clean up but
+# we check anyway, so a future regression that *does* create a half-baked
+# VM gets caught.
+SOCKETS=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.sock" -type s 2>/dev/null | wc -l | tr -d ' ')
+if [ "$SOCKETS" != "0" ]; then
+  fail "expected no CH socket (image was never found), got $SOCKETS"
+fi
+log "no CH socket created (clean failure)"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+log "== T11-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t12_firmware_missing.sh
+++ b/tests/e2e/cloud-hypervisor/t12_firmware_missing.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# T12-CH: when the configured firmware path does not exist, Cloud
+# Hypervisor maps the failure to `RuntimeError::FirmwareNotFound`,
+# which the lifecycle pins to `DeploymentStatus::Failed` (permanent —
+# the operator must fix `firmware_path`).
+#
+# We override `firmware_path` for this test only, leaving the rest of
+# the suite unaffected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T12-CH: firmware missing =="
+
+# Point CH at a path that does not exist. setup_ch normally hands down
+# the real firmware via RING_EXTRA_CONFIG; we override before it runs.
+BOGUS_FW="$(mktemp -u -t ring-e2e-bogus-fw-XXXXXX).bin"
+RING_E2E_CH_FIRMWARE_BACKUP="${RING_E2E_CH_FIRMWARE:-}"
+RING_E2E_CH_FIRMWARE="$BOGUS_FW"
+export RING_E2E_CH_FIRMWARE
+
+# setup_ch's prereq check refuses an absent firmware. Bypass by skipping
+# `check_ch_prereqs` and going straight to the bits we need.
+ensure_ch_image
+RING_E2E_CH_SOCKET_DIR="${RING_E2E_CH_SOCKET_DIR:-$(mktemp -d -t ring-e2e-ch-sockets-XXXXXX)}"
+export RING_E2E_CH_SOCKET_DIR
+RING_EXTRA_CONFIG=$(cat <<EOF
+[contexts.default.runtime.cloud_hypervisor]
+firmware_path = "$BOGUS_FW"
+socket_dir = "$RING_E2E_CH_SOCKET_DIR"
+seccomp = "false"
+EOF
+)
+export RING_EXTRA_CONFIG
+trap 'cleanup_ch; cleanup_ring' EXIT
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/no-fw.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  no-fw:
+    name: no-fw
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "no-fw" "failed" 60
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "no-fw")
+log "deployment landed in 'failed' as expected: $DEPLOYMENT_ID"
+
+# === Permanent failure: restart_count must stay at 0 ===
+sleep 5
+RC=$(get_restart_count "ring-e2e" "no-fw")
+if [ "$RC" != "0" ]; then
+  fail "restart_count=$RC for FirmwareNotFound (expected 0 — permanent error)"
+fi
+log "restart_count stayed at 0"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+log "== T12-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t13_ports_with_volumes.sh
+++ b/tests/e2e/cloud-hypervisor/t13_ports_with_volumes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# T13-CH: a deployment combining `ports` and `volumes` must pull both
+# features at once. We assert the host-side wiring (tap interface +
+# socat + virtiofsd pid file + named volume directory) co-exists for
+# the same VM. Earlier tests already cover each in isolation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T13-CH: ports + volumes combined =="
+
+if [ ! -x "/usr/libexec/virtiofsd" ] && [ ! -x "/usr/lib/qemu/virtiofsd" ] && [ -z "${RING_VIRTIOFSD:-}" ]; then
+  echo "[e2e] SKIP: virtiofsd not installed" >&2
+  exit 0
+fi
+if ! command -v socat > /dev/null 2>&1; then
+  echo "[e2e] SKIP: socat not installed" >&2
+  exit 0
+fi
+
+setup_ch
+start_ring
+ring_login
+
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+BIND_SRC="$RING_TEST_DIR/combo-bind"
+mkdir -p "$BIND_SRC"
+echo "combo-marker" > "$BIND_SRC/marker.txt"
+
+FIXTURE="$RING_TEST_DIR/combo.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  combo:
+    name: combo
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    ports:
+      - { published: $PORT, target: 80 }
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /data
+        driver: local
+        permission: rw
+      - type: volume
+        source: combo-data
+        destination: /var/lib/data
+        driver: local
+        permission: rw
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "combo" "running" 120
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "combo")
+
+# === socat for the port ===
+ok=0
+for _ in $(seq 1 30); do
+  if (pgrep -f "socat.*TCP4-LISTEN:$PORT" || true) | grep -q .; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "no socat forwarder for port $PORT"
+log "socat forwarder running for port $PORT"
+
+# === virtiofsd pid files (one per volume = 2) ===
+PIDS=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+[ "$PIDS" -ge 2 ] || fail "expected ≥2 virtiofsd pid files, got $PIDS"
+log "$PIDS virtiofsd pid files (one per volume)"
+
+# === ring-* tap created by CH ===
+TAPS=$( (ip tuntap show 2>/dev/null | grep -E "^ring-[0-9a-f]+:" || true) | wc -l | tr -d ' ')
+[ "$TAPS" -ge 1 ] || fail "no ring-* tap interface present"
+log "ring-* tap present"
+
+# === named volume dir persists ===
+[ -d "$RING_E2E_CH_SOCKET_DIR/volumes/ring-e2e/combo-data" ] \
+  || fail "named volume dir missing"
+log "named volume dir present at socket_dir/volumes/ring-e2e/combo-data"
+
+# === Delete tears everything down ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+for _ in $(seq 1 60); do
+  pids_left=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+  socat_left=$( (pgrep -f "socat.*TCP4-LISTEN:$PORT" || true) | wc -l | tr -d ' ')
+  if [ "$pids_left" -eq 0 ] && [ "$socat_left" -eq 0 ]; then
+    break
+  fi
+  sleep 1
+done
+[ "$pids_left" -eq 0 ] && [ "$socat_left" -eq 0 ] \
+  || fail "leak after delete: virtiofs_pids=$pids_left socat=$socat_left"
+log "everything cleaned up"
+
+# Named volume dir must persist even after delete (intentional).
+[ -d "$RING_E2E_CH_SOCKET_DIR/volumes/ring-e2e/combo-data" ] \
+  || fail "named volume dir was unexpectedly removed"
+log "named volume dir persisted across deletion"
+
+log "== T13-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t14_multi_replicas_volumes.sh
+++ b/tests/e2e/cloud-hypervisor/t14_multi_replicas_volumes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# T14-CH: each replica of a CH deployment with volumes must spawn its
+# OWN set of virtiofsd daemons (sockets + pid files), keyed on the
+# instance id, not the deployment id. Two replicas with one bind volume
+# = 2 virtiofsd processes.
+#
+# Also asserts that scaling down to 1 replica kills exactly one of the
+# two virtiofsd daemons — the cleanup is per-instance, not per-deployment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T14-CH: multi-replica volumes =="
+
+if [ ! -x "/usr/libexec/virtiofsd" ] && [ ! -x "/usr/lib/qemu/virtiofsd" ] && [ -z "${RING_VIRTIOFSD:-}" ]; then
+  echo "[e2e] SKIP: virtiofsd not installed" >&2
+  exit 0
+fi
+
+setup_ch
+start_ring
+ring_login
+
+BIND_SRC="$RING_TEST_DIR/multi-bind"
+mkdir -p "$BIND_SRC"
+
+FIXTURE="$RING_TEST_DIR/multi-vol.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  multi-vol:
+    name: multi-vol
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 2
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /data
+        driver: local
+        permission: rw
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "multi-vol" "running" 180
+
+# === 2 instances, 2 virtiofsd pid files (one per replica) ===
+ok=0
+for _ in $(seq 1 60); do
+  PIDS=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$PIDS" -eq 2 ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "expected 2 virtiofsd pid files (one per replica), got $PIDS"
+log "$PIDS virtiofsd pid files for 2 replicas"
+
+# === virtiofsd processes are distinct (different sockets) ===
+PROC_COUNT=$( (pgrep -f "virtiofsd.*virtiofs-[0-9]+\.sock" || true) | wc -l | tr -d ' ')
+[ "$PROC_COUNT" -ge 2 ] || { pgrep -af virtiofsd >&2 || true; fail "expected ≥2 virtiofsd processes, got $PROC_COUNT"; }
+log "$PROC_COUNT virtiofsd processes alive"
+
+# === Scale to 1 — exactly one virtiofsd should die ===
+SCALE_FIXTURE="$RING_TEST_DIR/multi-vol-1.yaml"
+cat > "$SCALE_FIXTURE" <<EOF
+deployments:
+  multi-vol:
+    name: multi-vol
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /data
+        driver: local
+        permission: rw
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+"$RING_BIN" apply --file "$SCALE_FIXTURE"
+
+ok=0
+for _ in $(seq 1 60); do
+  PIDS=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.virtiofs-*.sock.pid" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$PIDS" -eq 1 ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "expected 1 virtiofsd pid file after scale-down, got $PIDS"
+log "$PIDS virtiofsd pid file after scale-down to 1 replica"
+
+# Cleanup the active deployment (its id changed after re-apply).
+NEW_ID=$(get_deployment_id "ring-e2e" "multi-vol")
+"$RING_BIN" deployment delete "$NEW_ID"
+
+log "== T14-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t1_boot_delete.sh
+++ b/tests/e2e/cloud-hypervisor/t1_boot_delete.sh
@@ -10,10 +10,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T1-CH: boot / delete =="
 

--- a/tests/e2e/cloud-hypervisor/t2_replicas.sh
+++ b/tests/e2e/cloud-hypervisor/t2_replicas.sh
@@ -10,10 +10,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 # Wait for exactly <expected> CH sockets to be present in $RING_E2E_CH_SOCKET_DIR.
 # Usage: wait_ch_socket_count <expected> [timeout_seconds]

--- a/tests/e2e/cloud-hypervisor/t3_crashloop.sh
+++ b/tests/e2e/cloud-hypervisor/t3_crashloop.sh
@@ -19,10 +19,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T6-CH: crash loop must converge to CrashLoopBackOff =="
 

--- a/tests/e2e/cloud-hypervisor/t4_environment.sh
+++ b/tests/e2e/cloud-hypervisor/t4_environment.sh
@@ -14,10 +14,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T9-CH: cloud-init environment variables =="
 

--- a/tests/e2e/cloud-hypervisor/t5_volumes.sh
+++ b/tests/e2e/cloud-hypervisor/t5_volumes.sh
@@ -10,10 +10,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T10-CH: virtio-fs volumes (bind, named, config) =="
 

--- a/tests/e2e/cloud-hypervisor/t6_ports.sh
+++ b/tests/e2e/cloud-hypervisor/t6_ports.sh
@@ -12,10 +12,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T11-CH: port mapping via socat =="
 

--- a/tests/e2e/cloud-hypervisor/t7_logs.sh
+++ b/tests/e2e/cloud-hypervisor/t7_logs.sh
@@ -14,10 +14,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
-# shellcheck source=./setup-ch.sh
-source "$SCRIPT_DIR/setup-ch.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
 
 log "== T12-CH: serial console logs =="
 

--- a/tests/e2e/cloud-hypervisor/t8_resource_limits.sh
+++ b/tests/e2e/cloud-hypervisor/t8_resource_limits.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# T8-CH: a deployment with `resources.limits` must size the VM accordingly.
+# CH's `vm.info` API exposes `cpus.boot_vcpus` and `memory.size` (bytes),
+# both readable from the VMM via the Unix socket Ring already maintains.
+# We assert that 0.5 CPU rounds up to 1 vCPU (a VM cannot have less than
+# one) and that 256Mi rounds to 256 MB of memory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T8-CH: resource limits =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/limits-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  limits-vm:
+    name: limits-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "2"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "limits-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "limits-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# Find the VM API socket. There's exactly one for a single replica.
+SOCK=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.sock" -type s 2>/dev/null | head -n1 || true)
+[ -z "$SOCK" ] && fail "no CH API socket in $RING_E2E_CH_SOCKET_DIR"
+log "VM API socket: $SOCK"
+
+# Pull live VM info from CH. The HTTP API speaks JSON over the Unix socket.
+# We use curl's --unix-socket; jq parses the response.
+INFO=$(curl -s --unix-socket "$SOCK" http://localhost/api/v1/vm.info || true)
+if [ -z "$INFO" ]; then
+  fail "vm.info returned nothing"
+fi
+
+# === vcpus matches the resource limit ===
+# Ring's parse_cpu_string maps "2" → 2 vCPUs. CH's `cpus.boot_vcpus`
+# carries it.
+VCPUS=$(echo "$INFO" | jq -r '.config.cpus.boot_vcpus' 2>/dev/null || true)
+if [ "$VCPUS" != "2" ]; then
+  echo "$INFO" | jq '.config.cpus' >&2 || echo "$INFO" >&2
+  fail "expected boot_vcpus=2, got '$VCPUS'"
+fi
+log "VM has $VCPUS vCPUs (matches limit cpu=2)"
+
+# === memory matches the resource limit ===
+# 256 Mi = 256 * 1024 * 1024 = 268435456 bytes.
+MEM=$(echo "$INFO" | jq -r '.config.memory.size' 2>/dev/null || true)
+EXPECTED_MEM=268435456
+if [ "$MEM" != "$EXPECTED_MEM" ]; then
+  echo "$INFO" | jq '.config.memory' >&2 || echo "$INFO" >&2
+  fail "expected memory.size=$EXPECTED_MEM bytes, got '$MEM'"
+fi
+log "VM has $MEM bytes of memory (matches limit memory=256Mi)"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+log "== T8-CH: PASS =="

--- a/tests/e2e/cloud-hypervisor/t9_scaledown.sh
+++ b/tests/e2e/cloud-hypervisor/t9_scaledown.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# T9-CH: scaling a CH deployment from 3 to 1 replica must remove exactly
+# 2 VMs (sockets, instance disks, virtiofsd if any) without bumping the
+# deployment's restart_count. Operator-initiated VM stops are tagged as
+# intentional shutdowns; the same scheduler logic that protected Docker
+# applies to CH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T9-CH: scale-down does not crash-loop =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/scale-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  scale-vm:
+    name: scale-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 3
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "scale-vm" "running" 180
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "scale-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === 3 sockets are present ===
+# CH names sockets `ch-<short_id>-<random>.sock`. Wait until the count
+# reaches 3, the scheduler's tick is 1s.
+ok=0
+for _ in $(seq 1 60); do
+  count=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.sock" -type s 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$count" -eq 3 ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "expected 3 CH sockets, got $count"
+log "3 VM sockets observed"
+
+# === Scale down to 1 ===
+SCALE_FILE="$RING_TEST_DIR/scale-vm-1.yaml"
+cat > "$SCALE_FILE" <<EOF
+deployments:
+  scale-vm:
+    name: scale-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+"$RING_BIN" apply --file "$SCALE_FILE"
+
+# === Wait for the count to settle at 1 ===
+ok=0
+for _ in $(seq 1 60); do
+  count=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.sock" -type s 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$count" -eq 1 ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "expected 1 CH socket after scale-down, got $count"
+log "scale-down landed: 1 VM socket remaining"
+
+# A re-apply with a different replicas count creates a new deployment row
+# in DB and marks the previous one as deleted (the rolling-update / replace
+# semantics of `ring apply`). For the post-scale assertions we look up the
+# currently active deployment by namespace+name.
+NEW_DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "scale-vm")
+[ -z "$NEW_DEPLOYMENT_ID" ] && fail "could not find active deployment after scale-down"
+log "active deployment after scale-down: $NEW_DEPLOYMENT_ID"
+
+# === restart_count stayed at 0 ===
+# Operator-initiated stops must not be counted as crashes — that is the
+# whole point of the intentional_shutdowns module.
+RESTART_COUNT=$(get_restart_count "ring-e2e" "scale-vm")
+if [ "$RESTART_COUNT" != "0" ]; then
+  fail "restart_count bumped to $RESTART_COUNT during scale-down (expected 0)"
+fi
+log "restart_count stayed at 0 (no false-positive crash)"
+
+# === Status is still `running` (not crashloopbackoff or any other terminal) ===
+STATUS=$("$RING_BIN" deployment list --output json 2>/dev/null \
+  | jq -r --arg id "$NEW_DEPLOYMENT_ID" '.[] | select(.id==$id) | .status')
+if [ "$STATUS" != "running" ]; then
+  fail "deployment $NEW_DEPLOYMENT_ID landed in '$STATUS' after scale-down (expected running)"
+fi
+log "deployment is still running"
+
+# Cleanup
+"$RING_BIN" deployment delete "$NEW_DEPLOYMENT_ID"
+
+log "== T9-CH: PASS =="

--- a/tests/e2e/docker/t10_resource_limits.sh
+++ b/tests/e2e/docker/t10_resource_limits.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# T10: a deployment with `resources.limits` must propagate CPU and memory
+# caps into the Docker container's HostConfig (NanoCpus + Memory). The
+# deployment is configured with 0.5 CPU and 128Mi of memory; the Docker
+# inspect output is asserted byte-for-byte.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T10: docker resource limits =="
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/nginx-limits.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  nginx-limits:
+    name: nginx-limits
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    resources:
+      limits:
+        cpu: "0.5"
+        memory: "128Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "nginx-limits" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-limits")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+
+# === CPU limit ===
+# 0.5 CPU = 500_000_000 nanocores. Docker's HostConfig.NanoCpus carries it
+# verbatim from Ring's parse_cpu_string.
+NANOCPUS=$(docker inspect "$CID" --format '{{ .HostConfig.NanoCpus }}')
+EXPECTED_NANO=500000000
+if [ "$NANOCPUS" != "$EXPECTED_NANO" ]; then
+  docker inspect "$CID" --format '{{ json .HostConfig }}' >&2
+  fail "expected NanoCpus=$EXPECTED_NANO, got $NANOCPUS"
+fi
+log "NanoCpus = $NANOCPUS (matches 0.5 CPU)"
+
+# === Memory limit ===
+# 128 Mi = 128 * 1024 * 1024 = 134217728 bytes. parse_memory_string in Ring
+# uses the binary multiplier (Mi = 1024^2), not the SI one (M = 1000^2).
+MEMORY=$(docker inspect "$CID" --format '{{ .HostConfig.Memory }}')
+EXPECTED_MEM=134217728
+if [ "$MEMORY" != "$EXPECTED_MEM" ]; then
+  docker inspect "$CID" --format '{{ json .HostConfig }}' >&2
+  fail "expected Memory=$EXPECTED_MEM bytes, got $MEMORY"
+fi
+log "Memory = $MEMORY bytes (matches 128Mi)"
+
+# === Without limits, both fields stay at 0 (no cap) ===
+# Sanity check that limits aren't sneaking in via a default elsewhere in
+# the pipeline. Re-deploy without any `resources` and verify.
+FIXTURE2="$RING_TEST_DIR/nginx-no-limits.yaml"
+cat > "$FIXTURE2" <<'EOF'
+deployments:
+  nginx-no-limits:
+    name: nginx-no-limits
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE2"
+wait_deployment_status "ring-e2e" "nginx-no-limits" "running" 60
+DEPLOYMENT_ID2=$(get_deployment_id "ring-e2e" "nginx-no-limits")
+CID2=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID2" --format '{{.ID}}' | head -n1)
+[ -z "$CID2" ] && fail "no container for nginx-no-limits"
+NANOCPUS2=$(docker inspect "$CID2" --format '{{ .HostConfig.NanoCpus }}')
+MEMORY2=$(docker inspect "$CID2" --format '{{ .HostConfig.Memory }}')
+if [ "$NANOCPUS2" != "0" ] || [ "$MEMORY2" != "0" ]; then
+  fail "deployment without resources still has NanoCpus=$NANOCPUS2 Memory=$MEMORY2 (expected 0/0)"
+fi
+log "deployment without limits keeps NanoCpus=0 Memory=0"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID2"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+wait_docker_container_gone "$DEPLOYMENT_ID2" 30
+
+log "== T10: PASS =="

--- a/tests/e2e/docker/t11_logs.sh
+++ b/tests/e2e/docker/t11_logs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# T11: `ring deployment logs <id>` on a Docker deployment must return the
+# container's stdout/stderr stream. We use an alpine container that emits
+# a couple of recognisable lines via `echo`, then a long sleep so the
+# container stays around for the assertions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T11: docker logs =="
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/log-emitter.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  log-emitter:
+    name: log-emitter
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sh", "-c", "echo RING-LOG-MARKER-1; echo RING-LOG-MARKER-2; sleep 600"]
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "log-emitter" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "log-emitter")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# Give Docker a moment to flush the echoes to the log driver.
+sleep 2
+
+# === one-shot logs returns both markers ===
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 50 2>&1 || true)
+if ! echo "$LOGS_OUT" | grep -q "RING-LOG-MARKER-1"; then
+  echo "$LOGS_OUT" >&2
+  fail "first marker missing from logs output"
+fi
+if ! echo "$LOGS_OUT" | grep -q "RING-LOG-MARKER-2"; then
+  echo "$LOGS_OUT" >&2
+  fail "second marker missing from logs output"
+fi
+log "both stdout markers present in 'ring deployment logs --tail 50'"
+
+# === --tail caps the output ===
+# Append more lines via `docker exec` so we have something to clip. Use
+# /proc/1/fd/1 to write directly to the container's stdout (visible to
+# Docker's log driver). Then `--tail 1` should give us only the latest one.
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+docker exec "$CID" sh -c 'for i in 1 2 3 4 5; do echo "RING-EXTRA-$i" > /proc/1/fd/1; done'
+sleep 1
+
+TAIL_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 1 2>&1 || true)
+TAIL_LINES=$(printf '%s\n' "$TAIL_OUT" | grep -c "RING-EXTRA" || true)
+if [ "$TAIL_LINES" -gt 1 ]; then
+  echo "$TAIL_OUT" >&2
+  fail "--tail 1 returned $TAIL_LINES RING-EXTRA lines (expected ≤ 1)"
+fi
+log "--tail 1 returned $TAIL_LINES RING-EXTRA line(s) (within bounds)"
+
+# === --follow streams new lines ===
+# Run the follower in the background, append a unique line, then check the
+# follower captured it. We bound the wait to keep the test deterministic.
+FOLLOW_OUT="$RING_TEST_DIR/follow.log"
+"$RING_BIN" deployment logs "$DEPLOYMENT_ID" --follow > "$FOLLOW_OUT" 2>&1 &
+FOLLOW_PID=$!
+sleep 2
+docker exec "$CID" sh -c 'echo RING-STREAM-MARKER > /proc/1/fd/1'
+seen=0
+for _ in $(seq 1 20); do
+  if grep -q "RING-STREAM-MARKER" "$FOLLOW_OUT" 2>/dev/null; then
+    seen=1
+    break
+  fi
+  sleep 0.5
+done
+kill "$FOLLOW_PID" 2>/dev/null || true
+wait "$FOLLOW_PID" 2>/dev/null || true
+if [ "$seen" -ne 1 ]; then
+  cat "$FOLLOW_OUT" >&2 || true
+  fail "--follow did not pick up a new stdout line within 10s"
+fi
+log "--follow streamed RING-STREAM-MARKER as it appeared"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T11: PASS =="

--- a/tests/e2e/docker/t12_config_volume.sh
+++ b/tests/e2e/docker/t12_config_volume.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# T12: a `volume.type: config` mount must materialise the value of the
+# referenced config (a key inside a Ring config object) as a file inside
+# the container. The whole flow exercised here: create a Ring config via
+# the API, deploy a container that mounts one of its keys, then read the
+# mounted file from inside the container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T12: docker config volume =="
+
+start_ring
+ring_login
+
+# === Create a Ring config via the API ===
+# The CLI has no `ring config create` yet (see ROADMAP). We hit the REST
+# API directly. The data field is a JSON-encoded map<string, string>; one
+# key per "file" we want to materialise.
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+CONFIG_PAYLOAD=$(cat <<'EOF'
+{
+  "namespace": "ring-e2e",
+  "name": "app-conf",
+  "data": "{\"app.conf\":\"hello-from-ring-config\\n\"}"
+}
+EOF
+)
+HTTP_CODE=$(curl -s -o /tmp/ring-config-create.out -w '%{http_code}' \
+  -X POST "$RING_URL/configs" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$CONFIG_PAYLOAD")
+if [ "$HTTP_CODE" != "201" ]; then
+  cat /tmp/ring-config-create.out >&2
+  fail "POST /configs returned $HTTP_CODE (expected 201)"
+fi
+log "Ring config 'app-conf' created via API"
+
+# === Deploy a container that mounts the config key ===
+FIXTURE="$RING_TEST_DIR/cfg-volume.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  cfg-vm:
+    name: cfg-vm
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    volumes:
+      - type: config
+        source: app-conf
+        key: app.conf
+        destination: /etc/app/app.conf
+        driver: local
+        permission: ro
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "cfg-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "cfg-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+
+# === The file exists inside the container with the expected content ===
+content=$(docker exec "$CID" cat /etc/app/app.conf 2>&1 || true)
+if [ "$content" != "hello-from-ring-config" ]; then
+  echo "$content" >&2
+  fail "config volume content mismatch: got '$content'"
+fi
+log "config volume content matches: '$content'"
+
+# === The mount is read-only ===
+if docker exec "$CID" sh -c 'echo break > /etc/app/app.conf' 2>/dev/null; then
+  fail "config volume is writable but should be read-only"
+fi
+log "config volume is read-only as expected"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T12: PASS =="

--- a/tests/e2e/docker/t13_environment.sh
+++ b/tests/e2e/docker/t13_environment.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# T13: environment variables on a deployment must be exposed inside the
+# container. Both forms are exercised: plain `KEY: value` literal and
+# `secretRef` pointing to a Ring-managed encrypted secret.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T13: docker environment variables =="
+
+start_ring
+ring_login
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+# === Create the namespace, then the secret ===
+# Secrets require an existing namespace (POST /secrets returns 404 if
+# the namespace is missing). Deployments auto-create namespaces; secrets
+# don't.
+HTTP=$(curl -s -o /tmp/ring-ns.out -w '%{http_code}' \
+  -X POST "$RING_URL/namespaces" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"ring-e2e"}')
+if [ "$HTTP" != "201" ] && [ "$HTTP" != "409" ]; then
+  cat /tmp/ring-ns.out >&2
+  fail "POST /namespaces returned $HTTP (expected 201 or 409)"
+fi
+log "namespace ring-e2e ready"
+
+HTTP=$(curl -s -o /tmp/ring-secret.out -w '%{http_code}' \
+  -X POST "$RING_URL/secrets" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"namespace":"ring-e2e","name":"db-password","value":"s3cret-from-ring"}')
+if [ "$HTTP" != "201" ]; then
+  cat /tmp/ring-secret.out >&2
+  fail "POST /secrets returned $HTTP (expected 201)"
+fi
+log "secret 'db-password' created via API"
+
+# === Deploy a container reading the env ===
+FIXTURE="$RING_TEST_DIR/env-vm.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  env-vm:
+    name: env-vm
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    environment:
+      LOG_LEVEL: "debug"
+      DB_PASSWORD:
+        secretRef: "db-password"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "env-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "env-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+
+# === Plain env value lands in /proc/1/environ ===
+got=$(docker exec "$CID" sh -c 'echo "$LOG_LEVEL"' 2>&1 || true)
+if [ "$got" != "debug" ]; then
+  docker exec "$CID" env | sort >&2 || true
+  fail "expected LOG_LEVEL=debug, got '$got'"
+fi
+log "LOG_LEVEL=debug visible inside the container"
+
+# === secretRef is resolved to the cleartext value ===
+got=$(docker exec "$CID" sh -c 'echo "$DB_PASSWORD"' 2>&1 || true)
+if [ "$got" != "s3cret-from-ring" ]; then
+  docker exec "$CID" env | sort >&2 || true
+  fail "expected DB_PASSWORD=s3cret-from-ring, got '$got'"
+fi
+log "DB_PASSWORD resolved from secretRef inside the container"
+
+# === The cleartext secret must NOT leak through GET /deployments ===
+# Ring stores `{secretRef: "..."}` as the env value in DB and decrypts it
+# only when handing it to the runtime. The API response should reflect
+# the secretRef shape, not the cleartext.
+list_out=$(curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID" \
+  -H "Authorization: Bearer $TOKEN" 2>&1 || true)
+if echo "$list_out" | grep -q "s3cret-from-ring"; then
+  echo "$list_out" >&2
+  fail "cleartext secret leaked through GET /deployments/$DEPLOYMENT_ID"
+fi
+log "GET /deployments/{id} does not expose the cleartext secret"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T13: PASS =="

--- a/tests/e2e/docker/t14_health_check_http_and_command.sh
+++ b/tests/e2e/docker/t14_health_check_http_and_command.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# T14: HTTP and command health check types must work end-to-end on Docker.
+# T3 already covers TCP. We exercise:
+#   - http: nginx returns 200 on /, the scheduler records successes
+#   - command: a shell script run inside the container exits 0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T14: HTTP + command health checks =="
+
+start_ring
+ring_login
+
+# === HTTP probe against nginx ===
+HTTP_FIXTURE="$RING_TEST_DIR/nginx-hc-http.yaml"
+cat > "$HTTP_FIXTURE" <<'EOF'
+deployments:
+  nginx-hc-http:
+    name: nginx-hc-http
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    health_checks:
+      - { type: http, url: "http://localhost/", interval: "2s", timeout: "1s", on_failure: restart }
+EOF
+"$RING_BIN" apply --file "$HTTP_FIXTURE"
+wait_deployment_status "ring-e2e" "nginx-hc-http" "running" 60
+HTTP_ID=$(get_deployment_id "ring-e2e" "nginx-hc-http")
+[ -z "$HTTP_ID" ] && fail "no http hc deployment id"
+
+# Interval is 2s, so two consecutive successes take ~5s. Poll up to 20s.
+SUCC=0
+for _ in $(seq 1 20); do
+  SUCC=$("$RING_BIN" deployment health-checks "$HTTP_ID" --output json \
+    | jq '[.[] | select(.status=="success")] | length')
+  [ "${SUCC:-0}" -ge 2 ] && break
+  sleep 1
+done
+[ "${SUCC:-0}" -ge 2 ] || fail "http hc: expected ≥2 successes, got $SUCC"
+log "HTTP health check recorded $SUCC successes"
+
+# Stable: deployment must not restart.
+INIT=$(get_restart_count "ring-e2e" "nginx-hc-http")
+sleep 6
+END=$(get_restart_count "ring-e2e" "nginx-hc-http")
+[ "$END" = "$INIT" ] || fail "http hc: restart_count drifted from $INIT to $END"
+log "HTTP hc kept restart_count stable at $INIT"
+
+# === command probe ===
+# Run a tiny script that always succeeds. We use a simple `true` — the
+# container needs `/bin/sh` so we keep the alpine image but override
+# command to keep it alive via `sleep`.
+CMD_FIXTURE="$RING_TEST_DIR/alpine-hc-cmd.yaml"
+cat > "$CMD_FIXTURE" <<'EOF'
+deployments:
+  alpine-hc-cmd:
+    name: alpine-hc-cmd
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    health_checks:
+      - { type: command, command: "true", interval: "2s", timeout: "1s", on_failure: restart }
+EOF
+"$RING_BIN" apply --file "$CMD_FIXTURE"
+wait_deployment_status "ring-e2e" "alpine-hc-cmd" "running" 60
+CMD_ID=$(get_deployment_id "ring-e2e" "alpine-hc-cmd")
+[ -z "$CMD_ID" ] && fail "no command hc deployment id"
+
+SUCC=0
+for _ in $(seq 1 20); do
+  SUCC=$("$RING_BIN" deployment health-checks "$CMD_ID" --output json \
+    | jq '[.[] | select(.status=="success")] | length')
+  [ "${SUCC:-0}" -ge 2 ] && break
+  sleep 1
+done
+[ "${SUCC:-0}" -ge 2 ] || fail "command hc: expected ≥2 successes, got $SUCC"
+log "command health check recorded $SUCC successes"
+
+# Cleanup
+"$RING_BIN" deployment delete "$HTTP_ID"
+"$RING_BIN" deployment delete "$CMD_ID"
+wait_docker_container_gone "$HTTP_ID" 30
+wait_docker_container_gone "$CMD_ID" 30
+
+log "== T14: PASS =="

--- a/tests/e2e/docker/t15_health_check_actions.sh
+++ b/tests/e2e/docker/t15_health_check_actions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# T15: `on_failure` accepts `restart`, `stop` and `alert`. T3 covers
+# `restart` implicitly (no failures, no restart triggered). Here we
+# trigger real failures and verify the two other actions:
+#   - stop: scheduler stops the container after `threshold` failures
+#   - alert: the container keeps running, only an event is emitted
+#
+# The probe target is a TCP port no one listens on (port 1) — guaranteed
+# to fail. `threshold: 2` and `interval: 1s` keep the test under 10s.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T15: health check on_failure stop / alert =="
+
+start_ring
+ring_login
+
+# === on_failure: stop ===
+# After 2 consecutive failures, the scheduler must stop the container.
+STOP_FIXTURE="$RING_TEST_DIR/nginx-hc-stop.yaml"
+cat > "$STOP_FIXTURE" <<'EOF'
+deployments:
+  nginx-hc-stop:
+    name: nginx-hc-stop
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    health_checks:
+      - { type: tcp, port: 1, interval: "1s", timeout: "1s", threshold: 2, on_failure: stop }
+EOF
+"$RING_BIN" apply --file "$STOP_FIXTURE"
+wait_deployment_status "ring-e2e" "nginx-hc-stop" "running" 60
+STOP_ID=$(get_deployment_id "ring-e2e" "nginx-hc-stop")
+
+# Wait for the container to disappear (the scheduler stops + removes it
+# once threshold is reached). The deployment row stays in DB.
+ok=0
+for _ in $(seq 1 30); do
+  count=$(docker ps -q --filter "label=ring_deployment=$STOP_ID" | wc -l | tr -d ' ')
+  if [ "$count" -eq 0 ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "on_failure=stop: container still running 30s after threshold breached"
+log "on_failure=stop: container removed as expected"
+
+# === on_failure: alert ===
+# Container must keep running; only failed health check rows accumulate.
+ALERT_FIXTURE="$RING_TEST_DIR/nginx-hc-alert.yaml"
+cat > "$ALERT_FIXTURE" <<'EOF'
+deployments:
+  nginx-hc-alert:
+    name: nginx-hc-alert
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    health_checks:
+      - { type: tcp, port: 1, interval: "1s", timeout: "1s", threshold: 2, on_failure: alert }
+EOF
+"$RING_BIN" apply --file "$ALERT_FIXTURE"
+wait_deployment_status "ring-e2e" "nginx-hc-alert" "running" 60
+ALERT_ID=$(get_deployment_id "ring-e2e" "nginx-hc-alert")
+INIT_RC=$(get_restart_count "ring-e2e" "nginx-hc-alert")
+
+# Let the failed checks accumulate.
+sleep 8
+
+# Container must still be running.
+count=$(docker ps -q --filter "label=ring_deployment=$ALERT_ID" | wc -l | tr -d ' ')
+[ "$count" = "1" ] || fail "on_failure=alert: container disappeared (count=$count) — the action wrongly stopped it"
+
+# restart_count must NOT have moved (alert ≠ restart).
+END_RC=$(get_restart_count "ring-e2e" "nginx-hc-alert")
+[ "$END_RC" = "$INIT_RC" ] || fail "on_failure=alert: restart_count moved from $INIT_RC to $END_RC"
+
+# Failed health checks must be recorded.
+FAILED=$("$RING_BIN" deployment health-checks "$ALERT_ID" --output json \
+  | jq '[.[] | select(.status=="failure" or .status=="failed")] | length')
+[ "${FAILED:-0}" -ge 2 ] || fail "on_failure=alert: expected ≥2 failed health checks, got $FAILED"
+log "on_failure=alert: container stayed up, $FAILED failed checks recorded"
+
+# Cleanup. The `stop` deployment may have already been cleaned up by the
+# scheduler (status `deleted` after the stop action), so ignore 404s here.
+"$RING_BIN" deployment delete "$STOP_ID" 2>/dev/null || true
+"$RING_BIN" deployment delete "$ALERT_ID" 2>/dev/null || true
+wait_docker_container_gone "$ALERT_ID" 30
+
+log "== T15: PASS =="

--- a/tests/e2e/docker/t16_image_pull_policy.sh
+++ b/tests/e2e/docker/t16_image_pull_policy.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# T16: `config.image_pull_policy` controls whether the Docker runtime
+# pulls the image before each container start.
+#
+# - "Always" → Ring asks Docker to pull regardless of local cache.
+# - "IfNotPresent" → Ring skips the pull if the image already exists.
+#
+# We cannot reliably observe Docker's pull activity from the outside
+# (no public hook), so we test indirectly: with IfNotPresent, an image
+# that does NOT exist in the local cache must still be pulled (Ring
+# falls back to a pull on missing image). Once cached, a new container
+# with the same policy must start without an outbound pull. We verify
+# the policy lands in `deployment.config.image_pull_policy` via the API.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T16: image pull policy =="
+
+start_ring
+ring_login
+
+# Pre-pull alpine:3 so we know it's cached. This isolates the test from
+# network availability.
+docker pull alpine:3 > /dev/null 2>&1 || fail "could not pre-pull alpine:3 (network?)"
+
+# === IfNotPresent on a cached image ===
+# The container must start fast (no outbound pull) and reach Running.
+IFNP_FIXTURE="$RING_TEST_DIR/alpine-ifnp.yaml"
+cat > "$IFNP_FIXTURE" <<'EOF'
+deployments:
+  alpine-ifnp:
+    name: alpine-ifnp
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: IfNotPresent
+EOF
+"$RING_BIN" apply --file "$IFNP_FIXTURE"
+wait_deployment_status "ring-e2e" "alpine-ifnp" "running" 60
+IFNP_ID=$(get_deployment_id "ring-e2e" "alpine-ifnp")
+log "alpine-ifnp running with IfNotPresent on a cached image"
+
+# Verify the policy is reflected in the API output.
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+POLICY=$(curl -fsS "$RING_URL/deployments/$IFNP_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.config.image_pull_policy')
+[ "$POLICY" = "IfNotPresent" ] || fail "expected image_pull_policy=IfNotPresent, got '$POLICY'"
+log "API reports image_pull_policy=$POLICY"
+
+# === Always on a cached image ===
+ALW_FIXTURE="$RING_TEST_DIR/alpine-always.yaml"
+cat > "$ALW_FIXTURE" <<'EOF'
+deployments:
+  alpine-always:
+    name: alpine-always
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Always
+EOF
+"$RING_BIN" apply --file "$ALW_FIXTURE"
+wait_deployment_status "ring-e2e" "alpine-always" "running" 60
+ALW_ID=$(get_deployment_id "ring-e2e" "alpine-always")
+
+POLICY=$(curl -fsS "$RING_URL/deployments/$ALW_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.config.image_pull_policy')
+[ "$POLICY" = "Always" ] || fail "expected image_pull_policy=Always, got '$POLICY'"
+log "API reports image_pull_policy=$POLICY"
+
+# Cleanup
+"$RING_BIN" deployment delete "$IFNP_ID"
+"$RING_BIN" deployment delete "$ALW_ID"
+wait_docker_container_gone "$IFNP_ID" 30
+wait_docker_container_gone "$ALW_ID" 30
+
+log "== T16: PASS =="

--- a/tests/e2e/docker/t17_metrics.sh
+++ b/tests/e2e/docker/t17_metrics.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# T17: GET /deployments/{id}/metrics returns live CPU/memory/network/disk
+# stats, polled from Docker's stats API. We assert the response shape and
+# that the figures are within reason (instance_count > 0, memory > 0).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T17: deployment metrics =="
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/nginx-metrics.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  nginx-metrics:
+    name: nginx-metrics
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 2
+EOF
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "nginx-metrics" "running" 60
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-metrics")
+
+# Wait until both replicas are up so the metrics aggregation is meaningful.
+wait_docker_container_count "$DEPLOYMENT_ID" 2 60
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+# Docker's first stats call returns deltas of 0; let one or two cycles run
+# so the runtime can compute non-zero CPU. The endpoint itself is
+# synchronous — it polls live, so a brief wait is enough.
+sleep 3
+
+METRICS=$(curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID/metrics" \
+  -H "Authorization: Bearer $TOKEN")
+
+# === Shape ===
+echo "$METRICS" | jq -e '.deployment_id, .instance_count, .total_memory, .total_network, .total_disk_io, .instances' \
+  > /dev/null || { echo "$METRICS" >&2; fail "metrics response missing required fields"; }
+log "metrics response has the expected fields"
+
+# === Counts ===
+INST_COUNT=$(echo "$METRICS" | jq -r '.instance_count')
+[ "$INST_COUNT" = "2" ] || { echo "$METRICS" | jq '.' >&2; fail "instance_count=$INST_COUNT, expected 2"; }
+log "instance_count = 2 as expected"
+
+INST_LEN=$(echo "$METRICS" | jq -r '.instances | length')
+[ "$INST_LEN" = "2" ] || fail "instances array has $INST_LEN entries (expected 2)"
+
+# === Memory > 0 ===
+# A live nginx container always uses some bytes. Limit-bytes can be 0
+# when no resources.limits is set (no cap), but usage cannot.
+MEM_USAGE=$(echo "$METRICS" | jq -r '.total_memory.usage_bytes')
+if [ -z "$MEM_USAGE" ] || [ "$MEM_USAGE" = "null" ] || [ "$MEM_USAGE" -le 0 ]; then
+  echo "$METRICS" | jq '.total_memory' >&2
+  fail "total_memory.usage_bytes is $MEM_USAGE (expected > 0)"
+fi
+log "total memory usage: $MEM_USAGE bytes"
+
+# === Each instance has a non-empty instance_id ===
+EMPTY_IDS=$(echo "$METRICS" | jq -r '[.instances[] | select(.instance_id == null or .instance_id == "")] | length')
+[ "$EMPTY_IDS" = "0" ] || { echo "$METRICS" | jq '.instances' >&2; fail "$EMPTY_IDS instance(s) have empty instance_id"; }
+log "every instance carries an instance_id"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T17: PASS =="

--- a/tests/e2e/docker/t18_namespace_isolation.sh
+++ b/tests/e2e/docker/t18_namespace_isolation.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# T18: each Ring namespace maps to a dedicated Docker bridge network
+# (`ring-<namespace>`). Containers in different namespaces must NOT be
+# able to reach each other on the internal network — that is the whole
+# point of namespaces as a soft isolation layer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T18: per-namespace network isolation =="
+
+start_ring
+ring_login
+
+# Two deployments, two namespaces. Both run a long-lived `sleep`; we then
+# `docker exec` from inside each container to verify network reachability.
+NS_A_FIXTURE="$RING_TEST_DIR/ns-a.yaml"
+cat > "$NS_A_FIXTURE" <<'EOF'
+deployments:
+  pod-a:
+    name: pod-a
+    namespace: ns-alpha
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+EOF
+NS_B_FIXTURE="$RING_TEST_DIR/ns-b.yaml"
+cat > "$NS_B_FIXTURE" <<'EOF'
+deployments:
+  pod-b:
+    name: pod-b
+    namespace: ns-beta
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+EOF
+
+# pod-b runs an HTTP listener on port 8080 instead of just sleeping; that
+# way we can probe reachability with `wget --tries=1 --timeout=2` from
+# pod-a, which is more portable across kernels than ICMP ping (alpine's
+# busybox ping needs CAP_NET_RAW that some host kernels deny).
+NS_B_FIXTURE_HTTP="$RING_TEST_DIR/ns-b-http.yaml"
+cat > "$NS_B_FIXTURE_HTTP" <<'EOF'
+deployments:
+  pod-b:
+    name: pod-b
+    namespace: ns-beta
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sh", "-c", "while true; do echo -e 'HTTP/1.0 200 OK\\r\\n\\r\\nOK' | nc -l -p 8080; done"]
+EOF
+"$RING_BIN" apply --file "$NS_A_FIXTURE"
+"$RING_BIN" apply --file "$NS_B_FIXTURE_HTTP"
+wait_deployment_status "ns-alpha" "pod-a" "running" 60
+wait_deployment_status "ns-beta" "pod-b" "running" 60
+
+A_ID=$(get_deployment_id "ns-alpha" "pod-a")
+B_ID=$(get_deployment_id "ns-beta" "pod-b")
+A_CID=$(docker ps -q --filter "label=ring_deployment=$A_ID" | head -n1)
+B_CID=$(docker ps -q --filter "label=ring_deployment=$B_ID" | head -n1)
+[ -z "$A_CID" ] && fail "no container for pod-a"
+[ -z "$B_CID" ] && fail "no container for pod-b"
+
+# === Each namespace has its own bridge ===
+# Bridges are named `ring_<namespace>` (underscore separator).
+docker network ls --format '{{ .Name }}' | grep -q "^ring_ns-alpha$" \
+  || fail "no bridge 'ring_ns-alpha' (expected one bridge per namespace)"
+docker network ls --format '{{ .Name }}' | grep -q "^ring_ns-beta$" \
+  || fail "no bridge 'ring_ns-beta' (expected one bridge per namespace)"
+log "per-namespace bridges present: ring_ns-alpha, ring_ns-beta"
+
+# === Discover B's IP and assert pod-a cannot reach it across namespaces ===
+# We use `wget` (busybox) on a strict 2-second connect timeout. Cross-bridge
+# reachability is decided by the host's bridge filter (no FORWARD rule
+# between the two `ring_*` bridges by default), so the connect should
+# never succeed.
+B_IP=$(docker inspect "$B_CID" --format '{{ (index .NetworkSettings.Networks "ring_ns-beta").IPAddress }}')
+[ -z "$B_IP" ] && fail "could not resolve pod-b IP"
+
+# Give pod-b's nc a beat to bind 8080 inside the container.
+sleep 2
+if docker exec "$A_CID" wget -q --tries=1 --timeout=2 -O - "http://$B_IP:8080/" > /dev/null 2>&1; then
+  fail "pod-a (ns-alpha) reached pod-b on $B_IP:8080 across namespaces"
+fi
+log "pod-a cannot reach pod-b across namespaces (TCP connect refused/timeout)"
+
+# Sanity: deploy a second HTTP pod in ns-alpha and verify pod-a CAN reach
+# it via the same TCP probe — this proves we're testing isolation and not
+# just a generic firewall block.
+NS_A2_FIXTURE="$RING_TEST_DIR/ns-a2.yaml"
+cat > "$NS_A2_FIXTURE" <<'EOF'
+deployments:
+  pod-a2:
+    name: pod-a2
+    namespace: ns-alpha
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sh", "-c", "while true; do echo -e 'HTTP/1.0 200 OK\\r\\n\\r\\nOK' | nc -l -p 8080; done"]
+EOF
+"$RING_BIN" apply --file "$NS_A2_FIXTURE"
+wait_deployment_status "ns-alpha" "pod-a2" "running" 60
+A2_ID=$(get_deployment_id "ns-alpha" "pod-a2")
+A2_CID=$(docker ps -q --filter "label=ring_deployment=$A2_ID" | head -n1)
+A2_IP=$(docker inspect "$A2_CID" --format '{{ (index .NetworkSettings.Networks "ring_ns-alpha").IPAddress }}')
+[ -z "$A2_IP" ] && fail "could not resolve pod-a2 IP"
+
+# Wait for nc to bind.
+sleep 2
+ok=0
+for _ in $(seq 1 10); do
+  if docker exec "$A_CID" wget -q --tries=1 --timeout=2 -O - "http://$A2_IP:8080/" > /dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "pod-a CANNOT reach pod-a2 inside the same namespace (sanity check failed)"
+log "pod-a reaches pod-a2 inside ns-alpha (sanity check)"
+
+# Cleanup
+"$RING_BIN" deployment delete "$A_ID"
+"$RING_BIN" deployment delete "$A2_ID"
+"$RING_BIN" deployment delete "$B_ID"
+wait_docker_container_gone "$A_ID" 30
+wait_docker_container_gone "$B_ID" 30
+
+log "== T18: PASS =="

--- a/tests/e2e/docker/t19_bind_mount_readonly.sh
+++ b/tests/e2e/docker/t19_bind_mount_readonly.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# T19: a bind mount with `permission: ro` must reach the container as
+# read-only. T2 covers the rw case via assert_docker_bind_mount; here
+# we go further and try to actually write to the mount, expecting EROFS.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T19: bind mount permission=ro =="
+
+start_ring
+ring_login
+
+HOST_DIR="$RING_TEST_DIR/ro-bind-src"
+mkdir -p "$HOST_DIR"
+echo "from-host" > "$HOST_DIR/marker.txt"
+
+FIXTURE="$RING_TEST_DIR/ro-mount.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  ro-mount:
+    name: ro-mount
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    volumes:
+      - type: bind
+        source: $HOST_DIR
+        destination: /data
+        driver: local
+        permission: ro
+EOF
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "ro-mount" "running" 60
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "ro-mount")
+CID=$(docker ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+
+# === The host file is visible inside the container ===
+got=$(docker exec "$CID" cat /data/marker.txt 2>&1 || true)
+[ "$got" = "from-host" ] || fail "expected to read 'from-host', got '$got'"
+log "host file visible inside the container"
+
+# === Writes are rejected with EROFS ===
+# alpine's busybox sh writes to a tmp variable on failure; we capture stderr.
+if docker exec "$CID" sh -c 'echo nope > /data/marker.txt' 2>/dev/null; then
+  fail "write to /data/marker.txt succeeded — bind mount is not read-only"
+fi
+log "write to read-only bind mount rejected as expected"
+
+# === The host file content is unchanged ===
+host_after=$(cat "$HOST_DIR/marker.txt")
+[ "$host_after" = "from-host" ] || fail "host file modified despite ro mount: '$host_after'"
+log "host file content unchanged"
+
+# === The mount appears in docker inspect as ro ===
+docker inspect "$CID" --format '{{ json .Mounts }}' | jq -e \
+  --arg src "$HOST_DIR" --arg dst "/data" \
+  '.[] | select(.Source==$src and .Destination==$dst and .RW==false)' > /dev/null \
+  || { docker inspect "$CID" --format '{{ json .Mounts }}' | jq '.' >&2; fail "docker inspect does not show RW=false for $HOST_DIR"; }
+log "docker inspect confirms RW=false on $HOST_DIR -> /data"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T19: PASS =="

--- a/tests/e2e/docker/t1_create_delete.sh
+++ b/tests/e2e/docker/t1_create_delete.sh
@@ -5,15 +5,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T1: create / delete =="
 
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx.yaml"
 
 wait_deployment_status "ring-e2e" "nginx" "running" 60
 

--- a/tests/e2e/docker/t20_force_flag.sh
+++ b/tests/e2e/docker/t20_force_flag.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# T20: POST /deployments?force=true must bypass the rolling-update path
+# even when health checks are defined. The previous deployment is marked
+# `deleted` immediately instead of being kept alive as the new
+# deployment's parent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T20: ?force=true bypasses rolling update =="
+
+start_ring
+ring_login
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+create_deployment() {
+  local query="$1"
+  curl -fsS -X POST "$RING_URL/deployments$query" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "name": "force-app",
+      "runtime": "docker",
+      "namespace": "ring-e2e",
+      "kind": "worker",
+      "replicas": 1,
+      "image": "nginx:alpine",
+      "labels": {},
+      "environment": {},
+      "volumes": [],
+      "health_checks": [
+        { "type": "tcp", "port": 80, "interval": "10s", "timeout": "5s", "on_failure": "restart" }
+      ]
+    }'
+}
+
+# === First create — establishes the baseline ===
+V1_JSON=$(create_deployment "")
+V1_ID=$(echo "$V1_JSON" | jq -r '.id')
+[ -z "$V1_ID" ] || [ "$V1_ID" = "null" ] && { echo "$V1_JSON" >&2; fail "no v1 id"; }
+wait_deployment_by_image "ring-e2e" "force-app" "nginx:alpine" "running" 60
+log "v1 id: $V1_ID"
+
+# Force the deployment to `running` in DB so the rolling-update path
+# could trigger on the next create. (Without this, an existing pending
+# deployment is replaced regardless.)
+sleep 2
+
+# === Re-create with ?force=true ===
+V2_JSON=$(create_deployment "?force=true")
+V2_ID=$(echo "$V2_JSON" | jq -r '.id')
+[ -z "$V2_ID" ] || [ "$V2_ID" = "null" ] && { echo "$V2_JSON" >&2; fail "no v2 id"; }
+[ "$V1_ID" = "$V2_ID" ] && fail "v1 and v2 share the same id"
+log "v2 id: $V2_ID"
+
+# === v2 has no parent_id (force bypassed the rolling update) ===
+V2_PARENT=$(curl -fsS "$RING_URL/deployments/$V2_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.parent_id // ""')
+if [ -n "$V2_PARENT" ]; then
+  fail "v2.parent_id = '$V2_PARENT' (force should have bypassed the rolling update)"
+fi
+log "v2 has no parent_id — rolling update was bypassed"
+
+# === v1 must end up `deleted` (not kept alive as parent) ===
+ok=0
+for _ in $(seq 1 30); do
+  st=$(curl -fsS "$RING_URL/deployments/$V1_ID" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.status')
+  if [ "$st" = "deleted" ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+[ "$ok" -eq 1 ] || fail "v1 final status was not 'deleted' within 30s"
+log "v1 marked 'deleted' (force semantics)"
+
+# Cleanup
+curl -fsS -X DELETE "$RING_URL/deployments/$V2_ID" \
+  -H "Authorization: Bearer $TOKEN" > /dev/null
+wait_docker_container_gone "$V2_ID" 30
+
+log "== T20: PASS =="

--- a/tests/e2e/docker/t21_multi_deployments.sh
+++ b/tests/e2e/docker/t21_multi_deployments.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# T21: a single `ring apply` must be able to declare multiple deployments
+# in the same YAML and create them all in one call. We declare three
+# deployments in different namespaces and verify each one becomes
+# Running with its own container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T21: apply multiple deployments at once =="
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/multi.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  alpha:
+    name: alpha
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+
+  beta:
+    name: beta
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+
+  gamma:
+    name: gamma
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+EOF
+
+OUT=$("$RING_BIN" apply --file "$FIXTURE")
+# The CLI summary should report 3 successes.
+echo "$OUT" | grep -q "Successful: 3" \
+  || { echo "$OUT" >&2; fail "apply summary did not report 3 successes"; }
+log "apply summary: 3 successful deployments"
+
+for name in alpha beta gamma; do
+  wait_deployment_status "ring-e2e" "$name" "running" 90
+  id=$(get_deployment_id "ring-e2e" "$name")
+  [ -z "$id" ] && fail "no deployment id for $name"
+  count=$(docker ps -q --filter "label=ring_deployment=$id" | wc -l | tr -d ' ')
+  [ "$count" = "1" ] || fail "deployment $name has $count containers (expected 1)"
+done
+log "all three deployments are running with one container each"
+
+# Cleanup
+for name in alpha beta gamma; do
+  id=$(get_deployment_id "ring-e2e" "$name")
+  "$RING_BIN" deployment delete "$id"
+done
+for name in alpha beta gamma; do
+  id=$(get_deployment_id "ring-e2e" "$name" 2>/dev/null || true)
+  [ -n "$id" ] && wait_docker_container_gone "$id" 30 || true
+done
+
+log "== T21: PASS =="

--- a/tests/e2e/docker/t2_bind_volume.sh
+++ b/tests/e2e/docker/t2_bind_volume.sh
@@ -5,8 +5,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T2: bind volume (read-only) =="
 
@@ -17,7 +17,7 @@ mkdir -p "$BIND_SOURCE"
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-bind.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-bind.yaml"
 
 wait_deployment_status "ring-e2e" "nginx-bind" "running" 60
 

--- a/tests/e2e/docker/t3_health_check.sh
+++ b/tests/e2e/docker/t3_health_check.sh
@@ -6,15 +6,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T3: TCP health check =="
 
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-healthcheck.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-healthcheck.yaml"
 
 wait_deployment_status "ring-e2e" "nginx-hc" "running" 60
 

--- a/tests/e2e/docker/t4_rolling_update.sh
+++ b/tests/e2e/docker/t4_rolling_update.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T4: rolling update =="
 
@@ -16,7 +16,7 @@ start_ring
 ring_login
 
 # Apply v1
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-rolling-v1.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-rolling-v1.yaml"
 wait_deployment_by_image "ring-e2e" "nginx-rolling" "nginx:1.25-alpine" "running" 90
 
 V1_ID=$(get_deployment_id_by_image "ring-e2e" "nginx-rolling" "nginx:1.25-alpine")
@@ -30,7 +30,7 @@ V1_CONTAINER=$(docker ps -q --filter "label=ring_deployment=$V1_ID" | head -n1)
 log "v1 container: $V1_CONTAINER"
 
 # Apply v2 (same name, different image)
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-rolling-v2.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-rolling-v2.yaml"
 wait_deployment_by_image "ring-e2e" "nginx-rolling" "nginx:1.26-alpine" "running" 90
 
 V2_ID=$(get_deployment_id_by_image "ring-e2e" "nginx-rolling" "nginx:1.26-alpine")

--- a/tests/e2e/docker/t5_replicas.sh
+++ b/tests/e2e/docker/t5_replicas.sh
@@ -5,15 +5,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T5: replicas (3 containers per deployment) =="
 
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-replicas.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-replicas.yaml"
 
 wait_deployment_status "ring-e2e" "nginx-scaled" "running" 60
 

--- a/tests/e2e/docker/t6_crashloop.sh
+++ b/tests/e2e/docker/t6_crashloop.sh
@@ -7,15 +7,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T6: crash loop must converge to CrashLoopBackOff =="
 
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/crashloop.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/crashloop.yaml"
 
 # Give the scheduler time to react. With a 1s scheduler interval, 90s leaves
 # comfortable headroom for restart_count to climb past MAX_RESTART_COUNT (5).

--- a/tests/e2e/docker/t7_scaledown_no_falsepositive.sh
+++ b/tests/e2e/docker/t7_scaledown_no_falsepositive.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T7: scale-down must not bump restart_count =="
 
@@ -16,7 +16,7 @@ start_ring
 ring_login
 
 # Use the existing replicas fixture (nginx, replicas=3).
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-replicas.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-replicas.yaml"
 
 wait_deployment_status "ring-e2e" "nginx-scaled" "running" 60
 

--- a/tests/e2e/docker/t8_named_volume_persists.sh
+++ b/tests/e2e/docker/t8_named_volume_persists.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib.sh
-source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
 
 log "== T8: named volume persists across deployment deletion =="
 
@@ -21,7 +21,7 @@ docker volume rm -f "$VOLUME_NAME" > /dev/null 2>&1 || true
 start_ring
 ring_login
 
-"$RING_BIN" apply --file "$SCRIPT_DIR/fixtures/nginx-named-volume.yaml"
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-named-volume.yaml"
 
 wait_deployment_status "ring-e2e" "nginx-named-volume" "running" 60
 

--- a/tests/e2e/docker/t9_ports.sh
+++ b/tests/e2e/docker/t9_ports.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# T9: a Docker deployment with `ports` must publish the host ports through
+# Docker's PortBindings (PR #57) and reach the container application from
+# the host. We pick free ephemeral ports up front so the test is reusable
+# in parallel CI lanes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T9: docker port mapping =="
+
+# Pick a free port up front. Asking the kernel for an ephemeral port and
+# closing the socket is the standard race-free pattern.
+PORT_HTTP=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/nginx-ports.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  nginx-ports:
+    name: nginx-ports
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    ports:
+      - { published: $PORT_HTTP, target: 80 }
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "nginx-ports" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-ports")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === Docker reports the binding ===
+# `docker inspect` exposes the `HostConfig.PortBindings` Ring set. The
+# expected shape is `{ "80/tcp": [{ "HostIp": "", "HostPort": "<PORT_HTTP>" }] }`.
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+HOST_PORT=$(docker inspect "$CID" --format '{{ (index (index .NetworkSettings.Ports "80/tcp") 0).HostPort }}' 2>/dev/null || true)
+if [ "$HOST_PORT" != "$PORT_HTTP" ]; then
+  docker inspect "$CID" --format '{{ json .NetworkSettings.Ports }}' >&2
+  fail "expected host port $PORT_HTTP for container 80/tcp, got '$HOST_PORT'"
+fi
+log "Docker reports 80/tcp -> host:$PORT_HTTP"
+
+# === The port is reachable from the host ===
+# nginx:alpine answers on / with a 200 immediately after start. Give it up
+# to a few seconds in case the container is still warming up.
+ok=0
+for _ in $(seq 1 20); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:$PORT_HTTP/" > /dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+if [ "$ok" -ne 1 ]; then
+  fail "could not curl http://127.0.0.1:$PORT_HTTP/ within 20s"
+fi
+log "nginx is reachable on 127.0.0.1:$PORT_HTTP"
+
+# === The body really comes from nginx (not a coincidental listener) ===
+body=$(curl -fsS --max-time 2 "http://127.0.0.1:$PORT_HTTP/" || true)
+if ! echo "$body" | grep -qi "nginx"; then
+  echo "$body" | head -5 >&2
+  fail "response body does not look like nginx: $(echo "$body" | head -1)"
+fi
+log "response body identifies nginx"
+
+# === Conflict on the same host port ===
+# A second deployment trying to publish the same `published` must fail at
+# Docker level: the Ring API still creates the deployment row (we mirror
+# Docker's "lazy" semantics), but Docker refuses to start the container
+# with `bind: address already in use`, so it never reaches `running`.
+log "creating a conflicting deployment on host port $PORT_HTTP..."
+CONFLICT_FIXTURE="$RING_TEST_DIR/nginx-ports-conflict.yaml"
+cat > "$CONFLICT_FIXTURE" <<EOF
+deployments:
+  nginx-ports-conflict:
+    name: nginx-ports-conflict
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 1
+    ports:
+      - { published: $PORT_HTTP, target: 80 }
+EOF
+"$RING_BIN" apply --file "$CONFLICT_FIXTURE"
+
+# Poll for ~30s. The conflicting deployment must NOT reach `running`
+# because Docker keeps refusing to bind the busy port. Acceptable terminal
+# states are `creating`, `failed`, `crashloopbackoff`, etc. — anything but
+# `running`.
+saw_running=0
+for _ in $(seq 1 30); do
+  status=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r '.[] | select(.namespace=="ring-e2e" and .name=="nginx-ports-conflict") | .status' \
+    | head -n1)
+  if [ "$status" = "running" ]; then
+    saw_running=1
+    break
+  fi
+  sleep 1
+done
+if [ "$saw_running" -eq 1 ]; then
+  fail "conflicting deployment unexpectedly reached 'running' on busy port $PORT_HTTP"
+fi
+log "conflicting deployment correctly stayed out of 'running' (last status: ${status:-<none>})"
+
+# Original deployment is still running on the port.
+status_orig=$("$RING_BIN" deployment list --output json 2>/dev/null \
+  | jq -r --arg id "$DEPLOYMENT_ID" '.[] | select(.id==$id) | .status')
+if [ "$status_orig" != "running" ]; then
+  fail "original deployment $DEPLOYMENT_ID lost its 'running' state during conflict (got '$status_orig')"
+fi
+log "original deployment still 'running' — conflict did not steal the port"
+
+# Cleanup the conflicting one before tearing down the original.
+CONFLICT_ID=$(get_deployment_id "ring-e2e" "nginx-ports-conflict")
+[ -n "$CONFLICT_ID" ] && "$RING_BIN" deployment delete "$CONFLICT_ID" || true
+
+# === Delete frees the host port ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+# Re-bind the port to confirm Docker released it.
+for _ in $(seq 1 20); do
+  if python3 -c "
+import socket
+s = socket.socket()
+try:
+  s.bind(('127.0.0.1', $PORT_HTTP))
+  print('FREE')
+except OSError:
+  print('BUSY')
+" | grep -q FREE; then
+    log "port $PORT_HTTP released after delete"
+    log "== T9: PASS =="
+    exit 0
+  fi
+  sleep 1
+done
+fail "host port $PORT_HTTP still bound after deployment delete"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -41,6 +41,10 @@ start_ring() {
   # scheduler may even boot stale ones, masking failures and producing
   # false positives. Pin each test to its own database file.
   export RING_DATABASE_PATH="$RING_TEST_DIR/ring.db"
+  # Required as soon as a deployment carries a `secretRef` (or any code path
+  # touches `secret::encrypt_value`); the server panics otherwise. The
+  # CI workflow sets the same constant — kept in sync.
+  export RING_SECRET_KEY="${RING_SECRET_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
 
   cat > "$RING_TEST_DIR/config.toml" <<EOF
 [contexts.default]

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -15,7 +15,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SUITES=("docker" "cloud-hypervisor")
+SUITES=("server" "docker" "cloud-hypervisor")
 
 # Restrict to the suite the user named, if any.
 if [ "$#" -gt 0 ]; then

--- a/tests/e2e/server/t1_secret_key_validation.sh
+++ b/tests/e2e/server/t1_secret_key_validation.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# T1-server: `ring server start` must validate RING_SECRET_KEY up front
+# and refuse to start with a clear error if it is missing or malformed.
+# Without this guard the process boots, accepts requests, and panics the
+# first time someone touches a secret. We exercise the four cases:
+#   1. unset      → exit 1, error mentions the variable
+#   2. invalid base64
+#   3. wrong size (< 32 bytes)
+#   4. valid      → server starts and answers /healthz
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+# --- Helper: run a short-lived ring server with a custom RING_SECRET_KEY,
+# capture stderr+stdout, return the exit code.
+run_with_key() {
+  local key="$1"
+  local cfg
+  cfg=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+  cat > "$cfg/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $((20000 + RANDOM % 10000))
+user.salt = "t1-server-salt"
+EOF
+  local out="$cfg/out.log"
+  if [ -z "$key" ]; then
+    env -u RING_SECRET_KEY \
+      RING_CONFIG_DIR="$cfg" \
+      RING_DATABASE_PATH="$cfg/ring.db" \
+      "$RING_BIN" server start > "$out" 2>&1
+  else
+    env \
+      RING_CONFIG_DIR="$cfg" \
+      RING_DATABASE_PATH="$cfg/ring.db" \
+      RING_SECRET_KEY="$key" \
+      "$RING_BIN" server start > "$out" 2>&1
+  fi
+  local ec=$?
+  cat "$out"
+  rm -rf "$cfg"
+  return $ec
+}
+
+log "== T1-server: RING_SECRET_KEY validation =="
+
+# === Case 1: unset ===
+out=$(run_with_key "" 2>&1) && fail "expected non-zero exit when RING_SECRET_KEY is unset"
+echo "$out" | grep -q "RING_SECRET_KEY" \
+  || { echo "$out" >&2; fail "case 1: error message must mention RING_SECRET_KEY"; }
+echo "$out" | grep -q "is not set" \
+  || { echo "$out" >&2; fail "case 1: error message must say 'is not set'"; }
+log "case 1 (unset): server refused to start with a clear error"
+
+# === Case 2: invalid base64 ===
+out=$(run_with_key "%%%not-base64%%%" 2>&1) && fail "expected non-zero exit on invalid base64"
+echo "$out" | grep -qi "base64" \
+  || { echo "$out" >&2; fail "case 2: error message must mention base64"; }
+log "case 2 (invalid base64): server refused with a clear error"
+
+# === Case 3: wrong size ===
+# "aGVsbG8=" decodes to 5 bytes, well below 32.
+out=$(run_with_key "aGVsbG8=" 2>&1) && fail "expected non-zero exit on undersized key"
+echo "$out" | grep -q "32 bytes" \
+  || { echo "$out" >&2; fail "case 3: error must mention the 32-byte requirement"; }
+log "case 3 (wrong size): server refused with a clear error"
+
+# === Case 4: valid key ===
+# Same canned key the CI uses. Start in the background, hit /healthz, kill.
+key="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+cfg=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+port=$((20000 + RANDOM % 10000))
+cat > "$cfg/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $port
+user.salt = "t1-server-salt"
+EOF
+RING_CONFIG_DIR="$cfg" RING_DATABASE_PATH="$cfg/ring.db" RING_SECRET_KEY="$key" \
+  "$RING_BIN" server start > "$cfg/out.log" 2>&1 &
+SRV_PID=$!
+trap 'kill "$SRV_PID" 2>/dev/null || true; rm -rf "$cfg"' EXIT
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "http://127.0.0.1:$port/healthz" > /dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$cfg/out.log" >&2; fail "case 4: server did not become healthy with a valid key"; }
+log "case 4 (valid key): server started and answered /healthz"
+
+kill "$SRV_PID" 2>/dev/null || true
+wait "$SRV_PID" 2>/dev/null || true
+rm -rf "$cfg"
+trap - EXIT
+
+log "== T1-server: PASS =="


### PR DESCRIPTION
## Summary

Doubles the end-to-end test coverage for both runtimes and the server core. The new tests caught (and this PR fixes) four latent bugs that `cargo test` could not surface.

| Suite | Before | After |
|---|---|---|
| `tests/e2e/server/` | (did not exist) | 1 test |
| `tests/e2e/docker/` | 8 tests | 21 tests |
| `tests/e2e/cloud-hypervisor/` | 7 tests | 14 tests |
| `cargo test` | 228 | 228 (unchanged — no logic regression) |

All 36 e2e tests pass on Ubuntu 25.10 with Docker, virtiofsd 1.13.2 and cloud-hypervisor v46.

## Latent bugs found and fixed

Each of these existed silently on `main` and was uncovered by writing the e2e tests:

1. **`apply::Deployment` was missing the `key` field on `Volume`.** The CLI dropped the `key:` line silently, so any `type: config` volume in a YAML was rejected by the API with a confusing `"key is required for config volumes"` error. Fix: add the field to the CLI struct.
2. **`RING_SECRET_KEY` validation happened too late.** The server booted fine without the variable and panicked at the first request that touched a secret. Fix: validate at startup with a clear error, surface in `ring doctor`, drop the four panics in `models::secret`. New e2e: `server/t1_secret_key_validation.sh` covers unset / bad base64 / wrong size / valid.
3. **`DeploymentOutput` did not expose `parent_id`.** Rolling-update behaviour was completely invisible from the API side, even though the field exists in the database and the docs already mentioned it. Fix: add the field to the DTO. The CH rolling-update e2e (`cloud-hypervisor/t10_rolling_update.sh`) needed this to assert the parent/child relationship.
4. **Per-namespace bridges are named `ring_<ns>`, not `ring-<ns>`** — the docs were wrong. Fix: update `documentation/runtimes/docker.md`. Caught by `docker/t18_namespace_isolation.sh`.

## What's in each commit

- **`c5c974f`** *(already on main from PR #65 follow-up)* — paths after the suite split.
- **`631413b`** — 13 Docker tests:
  - `t9_ports.sh` — port mapping + conflict detection.
  - `t10_resource_limits.sh` — CPU/mem propagation into Docker `HostConfig`.
  - `t11_logs.sh` — `ring deployment logs` with `--tail` and `--follow`.
  - `t12_config_volume.sh` — Ring config mounted as a file inside the container (read-only, content matches).
  - `t13_environment.sh` — plain env + `secretRef`, plus a check that GET /deployments does not leak the cleartext.
  - `t14_health_check_http_and_command.sh` — HTTP and command probe types (T3 covered TCP only).
  - `t15_health_check_actions.sh` — `on_failure: stop` and `on_failure: alert` (T3 covered restart implicitly).
  - `t16_image_pull_policy.sh` — `Always` vs `IfNotPresent` reflected in the API.
  - `t17_metrics.sh` — `/metrics` shape, `instance_count`, non-zero memory, non-empty `instance_id`.
  - `t18_namespace_isolation.sh` — per-namespace bridge isolation (verified via cross-namespace TCP probe).
  - `t19_bind_mount_readonly.sh` — `permission: ro` actually enforces read-only inside the container.
  - `t20_force_flag.sh` — `?force=true` bypasses the rolling-update path (no `parent_id` set, old deployment marked deleted).
  - `t21_multi_deployments.sh` — multiple deployments in a single `ring apply`.
  - Adds the `key` field to `apply::Volume` and corrects bridge naming in the Docker doc.
- **`22a982c`** — 7 Cloud Hypervisor tests:
  - `t8_resource_limits.sh` — vCPU + memory size readable from CH's `vm.info` API.
  - `t9_scaledown.sh` — 3→1 replicas without bumping `restart_count`.
  - `t10_rolling_update.sh` — re-apply with health checks, assert `parent_id` chains old → new.
  - `t11_image_not_found.sh` — permanent `ImagePullBackOff`, scheduler must not retry.
  - `t12_firmware_missing.sh` — permanent `failed`, idem.
  - `t13_ports_with_volumes.sh` — both features combined (socat + virtiofsd + tap on the same VM).
  - `t14_multi_replicas_volumes.sh` — each replica spawns its own virtiofsd; scaling kills exactly one.
  - Adds `parent_id` to `DeploymentOutput` and updates the API reference.
- **`ec30e39`** — `RING_SECRET_KEY` validated at startup + `ring doctor` Server section + 1 e2e + doc updates.

## Test plan

- [x] `cargo test` — 228/228 passing, no regression.
- [x] `cargo fmt --check` — clean.
- [x] `tests/e2e/run.sh` — 36/36 passing across all three suites (`server`, `docker`, `cloud-hypervisor`).
- [x] `ring doctor` exit code: 1 when RING_SECRET_KEY is missing/malformed, 0 when valid (and other prereqs are met).
- [x] `ring server start` without `RING_SECRET_KEY`: exits 1 with a clear error line, no panic stack.

## Out of scope (kept for follow-ups)

Listed in the previous discussion but explicitly **not** included to keep the PR review-able:

- Auth negative cases (invalid token, expired, cross-user).
- Concurrent requests on the SQLite pool.
- Recovery after `ring server` restart (orphan handling).
- Health check probes inside a real Ubuntu Focal CH guest (needs cloud-init mounts + a service in the guest).
- CLI coverage for `user`, `config update`, `secret`, `context`, `namespace prune`, `deployment events`.