### PR TITLE
feat(ch): support command health checks via in-guest ring-agent over vsock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1755,19 @@ dependencies = [
  "quote",
  "serde",
  "syn",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2269,6 +2297,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring-agent"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-vsock",
+]
+
+[[package]]
 name = "ring-server"
 version = "0.7.0"
 dependencies = [
@@ -2305,6 +2343,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tokio",
+ "tokio-vsock",
  "toml",
  "tower",
  "tower-http",
@@ -3145,6 +3184,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,6 +3500,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["crates/ring-agent"]
+
 [package]
 name = "ring-server"
 version = "0.7.0"
@@ -52,5 +55,6 @@ sysinfo = "0.35.1"
 thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
+tokio-vsock = "0.7"
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/crates/ring-agent/Cargo.toml
+++ b/crates/ring-agent/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ring-agent"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "ring-agent"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1.20", features = ["rt-multi-thread", "macros", "io-util", "process", "time"] }
+tokio-vsock = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/ring-agent/src/main.rs
+++ b/crates/ring-agent/src/main.rs
@@ -1,0 +1,191 @@
+//! ring-agent — in-guest companion to the Cloud Hypervisor runtime.
+//!
+//! Listens on AF_VSOCK port 2375 (well-known to the host-side client) and
+//! services length-prefixed JSON requests. Today the only supported request
+//! is `Exec`, used to back `health_checks: [{ type: command, ... }]` on CH
+//! deployments where Ring has no `docker exec` equivalent.
+//!
+//! Wire format:
+//!   request:  [u32 BE length][JSON ExecRequest]
+//!   response: [u32 BE length][JSON ExecResponse]
+//!
+//! One connection per request — no multiplexing, no streaming. Health checks
+//! are short-lived and idempotent; complexity isn't worth it yet.
+
+use serde::{Deserialize, Serialize};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
+
+const VSOCK_PORT: u32 = 2375;
+const MAX_REQUEST_BYTES: u32 = 1 << 20; // 1 MiB cap so a malformed length can't OOM us.
+// Per-stream cap on captured guest output. The host-side client refuses
+// frames larger than 1 MiB; truncating each stream to 256 KiB keeps the
+// JSON envelope (plus exit_code etc.) under that limit with margin.
+const MAX_OUTPUT_BYTES: usize = 256 * 1024;
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Request {
+    Exec(ExecRequest),
+}
+
+#[derive(Deserialize)]
+struct ExecRequest {
+    argv: Vec<String>,
+    #[serde(default)]
+    env: Vec<(String, String)>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Response {
+    Exec(ExecResponse),
+    Error { message: String },
+}
+
+#[derive(Serialize)]
+struct ExecResponse {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+    timed_out: bool,
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> std::io::Result<()> {
+    let addr = VsockAddr::new(VMADDR_CID_ANY, VSOCK_PORT);
+    let listener = VsockListener::bind(addr)?;
+    eprintln!("ring-agent listening on vsock port {}", VSOCK_PORT);
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("accept failed: {}", e);
+                continue;
+            }
+        };
+        tokio::spawn(async move {
+            if let Err(e) = handle(stream).await {
+                eprintln!("connection from {:?} failed: {}", peer, e);
+            }
+        });
+    }
+}
+
+async fn handle(mut stream: tokio_vsock::VsockStream) -> std::io::Result<()> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let len = u32::from_be_bytes(len_buf);
+    if len > MAX_REQUEST_BYTES {
+        write_response(
+            &mut stream,
+            &Response::Error {
+                message: format!("request too large: {} bytes", len),
+            },
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let mut body = vec![0u8; len as usize];
+    stream.read_exact(&mut body).await?;
+
+    let response = match serde_json::from_slice::<Request>(&body) {
+        Ok(Request::Exec(req)) => match run_exec(req).await {
+            Ok(r) => Response::Exec(r),
+            Err(e) => Response::Error { message: e },
+        },
+        Err(e) => Response::Error {
+            message: format!("malformed request: {}", e),
+        },
+    };
+
+    write_response(&mut stream, &response).await
+}
+
+async fn run_exec(req: ExecRequest) -> Result<ExecResponse, String> {
+    let mut argv = req.argv.into_iter();
+    let program = argv
+        .next()
+        .ok_or_else(|| "argv must have at least one element".to_string())?;
+
+    let mut cmd = Command::new(&program);
+    cmd.args(argv).stdout(Stdio::piped()).stderr(Stdio::piped());
+    // Start with an empty environment; the caller supplies the explicit set.
+    // Avoids leaking arbitrary host/system env into the probe command.
+    cmd.env_clear();
+    for (k, v) in req.env {
+        cmd.env(k, v);
+    }
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn '{}' failed: {}", program, e))?;
+
+    let timeout = req
+        .timeout_ms
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_secs(30));
+
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(out)) => Ok(ExecResponse {
+            exit_code: out.status.code().unwrap_or(-1),
+            stdout: truncate_lossy(&out.stdout),
+            stderr: truncate_lossy(&out.stderr),
+            timed_out: false,
+        }),
+        Ok(Err(e)) => Err(format!("wait failed: {}", e)),
+        Err(_) => Ok(ExecResponse {
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: format!("timed out after {}ms", timeout.as_millis()),
+            timed_out: true,
+        }),
+    }
+}
+
+/// Lossy-decode then truncate. We always trim to `MAX_OUTPUT_BYTES` *after*
+/// turning bytes into a `String` so the cut never lands inside a multi-byte
+/// UTF-8 sequence (lossy_into_owned has already replaced any invalid bytes
+/// with `U+FFFD`).
+fn truncate_lossy(bytes: &[u8]) -> String {
+    let mut s = String::from_utf8_lossy(bytes).into_owned();
+    if s.len() > MAX_OUTPUT_BYTES {
+        // Find the largest char boundary <= MAX_OUTPUT_BYTES.
+        let mut end = MAX_OUTPUT_BYTES;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+        s.push_str("\n[truncated]");
+    }
+    s
+}
+
+async fn write_response(
+    stream: &mut tokio_vsock::VsockStream,
+    response: &Response,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(response)
+        .unwrap_or_else(|_| br#"{"type":"error","message":"serialize failed"}"#.to_vec());
+    // Hard cap. Anything bigger than u32::MAX bytes can't be framed; in
+    // practice we already trim per-stream output to MAX_OUTPUT_BYTES so the
+    // serialized body comfortably fits, but assert defensively.
+    if body.len() > u32::MAX as usize {
+        let fallback = br#"{"type":"error","message":"response exceeds frame size"}"#.to_vec();
+        let len = (fallback.len() as u32).to_be_bytes();
+        stream.write_all(&len).await?;
+        stream.write_all(&fallback).await?;
+        return stream.flush().await;
+    }
+    let len = (body.len() as u32).to_be_bytes();
+    stream.write_all(&len).await?;
+    stream.write_all(&body).await?;
+    stream.flush().await
+}

--- a/documentation/runtimes/cloud-hypervisor.md
+++ b/documentation/runtimes/cloud-hypervisor.md
@@ -108,6 +108,19 @@ Before using the Cloud Hypervisor runtime, you need:
 
     `ring doctor` reports whether `socat` is available.
 
+9. **`ring-agent` inside the guest image** (only if you use `health_checks: [{ type: command, ... }]`).
+
+    Container runtimes implement `command` health checks via `docker exec`. VMs have no equivalent — Ring talks to a small in-guest daemon over AF_VSOCK. Build the agent once and bake it into your guest image:
+
+    ```bash
+    # Build a static binary on the host
+    cargo build -p ring-agent --release --target x86_64-unknown-linux-musl
+    # Copy into the guest image at /usr/local/bin/ring-agent and enable a
+    # systemd unit (or equivalent) that runs it at boot.
+    ```
+
+    The agent listens on AF_VSOCK port 2375. Ring opens one connection per probe and reads the command's exit code; non-zero counts as a failed probe. See [Health Checks](#health-checks) for details on what gets shipped to the guest.
+
 ## Configuration
 
 Add a `runtime.cloud_hypervisor` section to your `config.toml` to customize paths:
@@ -194,7 +207,7 @@ resources:
 
 ## Health Checks
 
-`tcp` and `http` health checks are supported. `command` is rejected at the API (`400 Bad Request`) — the VM model has no direct `docker exec` equivalent; implementing it would require an in-guest agent (vsock or SSH).
+`tcp`, `http` and `command` health checks are all supported. `tcp` and `http` probes run from the host against the VM's deterministic guest IP (no agent required). `command` probes go through the in-guest `ring-agent` daemon over AF_VSOCK — the agent must be installed inside the guest image (see [Prerequisites](#prerequisites)). The probe receives the command verbatim and runs it through `/bin/sh -c`; exit code zero means success.
 
 ```yaml
 health_checks:
@@ -386,7 +399,7 @@ This is the **canonical parity table** between the Docker runtime (the reference
 | Feature | Status |
 |---|---|
 | `tcp` / `http` health checks | **Supported.** Probes run from the host against the VM's deterministic guest IP (no agent required). See [Health Checks](#health-checks). |
-| `command` health checks | Rejected at the API. No `docker exec` equivalent in the VM model — would need an in-guest agent (vsock or SSH). |
+| `command` health checks | **Supported** via the in-guest `ring-agent` daemon (AF_VSOCK port 2375). The guest image must ship the agent — see [Prerequisites](#prerequisites). |
 | Custom commands (`command: [...]`) | Rejected at the API — the VM boots whatever its image is configured to run. |
 | Docker image references | Rejected at the API — `image:` must be an absolute path to a raw disk image (e.g. `/var/lib/ring/images/ubuntu-focal.raw`). |
 | `labels:` | Silently ignored — no equivalent of Docker container labels in the VM model. |

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -38,16 +38,9 @@ fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
 
 fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
     if input.runtime == "cloud-hypervisor" {
-        if let Some(hcs) = &input.health_checks
-            && hcs
-                .iter()
-                .any(|hc| matches!(hc, crate::models::health_check::HealthCheck::Command { .. }))
-        {
-            return Err(
-                "command health checks are not supported on cloud-hypervisor runtime (alpha); use tcp or http"
-                    .to_string(),
-            );
-        }
+        // `command` health checks are now supported via the in-guest
+        // `ring-agent` daemon (vsock). The guest image must ship the agent
+        // listening on AF_VSOCK port 2375 — see the runtime documentation.
 
         // Reject silently-dropped fields up front so users get a clear error
         // instead of a deployment that runs but ignores half its configuration.
@@ -498,7 +491,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_cloud_hypervisor_rejects_command_health_check() {
+    async fn create_cloud_hypervisor_accepts_command_health_check() {
+        // command health checks now route through `ring-agent` over vsock.
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -523,12 +517,7 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
-        assert!(
-            body.message
-                .contains("command health checks are not supported on cloud-hypervisor runtime")
-        );
+        assert_eq!(response.status_code(), StatusCode::CREATED);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod runtime {
     pub(crate) mod port_forwarder;
     pub(crate) mod types;
     pub(crate) mod virtiofs;
+    pub(crate) mod vsock_client;
 }
 
 mod models {

--- a/src/runtime/cloud_hypervisor/client.rs
+++ b/src/runtime/cloud_hypervisor/client.rs
@@ -31,6 +31,8 @@ pub(crate) struct VmConfig {
     pub serial: Option<ConsoleConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub console: Option<ConsoleConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vsock: Option<VsockConfig>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -97,6 +99,15 @@ pub(crate) struct NetConfig {
     pub mask: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
+}
+
+/// Attaches a vhost-vsock device to the VM. The guest sees AF_VSOCK and
+/// `ring-agent` (running inside) listens on a well-known port. Ring opens
+/// connections from the host to (cid, port) for command health checks.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct VsockConfig {
+    pub cid: u32,
+    pub socket: String,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -453,6 +453,30 @@ impl CloudHypervisorLifecycle {
         } else {
             None
         };
+
+        // Attach a vhost-vsock device whenever the deployment declares a
+        // `command` health check — that's the only consumer today. Adding a
+        // vsock for every CH VM would mean an extra device per VM for no
+        // benefit; gate it on demand instead.
+        //
+        // Known limitation: `needs_vsock` is evaluated only at boot. If an
+        // operator adds a `command` health check to an already-running
+        // deployment, the existing VM has no vsock device; the next probe
+        // will fail at connect, the scheduler will increment failures and
+        // eventually restart the VM, at which point this path runs again
+        // and the vsock is provisioned. The transient failures are
+        // unavoidable without a hot-attach path through the CH API.
+        let needs_vsock = deployment
+            .health_checks
+            .iter()
+            .any(|hc| matches!(hc, crate::models::health_check::HealthCheck::Command { .. }));
+        let vsock_cid = if needs_vsock {
+            Some(crate::runtime::host_net::cid_for_instance(instance_id))
+        } else {
+            None
+        };
+        let vsock_socket_path = vsock_cid
+            .map(|_| PathBuf::from(&self.config.socket_dir).join(format!("{}.vsock", instance_id)));
         let guest_net = net_alloc.as_ref().map(|n| super::cloud_init::GuestNet {
             guest_ip: n.guest_ip.clone(),
             host_ip: n.host_ip.clone(),
@@ -537,6 +561,13 @@ impl CloudHypervisorLifecycle {
                 mode: "Off".to_string(),
                 file: None,
             }),
+            vsock: match (vsock_cid, vsock_socket_path.as_ref()) {
+                (Some(cid), Some(path)) => Some(super::client::VsockConfig {
+                    cid,
+                    socket: Self::path_str(path)?.to_string(),
+                }),
+                _ => None,
+            },
         };
 
         // From here on, any failure must clean up the half-created VM:
@@ -649,6 +680,14 @@ impl CloudHypervisorLifecycle {
         let console_log = self.console_log_path(instance_id);
         if let Err(e) = tokio::fs::remove_file(&console_log).await {
             debug!("Failed to remove console log {:?}: {}", console_log, e);
+        }
+
+        // CH creates the vsock backing socket on `create_vm` and leaves it
+        // behind on `delete`. Best-effort cleanup; absence is fine.
+        let vsock_path =
+            PathBuf::from(&self.config.socket_dir).join(format!("{}.vsock", instance_id));
+        if let Err(e) = tokio::fs::remove_file(&vsock_path).await {
+            debug!("Failed to remove vsock socket {:?}: {}", vsock_path, e);
         }
 
         // Drop any live virtiofsd processes for this instance. Their `Drop`
@@ -903,6 +942,46 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
     /// — every probe recomputes the same address the VM was booted with.
     async fn instance_address(&self, instance_id: &str) -> Option<std::net::IpAddr> {
         InstanceNet::for_instance(instance_id).guest_ip.parse().ok()
+    }
+
+    /// Execute the probe via vsock against `ring-agent` running in the guest.
+    /// The CID was assigned deterministically at boot from the instance id;
+    /// recompute it here so we don't need to thread state through the probe
+    /// path. The agent is responsible for shell-parsing the command — it
+    /// receives the string verbatim and lets the guest's shell deal with it.
+    async fn execute_command_probe(
+        &self,
+        instance_id: &str,
+        command: &str,
+    ) -> (
+        crate::models::health_check::HealthCheckStatus,
+        Option<String>,
+    ) {
+        use crate::models::health_check::HealthCheckStatus;
+
+        let cid = crate::runtime::host_net::cid_for_instance(instance_id);
+        let argv = vec!["/bin/sh".to_string(), "-c".to_string(), command.to_string()];
+        let timeout = std::time::Duration::from_secs(30);
+
+        match crate::runtime::vsock_client::exec(cid, &argv, &[], timeout).await {
+            Ok(resp) if resp.timed_out => (
+                HealthCheckStatus::Timeout,
+                Some(format!("command timed out: {}", command)),
+            ),
+            Ok(resp) if resp.exit_code == 0 => (HealthCheckStatus::Success, None),
+            Ok(resp) => (
+                HealthCheckStatus::Failed,
+                Some(format!(
+                    "exit code {}: {}",
+                    resp.exit_code,
+                    resp.stderr.trim()
+                )),
+            ),
+            Err(e) => (
+                HealthCheckStatus::Failed,
+                Some(format!("vsock probe failed: {}", e)),
+            ),
+        }
     }
 }
 

--- a/src/runtime/host_net.rs
+++ b/src/runtime/host_net.rs
@@ -89,6 +89,22 @@ impl InstanceNet {
     }
 }
 
+/// Deterministic AF_VSOCK CID for a given instance id. CIDs 0/1/2 are
+/// reserved by the kernel/hypervisor (HOST=2, ANY=u32::MAX, etc.); we map
+/// the instance hash into [3, u32::MAX-1) so collisions across distinct
+/// instances on the same host are vanishingly rare. Two VMs with the same
+/// CID can't both run on the same host (CH rejects duplicates), so the
+/// scheduler will surface this as a boot failure rather than silently mix
+/// traffic.
+pub fn cid_for_instance(instance_id: &str) -> u32 {
+    let h = stable_hash(instance_id);
+    // Reserved range [0..=2]. ANY = u32::MAX. Take a 32-bit slice and
+    // shift into [3, u32::MAX-1].
+    let raw = (h as u32) ^ ((h >> 32) as u32);
+    let span = u32::MAX - 4;
+    3 + (raw % span)
+}
+
 /// Tiny FNV-1a 64-bit. Vendor-free, deterministic across builds. We don't
 /// need cryptographic strength — just a good distribution across the /30
 /// space.

--- a/src/runtime/vsock_client.rs
+++ b/src/runtime/vsock_client.rs
@@ -1,0 +1,135 @@
+//! Host-side client that talks to `ring-agent` running inside a CH guest VM.
+//!
+//! Wire format mirrors `crates/ring-agent/src/main.rs`:
+//!   - request:  [u32 BE length][JSON `Request`]
+//!   - response: [u32 BE length][JSON `Response`]
+//!
+//! One TCP-style connection per request. The agent does not multiplex.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_vsock::{VsockAddr, VsockStream};
+
+const VSOCK_PORT: u32 = 2375;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_RESPONSE_BYTES: u32 = 1 << 20;
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Request<'a> {
+    Exec {
+        argv: &'a [String],
+        env: &'a [(String, String)],
+        timeout_ms: Option<u64>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Response {
+    Exec(ExecResponse),
+    Error { message: String },
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ExecResponse {
+    pub exit_code: i32,
+    #[allow(dead_code)]
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum VsockError {
+    #[error("connect to CID {cid} failed: {source}")]
+    Connect {
+        cid: u32,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("agent reported error: {0}")]
+    Agent(String),
+    #[error("agent response too large: {0} bytes")]
+    ResponseTooLarge(u32),
+    #[error("malformed agent response: {0}")]
+    Malformed(#[from] serde_json::Error),
+}
+
+/// Run `argv` inside the guest VM identified by `cid`. Blocks the calling task
+/// until the command exits or the agent's own timeout fires (whichever first).
+pub(crate) async fn exec(
+    cid: u32,
+    argv: &[String],
+    env: &[(String, String)],
+    timeout: Duration,
+) -> Result<ExecResponse, VsockError> {
+    // Invariant: the agent-side exec budget must be smaller than our read
+    // timeout, otherwise the host disconnects before the agent can answer
+    // and the exec process is orphaned inside the VM. Caller bug if violated.
+    debug_assert!(
+        timeout < READ_TIMEOUT,
+        "vsock exec timeout {:?} must be < READ_TIMEOUT {:?}",
+        timeout,
+        READ_TIMEOUT
+    );
+
+    let addr = VsockAddr::new(cid, VSOCK_PORT);
+
+    let mut stream = tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))
+        .await
+        .map_err(|_| VsockError::Connect {
+            cid,
+            source: std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timed out"),
+        })?
+        .map_err(|e| VsockError::Connect { cid, source: e })?;
+
+    let request = Request::Exec {
+        argv,
+        env,
+        timeout_ms: Some(timeout.as_millis() as u64),
+    };
+    let body = serde_json::to_vec(&request)?;
+    let len = (body.len() as u32).to_be_bytes();
+    // Without a write timeout, a full vsock send buffer (e.g. agent stuck in
+    // a slow command) would block this task indefinitely and stall the
+    // scheduler loop that owns the probe.
+    tokio::time::timeout(WRITE_TIMEOUT, stream.write_all(&len))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "vsock write timed out")
+        })??;
+    tokio::time::timeout(WRITE_TIMEOUT, stream.write_all(&body))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "vsock write timed out")
+        })??;
+    tokio::time::timeout(WRITE_TIMEOUT, stream.flush())
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "vsock flush timed out")
+        })??;
+
+    let mut len_buf = [0u8; 4];
+    tokio::time::timeout(READ_TIMEOUT, stream.read_exact(&mut len_buf))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "agent read timed out"))??;
+    let resp_len = u32::from_be_bytes(len_buf);
+    if resp_len > MAX_RESPONSE_BYTES {
+        return Err(VsockError::ResponseTooLarge(resp_len));
+    }
+    let mut resp_buf = vec![0u8; resp_len as usize];
+    tokio::time::timeout(READ_TIMEOUT, stream.read_exact(&mut resp_buf))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "agent body timed out"))??;
+
+    match serde_json::from_slice::<Response>(&resp_buf)? {
+        Response::Exec(r) => Ok(r),
+        Response::Error { message } => Err(VsockError::Agent(message)),
+    }
+}

--- a/tests/e2e/cloud-hypervisor/t17_command_health_check.sh
+++ b/tests/e2e/cloud-hypervisor/t17_command_health_check.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# T17-CH: a CH deployment with `health_checks: [{ type: command, ... }]` must:
+#   1. be accepted by the API (no 400 — pre-vsock rejection is gone),
+#   2. boot with a vsock device attached (visible in CH's vm.info),
+#   3. produce a host-side vsock socket file under socket_dir.
+#
+# We don't validate end-to-end probe success: that requires a guest image
+# shipping `ring-agent`, which the test harness doesn't build today (cirros
+# has no cargo). Once a packer pipeline produces an image with the agent,
+# extend this test to assert the deployment stays healthy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T17-CH: command health check wires up vsock =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/cmd-hc-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  cmd-hc-vm:
+    name: cmd-hc-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    health_checks:
+      - type: command
+        command: "/bin/true"
+        interval: "30s"
+        timeout: "5s"
+        threshold: 3
+        on_failure: restart
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+# API must accept the manifest now that vsock-based command probes work.
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "cmd-hc-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "cmd-hc-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === vsock socket file present ===
+# CH creates the host side of the vhost-vsock device at
+# <socket_dir>/<instance>.vsock. Find any matching file under the deployment.
+log "looking for vsock socket file..."
+VSOCK_FILES=$( (find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.vsock" 2>/dev/null || true) | wc -l | tr -d ' ')
+if [ "$VSOCK_FILES" -lt 1 ]; then
+  ls "$RING_E2E_CH_SOCKET_DIR" >&2 || true
+  fail "no .vsock socket file found under $RING_E2E_CH_SOCKET_DIR"
+fi
+log "found $VSOCK_FILES .vsock socket file(s)"
+
+# === CH vm.info exposes the vsock device ===
+# Query CH's HTTP API directly to confirm the device made it into the running
+# VM config. The API socket is <instance>.sock under socket_dir.
+API_SOCK=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*-*.sock" -not -name "*.vsock" 2>/dev/null | head -n1)
+[ -z "$API_SOCK" ] && fail "no CH API socket found"
+INFO=$(curl -s --unix-socket "$API_SOCK" http://localhost/api/v1/vm.info || true)
+if ! echo "$INFO" | grep -q '"vsock"'; then
+  echo "$INFO" >&2
+  fail "vsock device missing from vm.info"
+fi
+log "vm.info reports a vsock device"
+
+# === delete teardown ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# vsock socket file must be cleaned up.
+for _ in $(seq 1 30); do
+  remaining=$( (find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.vsock" 2>/dev/null || true) | wc -l | tr -d ' ')
+  [ "$remaining" -eq 0 ] && break
+  sleep 1
+done
+if [ "$remaining" -ne 0 ]; then
+  ls "$RING_E2E_CH_SOCKET_DIR" >&2 || true
+  fail ".vsock socket leak: $remaining still present after delete"
+fi
+log "vsock socket cleaned up"
+
+log "== T17-CH: PASS =="


### PR DESCRIPTION
## Summary

Cloud Hypervisor deployments can now use \`health_checks: [{ type: command, ... }]\`. Container runtimes implement this with \`docker exec\`; for VMs Ring opens an AF_VSOCK connection to a small in-guest daemon.

### Components

- **\`crates/ring-agent/\`** — new workspace member. Static-musl-buildable Rust binary that listens on AF_VSOCK port 2375, parses length-prefixed JSON \`{argv, env, timeout_ms}\` requests, runs the command via \`tokio::process\`, and returns \`{exit_code, stdout, stderr, timed_out}\`. Per-stream output capped at 256 KiB so a verbose command can never produce a frame larger than the host-side limit.
- **\`src/runtime/vsock_client.rs\`** — host-side client. Same wire format. \`exec(cid, argv, env, timeout)\` returns the agent's response. Connect / write / read all wrapped in their own timeouts; \`debug_assert!\` enforces \`timeout < READ_TIMEOUT\` so the host never disconnects before the agent can answer.
- **\`src/runtime/host_net.rs:cid_for_instance\`** — deterministic CID allocator from the instance id (same FNV-1a hash that allocates \`/30\` subnets), mapped into \`[3, u32::MAX-1]\`.
- **\`src/runtime/cloud_hypervisor/client.rs\`** — new \`VsockConfig\` field on \`VmConfig\` (\`{cid, socket}\`), serialized only when present.
- **\`src/runtime/cloud_hypervisor/lifecycle.rs\`**:
  - Attaches a vhost-vsock device whenever the deployment declares a \`command\` health check (gated on demand to avoid an extra device per VM otherwise). Limitation documented inline: an existing VM whose deployment gains a \`command\` probe later will fail probes until the next restart re-provisions vsock.
  - Overrides \`execute_command_probe\` to call \`vsock_client::exec\` with the recomputed CID; non-zero exit → \`Failed\`, timeout → \`Timeout\`, vsock connect error → \`Failed\` with the underlying error message.
  - \`stop_vm\` cleans up the host-side \`<instance>.vsock\` socket.
- **\`src/api/action/deployment/create.rs\`** — drops the \`400 Bad Request\` rejection. The existing API test that asserted the rejection is rewritten to assert acceptance.

### Documentation

- Adds a Prerequisites entry (#9) covering how to build and install \`ring-agent\` in the guest image.
- Updates the Health Checks section to document the vsock path.
- Updates the parity table to mark \`command\` health checks as **Supported**.

## Test plan

- [x] \`cargo check\` passes
- [x] \`cargo test --bin ring\` — 232 tests pass (including the rewritten \`create_cloud_hypervisor_accepts_command_health_check\`)
- [x] \`cargo build -p ring-agent\` succeeds
- [x] \`cargo build -p ring-agent --target x86_64-unknown-linux-musl --release\` produces a 1.3 MiB static-pie binary
- [x] \`tests/e2e/cloud-hypervisor/t17_command_health_check.sh\` — boots a CH VM with a command health check, asserts the vsock device appears in CH's \`vm.info\` and that the host-side socket file is created/cleaned (PASS locally). Doesn't validate end-to-end probe success because the e2e cirros image doesn't ship \`ring-agent\` yet — extend once a guest image with the agent is available.
- [ ] Manual: build an Ubuntu cloud image with \`ring-agent\` baked in, deploy with a \`command\` probe, verify the deployment stays healthy and that flipping the probe command to \`/bin/false\` triggers a restart.

## Review feedback addressed

Code review surfaced two blockers and a few important items, all addressed in the latest amend:

- **Write timeout** (\`vsock_client.rs\`) — added \`WRITE_TIMEOUT = 5s\` wrapping each \`write_all\` and the \`flush\`, plus a \`debug_assert!\` enforcing \`timeout < READ_TIMEOUT\` so the host never disconnects before the agent can answer.
- **Output cap** (\`ring-agent\`) — per-stream truncation at 256 KiB via \`truncate_lossy\`, plus a fallback frame for the (unreachable) case where the serialized body exceeds \`u32::MAX\`.
- **Lifecycle gating mismatch** — documented inline as a known limitation; a hot-attach path through the CH API would be needed to fix it without a VM restart.
- **Doc + comments** — \`env_clear()\` rationale, \`stderr\` field marked correctly (it's \`stdout\` that's currently unused on the success path, not \`stderr\`).

## Follow-ups (not in this PR)

- Bake \`ring-agent\` into a Packer image so the e2e test can validate end-to-end probe success.
- \`ring exec <id> -- <cmd>\` reuses the same vsock client + agent — natural next PR.