### PR TITLE
feat(scheduler): readiness gate for rolling updates with Docker HEALTHCHECK

### DIFF
--- a/documentation/guides/health-checks.md
+++ b/documentation/guides/health-checks.md
@@ -160,7 +160,7 @@ A deployment that has **at least one** health check enables zero-downtime rollin
 1. `ring apply` finds an active deployment with the same `name` + `namespace`.
 2. Ring creates a **child deployment** (carrying `parent_id`) with the new manifest.
 3. The scheduler boots the child's instances. Old containers keep serving traffic.
-4. As soon as a new instance returns `success` on its check, Ring removes one old instance and decrements the parent's instance list.
+4. Once the child's readiness gate opens (see below), Ring removes one old instance and decrements the parent's instance list.
 5. Once the parent has zero instances, it's marked `deleted`.
 
 If the new instances **never** pass their health checks, the parent stays running, the child is marked `failed`, and the rollout halts. Inspect with:
@@ -176,6 +176,50 @@ Rolling updates are skipped (immediate replacement, brief downtime) when:
 - The deployment has **no** health checks declared.
 - `ring apply --force` is set.
 - More than one active deployment shares the `name`+`namespace` (an unusual state — fix the duplicates first).
+
+In each case Ring logs a `ForceReplace` event on the new deployment with the precise reason — `ring deployment events <ID> --level warning` to see it.
+
+### Readiness gate (`readiness: true`)
+
+By default Ring drains the parent as soon as the child container reaches `Running`. That's fast, but it ignores application-level boot time (warmup, migrations, cache priming, etc.). Mark a check as **readiness** to gate the drain on real application readiness:
+
+```yaml
+health_checks:
+  - type: command
+    command: test -f /var/run/kemeter/ready
+    interval: 5s
+    timeout: 2s
+    threshold: 3
+    on_failure: alert
+    readiness: true        # ← drain the parent only after this passes
+```
+
+Behaviour with at least one `readiness: true` check:
+
+- The child must produce **at least one `success` result** for **every** readiness check before the parent is touched.
+- Each readiness check must remain green for at least **10 seconds** (`min_healthy_time`, hardcoded — anti-flap window borrowed from Nomad).
+- Any `failed` or `timeout` on a readiness check resets the gate. The parent stays alive.
+- Non-readiness checks keep their existing role (liveness / restart / alert) and don't influence the gate.
+
+If no check is marked `readiness: true`, the legacy "drain on `Running`" behaviour is preserved — existing manifests are unaffected.
+
+### Proxy integration (Traefik / Sozune)
+
+A `readiness: true` check of `type: command` is **also** translated into a native Docker `HEALTHCHECK` on the container. Proxies that read Docker labels (Traefik, Sozune, …) gate traffic on `Status: healthy` automatically — they won't route to the new container while the readiness command is failing.
+
+```bash
+docker inspect <container> | jq '.[0].Config.Healthcheck'
+docker inspect <container> | jq '.[0].State.Health.Status'   # → starting | healthy | unhealthy
+```
+
+| Check type | Ring scheduler gate (drain) | Docker HEALTHCHECK (proxy gate) |
+|---|---|---|
+| `command` + `readiness: true` | ✅ | ✅ |
+| `tcp` + `readiness: true`     | ✅ | ❌ — Docker has no native TCP probe |
+| `http` + `readiness: true`    | ✅ | ❌ — Docker has no native HTTP probe |
+| any without `readiness: true` | ❌ (legacy drain on Running) | ❌ |
+
+If you need proxy-aware readiness for HTTP, wrap the probe in a shell command that calls `curl -fsS http://localhost:<port>/health` from inside the container, and use `type: command` with `readiness: true`. The image must ship `curl` (or `wget`/`busybox`) for that to work.
 
 See [managing deployments → rolling update](/documentation/getting-started/managing-deployments#rolling-update-zero-downtime) for the operator's perspective.
 
@@ -322,6 +366,40 @@ health_checks:
     threshold: 3
     on_failure: alert
 ```
+
+### Zero-downtime rolling update for a slow-booting service
+
+The app writes `/var/run/kemeter/ready` once it has run its migrations,
+warmed its cache, and is ready to serve traffic. The readiness check both
+gates Ring's drain of the old version *and* tells Traefik (via the Docker
+HEALTHCHECK Ring writes for it) not to route traffic to the new container
+until that file exists.
+
+```yaml
+health_checks:
+  # Liveness — restart on hard listener failure (no readiness flag)
+  - type: tcp
+    port: 8080
+    interval: "5s"
+    timeout: "2s"
+    threshold: 3
+    on_failure: restart
+
+  # Readiness — gates rolling drain AND proxy traffic
+  - type: command
+    command: test -f /var/run/kemeter/ready
+    interval: "5s"
+    timeout: "2s"
+    threshold: 3
+    on_failure: alert
+    readiness: true
+```
+
+Operationally, your application creates the file at the very end of its
+boot sequence (after migrations, after cache warmup, after a self-test).
+Ring's scheduler waits for ≥1 success kept green for 10s before draining
+the old deployment, and Docker's `Status: healthy` flag tells the proxy
+when to start routing traffic to the new container.
 
 ### Stateful service that should be hands-off
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -114,6 +114,8 @@ enum HealthCheck {
         #[serde(default = "default_hc_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        #[serde(default)]
+        readiness: bool,
     },
     Http {
         url: String,
@@ -122,6 +124,8 @@ enum HealthCheck {
         #[serde(default = "default_hc_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        #[serde(default)]
+        readiness: bool,
     },
     Command {
         command: String,
@@ -130,6 +134,8 @@ enum HealthCheck {
         #[serde(default = "default_hc_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        #[serde(default)]
+        readiness: bool,
     },
 }
 

--- a/src/models/health_check.rs
+++ b/src/models/health_check.rs
@@ -1,8 +1,13 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 fn default_threshold() -> u32 {
     3
+}
+
+fn default_readiness() -> bool {
+    false
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -16,6 +21,14 @@ pub(crate) enum HealthCheck {
         #[serde(default = "default_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        /// When true, the rolling-update scheduler waits for this check to
+        /// pass before draining the parent. Type-agnostic: works for tcp,
+        /// http and command. Only `command` readiness checks are also
+        /// pushed to Docker as a native `HEALTHCHECK` so the proxy
+        /// (Traefik / Sozune) can gate traffic — tcp/http have no native
+        /// Docker equivalent and are documented as Ring-only readiness.
+        #[serde(default = "default_readiness")]
+        readiness: bool,
     },
     #[serde(rename = "http")]
     Http {
@@ -25,6 +38,8 @@ pub(crate) enum HealthCheck {
         #[serde(default = "default_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        #[serde(default = "default_readiness")]
+        readiness: bool,
     },
     #[serde(rename = "command")]
     Command {
@@ -34,6 +49,8 @@ pub(crate) enum HealthCheck {
         #[serde(default = "default_threshold")]
         threshold: u32,
         on_failure: FailureAction,
+        #[serde(default = "default_readiness")]
+        readiness: bool,
     },
 }
 
@@ -113,6 +130,22 @@ impl HealthCheck {
             HealthCheck::Command { .. } => "command",
         }
     }
+
+    pub(crate) fn is_readiness(&self) -> bool {
+        match self {
+            HealthCheck::Tcp { readiness, .. } => *readiness,
+            HealthCheck::Http { readiness, .. } => *readiness,
+            HealthCheck::Command { readiness, .. } => *readiness,
+        }
+    }
+
+    pub(crate) fn interval(&self) -> &str {
+        match self {
+            HealthCheck::Tcp { interval, .. } => interval,
+            HealthCheck::Http { interval, .. } => interval,
+            HealthCheck::Command { interval, .. } => interval,
+        }
+    }
 }
 
 impl Default for HealthCheck {
@@ -123,6 +156,95 @@ impl Default for HealthCheck {
             timeout: "5s".to_string(),
             threshold: 3,
             on_failure: FailureAction::Restart,
+            readiness: false,
+        }
+    }
+}
+
+/// Decision from `evaluate_readiness`. The variants spell out exactly *why*
+/// the rolling update can or can't progress so callers can log a precise event
+/// instead of a generic "not ready".
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReadinessDecision {
+    /// No readiness HC is configured on the deployment — the caller should
+    /// fall back to the legacy "drain on Running" behaviour. This is what
+    /// keeps the new flag opt-in for existing deployments.
+    NotConfigured,
+    /// At least one readiness HC has never produced a result yet.
+    PendingNoResult,
+    /// All readiness HCs are currently passing, but the most recent success
+    /// happened too recently — keep waiting until `min_healthy_time` elapses
+    /// to filter out flapping checks.
+    PendingMinHealthyTime { remaining: Duration },
+    /// At least one readiness HC is currently failing.
+    Failing,
+    /// All readiness HCs have been Success for at least `min_healthy_time` —
+    /// the rolling update may drain the parent.
+    Ready,
+}
+
+/// Decide whether a deployment with these readiness checks is ready to drain
+/// its rolling-update parent.
+///
+/// Pure function so the test suite can exhaustively exercise the decision
+/// table without spinning up a database or sleeping. The caller passes:
+/// - `expected_readiness_count`: how many HCs in the deployment manifest are
+///   marked `readiness: true`. Used to detect "I'm waiting on a HC that
+///   hasn't produced any result yet".
+/// - `latest_readiness_results`: the freshest result for each readiness HC
+///   that has produced at least one entry (one row per `check_type`).
+/// - `min_healthy_time`: anti-flap window, injected (not hardcoded) so tests
+///   can pass `0s` and skip it deterministically.
+pub(crate) fn evaluate_readiness(
+    expected_readiness_count: usize,
+    latest_readiness_results: &[(HealthCheckStatus, DateTime<Utc>)],
+    now: DateTime<Utc>,
+    min_healthy_time: Duration,
+) -> ReadinessDecision {
+    if expected_readiness_count == 0 {
+        return ReadinessDecision::NotConfigured;
+    }
+
+    if latest_readiness_results.len() < expected_readiness_count {
+        return ReadinessDecision::PendingNoResult;
+    }
+
+    // Any failing readiness check vetoes the drain immediately. We don't
+    // distinguish Failed from Timeout here — both mean "not ready". The
+    // operator who wants more nuance can read the underlying logs.
+    if latest_readiness_results
+        .iter()
+        .any(|(s, _)| !matches!(s, HealthCheckStatus::Success))
+    {
+        return ReadinessDecision::Failing;
+    }
+
+    // Find the freshest finished_at among the readiness checks. The drain
+    // is gated by *the latest* one — if any single readiness HC just turned
+    // Success a moment ago, we still need to ride out the anti-flap window.
+    let freshest = latest_readiness_results
+        .iter()
+        .map(|(_, finished_at)| *finished_at)
+        .max()
+        .expect("non-empty latest_readiness_results checked above");
+
+    let elapsed = now.signed_duration_since(freshest);
+    let elapsed_std = match elapsed.to_std() {
+        Ok(d) => d,
+        // Negative elapsed means the latest finished_at is in the future
+        // (clock skew or test fixture). Treat as "still fresh".
+        Err(_) => {
+            return ReadinessDecision::PendingMinHealthyTime {
+                remaining: min_healthy_time,
+            };
+        }
+    };
+
+    if elapsed_std >= min_healthy_time {
+        ReadinessDecision::Ready
+    } else {
+        ReadinessDecision::PendingMinHealthyTime {
+            remaining: min_healthy_time - elapsed_std,
         }
     }
 }
@@ -152,5 +274,102 @@ mod tests {
 
         let result = HealthCheck::parse_duration("abc");
         assert!(result.is_err());
+    }
+
+    fn fixed_now() -> DateTime<Utc> {
+        // Arbitrary fixed timestamp so tests are deterministic. The exact
+        // value doesn't matter — only its delta to the result timestamps does.
+        DateTime::parse_from_rfc3339("2026-05-10T19:42:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn ts(seconds_ago: i64) -> DateTime<Utc> {
+        fixed_now() - chrono::Duration::seconds(seconds_ago)
+    }
+
+    #[test]
+    fn readiness_not_configured_when_no_readiness_checks() {
+        let decision = evaluate_readiness(0, &[], fixed_now(), Duration::from_secs(10));
+        assert_eq!(decision, ReadinessDecision::NotConfigured);
+    }
+
+    #[test]
+    fn readiness_pending_when_expected_check_has_no_result_yet() {
+        // Two readiness HCs declared, only one has produced a result so far.
+        let results = [(HealthCheckStatus::Success, ts(20))];
+        let decision = evaluate_readiness(2, &results, fixed_now(), Duration::from_secs(10));
+        assert_eq!(decision, ReadinessDecision::PendingNoResult);
+    }
+
+    #[test]
+    fn readiness_failing_when_any_latest_is_failed() {
+        let results = [
+            (HealthCheckStatus::Success, ts(20)),
+            (HealthCheckStatus::Failed, ts(2)),
+        ];
+        let decision = evaluate_readiness(2, &results, fixed_now(), Duration::from_secs(10));
+        assert_eq!(decision, ReadinessDecision::Failing);
+    }
+
+    #[test]
+    fn readiness_failing_when_any_latest_is_timeout() {
+        let results = [
+            (HealthCheckStatus::Success, ts(20)),
+            (HealthCheckStatus::Timeout, ts(1)),
+        ];
+        let decision = evaluate_readiness(2, &results, fixed_now(), Duration::from_secs(10));
+        assert_eq!(decision, ReadinessDecision::Failing);
+    }
+
+    #[test]
+    fn readiness_pending_min_healthy_when_freshest_is_too_recent() {
+        // Both Success but the freshest finished 5s ago — anti-flap window
+        // is 10s, so we must wait 5 more seconds.
+        let results = [
+            (HealthCheckStatus::Success, ts(20)),
+            (HealthCheckStatus::Success, ts(5)),
+        ];
+        let decision = evaluate_readiness(2, &results, fixed_now(), Duration::from_secs(10));
+        match decision {
+            ReadinessDecision::PendingMinHealthyTime { remaining } => {
+                assert_eq!(remaining, Duration::from_secs(5));
+            }
+            other => panic!("expected PendingMinHealthyTime, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn readiness_ready_when_freshest_is_old_enough() {
+        let results = [
+            (HealthCheckStatus::Success, ts(30)),
+            (HealthCheckStatus::Success, ts(15)),
+        ];
+        let decision = evaluate_readiness(2, &results, fixed_now(), Duration::from_secs(10));
+        assert_eq!(decision, ReadinessDecision::Ready);
+    }
+
+    #[test]
+    fn readiness_ready_immediately_when_min_healthy_time_is_zero() {
+        // Useful as a deterministic test mode and as the "no anti-flap"
+        // configuration if an operator ever opts out.
+        let results = [(HealthCheckStatus::Success, ts(0))];
+        let decision = evaluate_readiness(1, &results, fixed_now(), Duration::from_secs(0));
+        assert_eq!(decision, ReadinessDecision::Ready);
+    }
+
+    #[test]
+    fn readiness_handles_future_finished_at_gracefully() {
+        // Clock skew between the result writer and the gate evaluator can
+        // produce a finished_at slightly in the future. Treat it as "still
+        // fresh" rather than panicking.
+        let results = [(HealthCheckStatus::Success, ts(-5))];
+        let decision = evaluate_readiness(1, &results, fixed_now(), Duration::from_secs(10));
+        match decision {
+            ReadinessDecision::PendingMinHealthyTime { remaining } => {
+                assert_eq!(remaining, Duration::from_secs(10));
+            }
+            other => panic!("expected PendingMinHealthyTime, got {:?}", other),
+        }
     }
 }

--- a/src/models/health_check_logs.rs
+++ b/src/models/health_check_logs.rs
@@ -75,6 +75,58 @@ pub(crate) async fn find_latest_by_deployment(
     .await
 }
 
+/// Per-check_type entry returned by `find_ready_since_by_deployment`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub(crate) struct ReadySinceRecord {
+    pub(crate) check_type: String,
+    pub(crate) ready_since: String,
+}
+
+/// For each `check_type`, return the timestamp of the **first** success since
+/// the last non-success result (or the first success ever if there was no
+/// failure). Used by the readiness gate to compute the anti-flap window
+/// against a stable point in time rather than the most recent success
+/// (which would slide forward at every probe and never let the window
+/// elapse). Check types whose most recent result is not Success are
+/// excluded — caller must treat a missing row as "failing or no result".
+pub(crate) async fn find_ready_since_by_deployment(
+    pool: &SqlitePool,
+    deployment_id: String,
+) -> Result<Vec<ReadySinceRecord>, sqlx::Error> {
+    sqlx::query_as::<_, ReadySinceRecord>(
+        "WITH last_failure AS (
+            SELECT check_type, MAX(finished_at) AS finished_at
+            FROM health_check
+            WHERE deployment_id = ? AND status != 'success'
+            GROUP BY check_type
+        ),
+        latest AS (
+            SELECT hc.check_type, hc.status
+            FROM health_check hc
+            INNER JOIN (
+                SELECT check_type, MAX(finished_at) AS max_f
+                FROM health_check WHERE deployment_id = ?
+                GROUP BY check_type
+            ) m ON hc.check_type = m.check_type AND hc.finished_at = m.max_f
+            WHERE hc.deployment_id = ?
+        )
+        SELECT hc.check_type, MIN(hc.finished_at) AS ready_since
+        FROM health_check hc
+        INNER JOIN latest ON latest.check_type = hc.check_type AND latest.status = 'success'
+        LEFT JOIN last_failure lf ON lf.check_type = hc.check_type
+        WHERE hc.deployment_id = ?
+          AND hc.status = 'success'
+          AND (lf.finished_at IS NULL OR hc.finished_at > lf.finished_at)
+        GROUP BY hc.check_type",
+    )
+    .bind(&deployment_id)
+    .bind(&deployment_id)
+    .bind(&deployment_id)
+    .bind(&deployment_id)
+    .fetch_all(pool)
+    .await
+}
+
 pub(crate) async fn delete_by_deployment_id(
     pool: &SqlitePool,
     deployment_id: &str,

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -6,7 +6,7 @@ use bollard::{
     Docker,
     auth::DockerCredentials,
     models::{
-        ContainerCreateBody, EndpointSettings, HostConfig, Mount, MountTypeEnum,
+        ContainerCreateBody, EndpointSettings, HealthConfig, HostConfig, Mount, MountTypeEnum,
         MountVolumeOptions, MountVolumeOptionsDriverConfig, NetworkConnectRequest,
         NetworkCreateRequest, PortBinding,
     },
@@ -44,6 +44,50 @@ fn extract_digest(repo_digests: &Option<Vec<String>>) -> Option<String> {
         .as_ref()?
         .first()
         .and_then(|d| d.split_once('@').map(|(_, digest)| digest.to_string()))
+}
+
+/// Translate the first readiness HC of `type: command` into a Docker
+/// `HEALTHCHECK`, so the proxy (Traefik / Sozune) can gate traffic via the
+/// container's `Status: healthy` flag — without that translation, the proxy
+/// would route to the new container as soon as it is `Running`, which is
+/// before the application is actually ready.
+///
+/// Only `command` is translated: Docker's healthcheck takes a shell command,
+/// it has no native TCP/HTTP probe. A `tcp` or `http` readiness HC is still
+/// honoured by Ring's own scheduler-side gating, but the proxy won't see it.
+/// This is documented as a limitation; users who need proxy-aware TCP/HTTP
+/// readiness can wrap the probe in a shell command (`curl -fsS …`).
+fn build_health_config(
+    health_checks: &[crate::models::health_check::HealthCheck],
+) -> Option<HealthConfig> {
+    let hc = health_checks
+        .iter()
+        .filter(|hc| hc.is_readiness())
+        .find(|hc| matches!(hc, crate::models::health_check::HealthCheck::Command { .. }))?;
+
+    let command = match hc {
+        crate::models::health_check::HealthCheck::Command { command, .. } => command.clone(),
+        _ => return None,
+    };
+
+    // Docker expects nanoseconds. Fall back to safe defaults if the user's
+    // duration string is malformed — the Ring scheduler-side gate will still
+    // run with the same values, so a misconfiguration doesn't go unnoticed.
+    let to_nanos = |s: &str| -> i64 {
+        crate::models::health_check::HealthCheck::parse_duration(s)
+            .ok()
+            .and_then(|d| i64::try_from(d.as_nanos()).ok())
+            .unwrap_or(0)
+    };
+
+    Some(HealthConfig {
+        test: Some(vec!["CMD-SHELL".to_string(), command]),
+        interval: Some(to_nanos(hc.interval())),
+        timeout: Some(to_nanos(hc.timeout())),
+        retries: Some(hc.threshold() as i64),
+        start_period: None,
+        start_interval: None,
+    })
 }
 
 async fn pull_image(
@@ -246,6 +290,7 @@ pub(crate) async fn create_container(
         labels: Some(labels),
         host_config: Some(host_config),
         user: user_config,
+        healthcheck: build_health_config(&deployment.health_checks),
         ..Default::default()
     };
 
@@ -607,5 +652,95 @@ mod tests {
     fn test_extract_digest_none_when_no_at_sign() {
         let repo_digests = Some(vec!["nginx:latest".to_string()]);
         assert_eq!(extract_digest(&repo_digests), None);
+    }
+
+    use crate::models::health_check::{FailureAction, HealthCheck};
+
+    #[test]
+    fn build_health_config_returns_none_when_no_readiness_hc() {
+        let hcs = vec![HealthCheck::Command {
+            command: "echo ok".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: false,
+        }];
+        assert!(build_health_config(&hcs).is_none());
+    }
+
+    #[test]
+    fn build_health_config_returns_none_for_tcp_readiness() {
+        // TCP readiness gates Ring scheduling but does not become a Docker
+        // HEALTHCHECK — Docker's healthcheck takes a shell command only.
+        let hcs = vec![HealthCheck::Tcp {
+            port: 80,
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+        }];
+        assert!(build_health_config(&hcs).is_none());
+    }
+
+    #[test]
+    fn build_health_config_returns_none_for_http_readiness() {
+        let hcs = vec![HealthCheck::Http {
+            url: "http://localhost/health".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+        }];
+        assert!(build_health_config(&hcs).is_none());
+    }
+
+    #[test]
+    fn build_health_config_translates_command_readiness() {
+        let hcs = vec![HealthCheck::Command {
+            command: "test -f /var/run/kemeter/ready".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+        }];
+        let cfg = build_health_config(&hcs).expect("should translate");
+        assert_eq!(
+            cfg.test,
+            Some(vec![
+                "CMD-SHELL".to_string(),
+                "test -f /var/run/kemeter/ready".to_string(),
+            ])
+        );
+        assert_eq!(cfg.interval, Some(10_000_000_000));
+        assert_eq!(cfg.timeout, Some(5_000_000_000));
+        assert_eq!(cfg.retries, Some(3));
+    }
+
+    #[test]
+    fn build_health_config_picks_first_command_readiness_when_mixed() {
+        let hcs = vec![
+            HealthCheck::Tcp {
+                port: 80,
+                interval: "10s".to_string(),
+                timeout: "5s".to_string(),
+                threshold: 3,
+                on_failure: FailureAction::Alert,
+                readiness: true,
+            },
+            HealthCheck::Command {
+                command: "/usr/local/bin/ready.sh".to_string(),
+                interval: "15s".to_string(),
+                timeout: "3s".to_string(),
+                threshold: 5,
+                on_failure: FailureAction::Alert,
+                readiness: true,
+            },
+        ];
+        let cfg = build_health_config(&hcs).expect("should translate the command HC");
+        assert_eq!(cfg.test.as_ref().unwrap()[1], "/usr/local/bin/ready.sh");
     }
 }

--- a/src/runtime/docker/health_check.rs
+++ b/src/runtime/docker/health_check.rs
@@ -13,8 +13,9 @@
 
 use crate::models::health_check::HealthCheckStatus;
 use bollard::Docker;
-use bollard::exec::{CreateExecOptions, StartExecOptions};
+use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
 use bollard::query_parameters::InspectContainerOptions;
+use futures::StreamExt;
 use std::net::IpAddr;
 
 /// Resolve a Docker container's IP from its network settings.
@@ -51,10 +52,12 @@ pub(crate) async fn container_address(docker: &Docker, container_id: &str) -> Op
     None
 }
 
-/// Run a `command` health-check probe via `docker exec`. Success means the
-/// command was successfully started — Docker's exec API doesn't surface the
-/// exit code synchronously, so a successful start is treated as a healthy
-/// probe (matches the historical behavior of this runtime).
+/// Run a `command` health-check probe via `docker exec` and report the
+/// outcome based on the **exit code**: 0 = `Success`, anything else =
+/// `Failed`. The stream returned by `start_exec` must be drained before
+/// `inspect_exec` will report the final exit code — otherwise the docker
+/// daemon may still show `running: true` and the inspect comes back without
+/// `exit_code`.
 pub(crate) async fn execute_command_check(
     docker: &Docker,
     container_id: &str,
@@ -99,13 +102,38 @@ pub(crate) async fn execute_command_check(
         .start_exec(&exec_result.id, Some(start_exec_options))
         .await
     {
-        Ok(_) => (
-            HealthCheckStatus::Success,
-            Some("Command executed successfully".to_string()),
-        ),
+        Ok(StartExecResults::Attached { mut output, .. }) => {
+            // Drain stdout/stderr — without this the daemon doesn't finalize
+            // the exec and inspect_exec returns exit_code=None.
+            while let Some(_chunk) = output.next().await {}
+        }
+        Ok(StartExecResults::Detached) => {}
+        Err(e) => {
+            return (
+                HealthCheckStatus::Failed,
+                Some(format!("Failed to execute command: {}", e)),
+            );
+        }
+    }
+
+    match docker.inspect_exec(&exec_result.id).await {
+        Ok(inspect) => match inspect.exit_code {
+            Some(0) => (
+                HealthCheckStatus::Success,
+                Some("Command exited 0".to_string()),
+            ),
+            Some(code) => (
+                HealthCheckStatus::Failed,
+                Some(format!("Command exited {}", code)),
+            ),
+            None => (
+                HealthCheckStatus::Failed,
+                Some("Command did not finish in time".to_string()),
+            ),
+        },
         Err(e) => (
             HealthCheckStatus::Failed,
-            Some(format!("Failed to execute command: {}", e)),
+            Some(format!("Failed to inspect exec result: {}", e)),
         ),
     }
 }

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -343,6 +343,7 @@ mod tests {
                 timeout: "10s".to_string(),
                 threshold: 3,
                 on_failure: FailureAction::Restart,
+                readiness: false,
             }],
         );
 
@@ -372,6 +373,7 @@ mod tests {
                 timeout: "5s".to_string(),
                 threshold: 1,
                 on_failure: FailureAction::Restart,
+                readiness: false,
             }],
         );
 
@@ -406,6 +408,7 @@ mod tests {
                 timeout: "10s".to_string(),
                 threshold: 3,
                 on_failure: FailureAction::Restart,
+                readiness: false,
             }],
         );
 
@@ -434,6 +437,7 @@ mod tests {
                 timeout: "10s".to_string(),
                 threshold: 3,
                 on_failure: FailureAction::Restart,
+                readiness: false,
             }],
         );
 
@@ -462,6 +466,7 @@ mod tests {
                 timeout: "5s".to_string(),
                 threshold: 3,
                 on_failure: FailureAction::Restart,
+                readiness: false,
             }],
         );
 
@@ -501,6 +506,7 @@ mod tests {
                 timeout: "5s".to_string(),
                 threshold: 1,
                 on_failure: FailureAction::Stop,
+                readiness: false,
             }],
         );
 
@@ -531,6 +537,7 @@ mod tests {
                 timeout: "5s".to_string(),
                 threshold: 1,
                 on_failure: FailureAction::Alert,
+                readiness: false,
             }],
         );
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -266,6 +266,140 @@ async fn cleanup_deleted(pool: &SqlitePool, deleted: Vec<String>) {
     }
 }
 
+/// Anti-flap window: how long all readiness HCs must have been green
+/// before the rolling update is allowed to drain a parent instance.
+/// Mirrors Nomad's `min_healthy_time` default (10s). Hardcoded for now —
+/// expose as a per-deployment field if operators ever need to tune it.
+const MIN_HEALTHY_TIME: Duration = Duration::from_secs(10);
+
+/// True when the child either has no readiness HC at all (legacy behaviour)
+/// or all of its readiness HCs have been green for `MIN_HEALTHY_TIME`.
+async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
+    use crate::models::health_check::{ReadinessDecision, evaluate_readiness};
+
+    let expected = child
+        .health_checks
+        .iter()
+        .filter(|hc| hc.is_readiness())
+        .count();
+
+    if expected == 0 {
+        // No readiness HC declared — legacy "drain on Running" semantics.
+        return true;
+    }
+
+    // We need two things per check_type: (1) the latest status, to detect
+    // Failing / PendingNoResult; (2) the **ready-since** timestamp, i.e. the
+    // first success after the last non-success — anchoring the anti-flap
+    // window to a stable point so the gate actually elapses instead of
+    // being re-armed by every new success.
+    let latest = match health_check_logs::find_latest_by_deployment(pool, child.id.clone()).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(
+                "Failed to load readiness check results for deployment {}: {} — holding rollout",
+                child.id, e
+            );
+            return false;
+        }
+    };
+    let ready_since =
+        match health_check_logs::find_ready_since_by_deployment(pool, child.id.clone()).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                warn!(
+                    "Failed to load ready-since timestamps for deployment {}: {} — holding rollout",
+                    child.id, e
+                );
+                return false;
+            }
+        };
+
+    // Restrict to the check_types that are marked readiness in the manifest.
+    let readiness_types: std::collections::HashSet<&str> = child
+        .health_checks
+        .iter()
+        .filter(|hc| hc.is_readiness())
+        .map(|hc| hc.check_type())
+        .collect();
+
+    let ready_since_by_type: std::collections::HashMap<&str, chrono::DateTime<chrono::Utc>> =
+        ready_since
+            .iter()
+            .filter_map(|r| {
+                chrono::DateTime::parse_from_rfc3339(&r.ready_since)
+                    .ok()
+                    .map(|t| (r.check_type.as_str(), t.with_timezone(&chrono::Utc)))
+            })
+            .collect();
+
+    // We currently identify a HC by its `check_type`. That works as long as
+    // a deployment doesn't declare two HCs of the same type (e.g. two
+    // separate http probes) — the storage layer aggregates results by
+    // check_type, so distinguishing two http checks would need a richer
+    // identifier. Document the limitation; revisit if a real use case lands.
+    let mut filtered: Vec<(
+        crate::models::health_check::HealthCheckStatus,
+        chrono::DateTime<chrono::Utc>,
+    )> = Vec::new();
+    for record in &latest {
+        if !readiness_types.contains(record.check_type.as_str()) {
+            continue;
+        }
+        let status = match record.status.as_str() {
+            "success" => crate::models::health_check::HealthCheckStatus::Success,
+            "timeout" => crate::models::health_check::HealthCheckStatus::Timeout,
+            _ => crate::models::health_check::HealthCheckStatus::Failed,
+        };
+        // For success, anchor the timestamp to ready_since (stable). For
+        // non-success, the timestamp is irrelevant — evaluate_readiness will
+        // short-circuit to Failing.
+        let anchor = if matches!(
+            status,
+            crate::models::health_check::HealthCheckStatus::Success
+        ) {
+            match ready_since_by_type.get(record.check_type.as_str()) {
+                Some(t) => *t,
+                None => continue,
+            }
+        } else {
+            match chrono::DateTime::parse_from_rfc3339(&record.finished_at) {
+                Ok(t) => t.with_timezone(&chrono::Utc),
+                Err(_) => continue,
+            }
+        };
+        filtered.push((status, anchor));
+    }
+
+    let decision = evaluate_readiness(expected, &filtered, chrono::Utc::now(), MIN_HEALTHY_TIME);
+
+    match decision {
+        ReadinessDecision::Ready => true,
+        ReadinessDecision::NotConfigured => true, // expected == 0 case, defensive.
+        ReadinessDecision::PendingNoResult => {
+            debug!(
+                "Rolling update on hold for {}: still waiting for first readiness check result",
+                child.id
+            );
+            false
+        }
+        ReadinessDecision::PendingMinHealthyTime { remaining } => {
+            debug!(
+                "Rolling update on hold for {}: readiness green but need {:?} more in the anti-flap window",
+                child.id, remaining
+            );
+            false
+        }
+        ReadinessDecision::Failing => {
+            debug!(
+                "Rolling update on hold for {}: at least one readiness check is failing",
+                child.id
+            );
+            false
+        }
+    }
+}
+
 /// Handle rolling update coordination for deployments that have a `parent_id`.
 ///
 /// Called after `apply_runtime` + `run_health_checks` for each child deployment.
@@ -309,6 +443,15 @@ async fn handle_rolling_update(
         return;
     }
 
+    // Readiness gate. If the child declares any HC with `readiness: true`,
+    // we hold off on draining the parent until those checks have been
+    // green for at least `min_healthy_time`. Deployments without any
+    // readiness HC keep the legacy behaviour (drain on `Running`) so this
+    // change is fully opt-in for existing manifests.
+    if !is_ready_to_drain(pool, child).await {
+        return;
+    }
+
     // Load the parent deployment.
     let mut parent = match deployments::find(pool, &parent_id).await {
         Ok(Some(d)) => d,
@@ -330,38 +473,9 @@ async fn handle_rolling_update(
     // Refresh parent's live instance list.
     parent.instances = runtime.list_instances(parent.id.clone(), "active").await;
 
-    if parent.instances.is_empty() {
-        // All parent instances are gone — finalize the rollout.
-        info!(
-            "Rolling update complete: parent {} has 0 instances, marking as deleted",
-            parent.id
-        );
-        parent.status = DeploymentStatus::Deleted;
-        if let Err(e) = deployments::update(pool, &parent).await {
-            error!("Failed to mark parent {} as deleted: {}", parent.id, e);
-        }
-        // Parent will be cleaned up in the next cleanup_deleted pass — add it to the list.
-        deleted.push(parent.id.clone());
-
-        child.parent_id = None;
-
-        if let Err(e) = deployment_event::log_event(
-            pool,
-            child.id.clone(),
-            "info",
-            format!(
-                "Rolling update complete: replaced parent deployment {}",
-                parent_id
-            ),
-            "scheduler",
-            Some("RollingUpdateComplete"),
-        )
-        .await
-        {
-            warn!("Failed to log rolling update complete event: {}", e);
-        }
-    } else {
-        // Remove one instance from the parent — one step per scheduler cycle.
+    // Drain one instance per cycle if the parent still has some. If the
+    // remove fails, bail — the next cycle will retry.
+    if !parent.instances.is_empty() {
         let instance_id = parent.instances[0].clone();
         if runtime.remove_instance(instance_id.clone()).await {
             parent.instances.remove(0);
@@ -395,6 +509,40 @@ async fn handle_rolling_update(
         .await
         {
             warn!("Failed to log rolling update step event: {}", e);
+        }
+    }
+
+    // Finalize in the same cycle the last instance was drained: otherwise
+    // the parent's `apply_runtime` on the next cycle would see replicas=1
+    // vs instances=0 and respawn a fresh container, sending us into a
+    // spawn/kill loop that never lets the rollout converge.
+    if parent.instances.is_empty() {
+        info!(
+            "Rolling update complete: parent {} has 0 instances, marking as deleted",
+            parent.id
+        );
+        parent.status = DeploymentStatus::Deleted;
+        if let Err(e) = deployments::update(pool, &parent).await {
+            error!("Failed to mark parent {} as deleted: {}", parent.id, e);
+        }
+        deleted.push(parent.id.clone());
+
+        child.parent_id = None;
+
+        if let Err(e) = deployment_event::log_event(
+            pool,
+            child.id.clone(),
+            "info",
+            format!(
+                "Rolling update complete: replaced parent deployment {}",
+                parent_id
+            ),
+            "scheduler",
+            Some("RollingUpdateComplete"),
+        )
+        .await
+        {
+            warn!("Failed to log rolling update complete event: {}", e);
         }
     }
 }
@@ -735,5 +883,197 @@ pub(crate) async fn schedule(
             duration.as_secs()
         );
         sleep(duration).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::health_check::{FailureAction, HealthCheck};
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn new_test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("Could not create test database pool");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Could not execute database migrations");
+
+        pool
+    }
+
+    fn child_with_health_checks(id: &str, hcs: Vec<HealthCheck>) -> Deployment {
+        Deployment {
+            id: id.to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: None,
+            status: DeploymentStatus::Running,
+            restart_count: 0,
+            namespace: "test".to_string(),
+            name: "child".to_string(),
+            image: "nginx:alpine".to_string(),
+            config: None,
+            runtime: "docker".to_string(),
+            kind: "worker".to_string(),
+            replicas: 1,
+            command: vec![],
+            instances: vec!["instance-1".to_string()],
+            labels: HashMap::new(),
+            environment: HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: hcs,
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: Some("parent-id".to_string()),
+        }
+    }
+
+    /// Insert a health_check row directly so the gate has something to read.
+    /// `seconds_ago` is the offset from now() applied to all timestamps —
+    /// makes the anti-flap window deterministic without sleeping.
+    async fn insert_hc_result(
+        pool: &SqlitePool,
+        deployment_id: &str,
+        check_type: &str,
+        status: &str,
+        seconds_ago: i64,
+    ) {
+        let ts = (chrono::Utc::now() - chrono::Duration::seconds(seconds_ago)).to_rfc3339();
+        sqlx::query(
+            "INSERT INTO health_check (id, deployment_id, check_type, status, message, created_at, started_at, finished_at)
+             VALUES (?, ?, ?, ?, NULL, ?, ?, ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(deployment_id)
+        .bind(check_type)
+        .bind(status)
+        .bind(&ts)
+        .bind(&ts)
+        .bind(&ts)
+        .execute(pool)
+        .await
+        .expect("insert HC result");
+    }
+
+    fn readiness_command(name: &str) -> HealthCheck {
+        let _ = name;
+        HealthCheck::Command {
+            command: "test -f /var/run/kemeter/ready".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+        }
+    }
+
+    fn readiness_tcp() -> HealthCheck {
+        HealthCheck::Tcp {
+            port: 80,
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+        }
+    }
+
+    fn liveness_command() -> HealthCheck {
+        HealthCheck::Command {
+            command: "true".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_allowed_when_no_readiness_hc() {
+        // Backward compat: deployments without any readiness HC keep the
+        // legacy "drain on Running" behaviour.
+        let pool = new_test_pool().await;
+        let child = child_with_health_checks("child-1", vec![liveness_command()]);
+        assert!(is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_blocked_when_readiness_has_no_result_yet() {
+        let pool = new_test_pool().await;
+        let child = child_with_health_checks("child-2", vec![readiness_command("ready")]);
+        // No insert into health_check — no result has been recorded yet.
+        assert!(!is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_blocked_when_readiness_too_recent() {
+        let pool = new_test_pool().await;
+        let child = child_with_health_checks("child-3", vec![readiness_command("ready")]);
+        // Success 5s ago, MIN_HEALTHY_TIME is 10s → not enough.
+        insert_hc_result(&pool, "child-3", "command", "success", 5).await;
+        assert!(!is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_allowed_when_readiness_old_enough() {
+        let pool = new_test_pool().await;
+        let child = child_with_health_checks("child-4", vec![readiness_command("ready")]);
+        // Success 30s ago — well past MIN_HEALTHY_TIME.
+        insert_hc_result(&pool, "child-4", "command", "success", 30).await;
+        assert!(is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_blocked_when_latest_readiness_failed() {
+        let pool = new_test_pool().await;
+        let child = child_with_health_checks("child-5", vec![readiness_command("ready")]);
+        // An old success and a recent failure — gate must read the latest only.
+        insert_hc_result(&pool, "child-5", "command", "success", 60).await;
+        insert_hc_result(&pool, "child-5", "command", "failed", 5).await;
+        assert!(!is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_requires_all_readiness_hcs_to_have_a_result() {
+        let pool = new_test_pool().await;
+        // Two readiness HCs declared (tcp + command) but only one has produced
+        // a result. We must wait until both have at least one entry.
+        let child =
+            child_with_health_checks("child-6", vec![readiness_tcp(), readiness_command("ready")]);
+        insert_hc_result(&pool, "child-6", "command", "success", 30).await;
+        // tcp has no result yet — gate must hold.
+        assert!(!is_ready_to_drain(&pool, &child).await);
+
+        // After both are green and old enough, gate opens.
+        insert_hc_result(&pool, "child-6", "tcp", "success", 30).await;
+        assert!(is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_ignores_non_readiness_hc_results() {
+        // A non-readiness HC must not influence the decision: even if it has
+        // never produced a result, the readiness HC alone gates the drain.
+        let pool = new_test_pool().await;
+        let mut hcs = vec![readiness_command("ready")];
+        hcs.push(HealthCheck::Tcp {
+            port: 80,
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: false, // not a readiness HC
+        });
+        let child = child_with_health_checks("child-7", hcs);
+        insert_hc_result(&pool, "child-7", "command", "success", 30).await;
+        // tcp has no result, but it's not a readiness HC, so gate opens.
+        assert!(is_ready_to_drain(&pool, &child).await);
     }
 }

--- a/tests/e2e/docker/t22_readiness_rolling_update.sh
+++ b/tests/e2e/docker/t22_readiness_rolling_update.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# T22: rolling update gated by readiness health checks.
+#
+# Five scenarios, each isolated, in increasing order of subtlety:
+#   A. A readiness HC of type=command is translated into a Docker
+#      HEALTHCHECK that the proxy can read.
+#   B. Without readiness:true, the legacy "drain on Running" behaviour
+#      is preserved — no regression for existing manifests.
+#   C. With readiness:true and the readiness file *missing* in the new
+#      container, the parent stays alive (no drain).
+#   D. As soon as the file appears in the new container, the gate opens
+#      and the parent gets drained.
+#   E. The Docker container's Health.Status flips to "healthy" once the
+#      readiness command succeeds — that's what makes Traefik route to it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T22: readiness-gated rolling update =="
+
+start_ring
+ring_login
+
+# We need a fixture directory because the test mutates files inside the
+# container at runtime. Building images would be overkill — using docker exec
+# to create/remove the readiness file inside the running container is enough.
+NS="ring-e2e-readiness"
+
+write_fixture() {
+  local file="$1" img="$2" with_readiness="$3"
+  local readiness_block=""
+  if [ "$with_readiness" = "yes" ]; then
+    readiness_block="
+        readiness: true"
+  fi
+  cat > "$file" <<EOF
+deployments:
+  ready-app:
+    name: ready-app
+    namespace: $NS
+    runtime: docker
+    image: $img
+    replicas: 1
+    health_checks:
+      - type: command
+        command: test -f /var/run/kemeter/ready
+        interval: 2s
+        timeout: 1s
+        threshold: 3
+        on_failure: alert$readiness_block
+EOF
+}
+
+# Helper: wait until docker inspect reports a non-empty Healthcheck.Test
+# (means Ring injected our HEALTHCHECK on container creation).
+wait_docker_healthcheck_present() {
+  local deployment_id="$1"
+  local timeout="${2:-20}"
+  for _ in $(seq 1 "$timeout"); do
+    local container_id
+    container_id=$(docker ps -q --filter "label=ring_deployment=$deployment_id" | head -n1)
+    if [ -n "$container_id" ]; then
+      local test_array
+      test_array=$(docker inspect "$container_id" | jq -c '.[0].Config.Healthcheck.Test // []')
+      if [ "$test_array" != "[]" ] && [ "$test_array" != "null" ]; then
+        log "Docker HEALTHCHECK present on $container_id: $test_array"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  fail "Docker HEALTHCHECK never appeared on container of deployment $deployment_id"
+}
+
+# Helper: read Health.Status from docker inspect (starting / healthy /
+# unhealthy / "" if no HC). Returns "" on missing container.
+docker_health_status() {
+  local deployment_id="$1"
+  local container_id
+  container_id=$(docker ps -q --filter "label=ring_deployment=$deployment_id" | head -n1)
+  [ -z "$container_id" ] && { echo ""; return; }
+  docker inspect "$container_id" | jq -r '.[0].State.Health.Status // ""'
+}
+
+wait_docker_health_status() {
+  local deployment_id="$1"
+  local expected="$2"
+  local timeout="${3:-30}"
+  local got=""
+  for _ in $(seq 1 "$timeout"); do
+    got=$(docker_health_status "$deployment_id")
+    if [ "$got" = "$expected" ]; then
+      log "container of $deployment_id reached Health.Status=$expected"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "container of $deployment_id has Health.Status='$got', expected '$expected' (timeout ${timeout}s)"
+}
+
+container_exec() {
+  local deployment_id="$1"; shift
+  local container_id
+  container_id=$(docker ps -q --filter "label=ring_deployment=$deployment_id" | head -n1)
+  [ -z "$container_id" ] && fail "no container for deployment $deployment_id"
+  docker exec "$container_id" "$@"
+}
+
+###############################################################################
+# Scenario A — readiness command HC becomes a Docker HEALTHCHECK.
+###############################################################################
+log "-- Scenario A: command readiness HC translates to Docker HEALTHCHECK"
+
+FIXTURE_A="$RING_TEST_DIR/ready-A.yaml"
+write_fixture "$FIXTURE_A" "nginx:1.25-alpine" yes
+"$RING_BIN" apply --file "$FIXTURE_A"
+wait_deployment_status "$NS" "ready-app" "running" 60
+DEP_A=$(get_deployment_id "$NS" "ready-app")
+[ -z "$DEP_A" ] && fail "no deployment id for scenario A"
+
+wait_docker_healthcheck_present "$DEP_A" 20
+CID_A=$(docker ps -q --filter "label=ring_deployment=$DEP_A" | head -n1)
+HC_TEST=$(docker inspect "$CID_A" | jq -r '.[0].Config.Healthcheck.Test | join(" ")')
+case "$HC_TEST" in
+  *"CMD-SHELL"*"test -f /var/run/kemeter/ready"*) log "HEALTHCHECK content matches expected command" ;;
+  *) fail "unexpected HEALTHCHECK content: $HC_TEST" ;;
+esac
+
+# Scenario E inlined here while we already have the container — the file is
+# missing so health must be "starting" then "unhealthy" (after retries=3).
+# Docker's first probe runs after `interval` so we need at least
+# 3 * 2s = 6s before the verdict drops to unhealthy.
+wait_docker_health_status "$DEP_A" "unhealthy" 30
+
+# Now create the readiness file and watch Docker flip to "healthy".
+mkdir_cmd='mkdir -p /var/run/kemeter && touch /var/run/kemeter/ready'
+container_exec "$DEP_A" sh -c "$mkdir_cmd"
+wait_docker_health_status "$DEP_A" "healthy" 30
+
+"$RING_BIN" deployment delete "$DEP_A"
+wait_docker_container_gone "$DEP_A" 30
+log "Scenario A: PASS"
+
+###############################################################################
+# Scenario B — without readiness:true, the legacy behaviour (no gate).
+###############################################################################
+log "-- Scenario B: without readiness:true, rolling drains as soon as Running"
+
+FIXTURE_B1="$RING_TEST_DIR/ready-B1.yaml"
+write_fixture "$FIXTURE_B1" "nginx:1.25-alpine" no
+"$RING_BIN" apply --file "$FIXTURE_B1"
+wait_deployment_status "$NS" "ready-app" "running" 60
+B_PARENT=$(get_deployment_id "$NS" "ready-app")
+PARENT_CID_B=$(docker ps -q --filter "label=ring_deployment=$B_PARENT" | head -n1)
+
+# Apply v2 (different image so we can tell them apart).
+FIXTURE_B2="$RING_TEST_DIR/ready-B2.yaml"
+write_fixture "$FIXTURE_B2" "nginx:1.26-alpine" no
+"$RING_BIN" apply --file "$FIXTURE_B2"
+wait_deployment_by_image "$NS" "ready-app" "nginx:1.26-alpine" "running" 90
+B_CHILD=$(get_deployment_id_by_image "$NS" "ready-app" "nginx:1.26-alpine")
+[ "$B_PARENT" = "$B_CHILD" ] && fail "scenario B: parent and child share id"
+
+# Without readiness, drain happens shortly after child becomes Running. Allow
+# up to 60s for the scheduler to converge.
+wait_docker_container_gone "$B_PARENT" 60
+log "Scenario B: parent drained without readiness — legacy behaviour preserved"
+[ -n "$PARENT_CID_B" ] || true # silence unused
+
+"$RING_BIN" deployment delete "$B_CHILD"
+wait_docker_container_gone "$B_CHILD" 30
+log "Scenario B: PASS"
+
+###############################################################################
+# Scenario C — readiness:true + readiness file missing → parent stays alive.
+###############################################################################
+log "-- Scenario C: readiness HC failing → parent NOT drained"
+
+FIXTURE_C1="$RING_TEST_DIR/ready-C1.yaml"
+write_fixture "$FIXTURE_C1" "nginx:1.25-alpine" yes
+"$RING_BIN" apply --file "$FIXTURE_C1"
+wait_deployment_status "$NS" "ready-app" "running" 60
+C_PARENT=$(get_deployment_id "$NS" "ready-app")
+
+# Mark the parent as "ready" so it stays in the active set with a healthy
+# Docker status — this is the realistic state when an upgrade happens.
+container_exec "$C_PARENT" sh -c "$mkdir_cmd"
+wait_docker_health_status "$C_PARENT" "healthy" 30
+
+# Apply v2 with readiness:true. The new container's readiness file is
+# absent, so /var/run/kemeter/ready does NOT exist — the gate must block
+# the drain.
+FIXTURE_C2="$RING_TEST_DIR/ready-C2.yaml"
+write_fixture "$FIXTURE_C2" "nginx:1.26-alpine" yes
+"$RING_BIN" apply --file "$FIXTURE_C2"
+wait_deployment_by_image "$NS" "ready-app" "nginx:1.26-alpine" "running" 90
+C_CHILD=$(get_deployment_id_by_image "$NS" "ready-app" "nginx:1.26-alpine")
+
+# Sit and watch for 30s. The parent must still have its container at the end.
+log "watching for 30s — parent container must stay alive while child is not ready"
+for i in $(seq 1 30); do
+  count=$(docker ps -q --filter "label=ring_deployment=$C_PARENT" | wc -l | tr -d ' ')
+  if [ "$count" -eq 0 ]; then
+    fail "scenario C: parent $C_PARENT was drained at second $i — readiness gate did not hold"
+  fi
+  sleep 1
+done
+log "Scenario C: parent survived 30s of un-ready child — gate held"
+
+###############################################################################
+# Scenario D — flip the readiness file on, parent gets drained.
+###############################################################################
+log "-- Scenario D: readiness file appears → parent IS drained"
+
+container_exec "$C_CHILD" sh -c "$mkdir_cmd"
+
+# Once the child reports healthy, the next scheduler cycle should drain the
+# parent. MIN_HEALTHY_TIME is 10s, plus one or two scheduler ticks.
+wait_docker_container_gone "$C_PARENT" 60
+log "Scenario D: parent drained once child became ready"
+
+"$RING_BIN" deployment delete "$C_CHILD"
+wait_docker_container_gone "$C_CHILD" 30
+log "Scenarios C+D: PASS"
+
+log "== T22: PASS =="


### PR DESCRIPTION
## Summary

Adds an opt-in `readiness: true` flag on health checks that gates the rolling-update drain on **real application readiness**, not on the bare "container Running" signal. Inspired by Kubernetes `readinessProbe` + Nomad `min_healthy_time`, but kept minimal: one flag, one constant, no breaking change for existing manifests.

The flag has two effects:

1. **Ring scheduler-side gate.** Before draining a parent instance, Ring requires every readiness HC of the child to have at least one `success` result that has stayed green for ≥10s (anti-flap window, mirrors Nomad's default). Any failing readiness check vetoes the drain. Without `readiness: true`, the legacy "drain on Running" behaviour is preserved — fully backward-compatible.

2. **Docker `HEALTHCHECK` translation (command only).** A `command` readiness HC is also written into the container's native Docker HEALTHCHECK, so proxies that read Docker labels (Traefik, Sozune, …) gate traffic on `Status: healthy` automatically. `tcp` and `http` readiness HCs are honoured by the Ring scheduler but not propagated to Docker — there's no native equivalent. Documented as a limitation; users can wrap probes in `curl`/`nc` shell commands if they need proxy-aware HTTP/TCP readiness.

## Behaviour matrix

| Check | Ring drain gate | Docker HEALTHCHECK |
|---|---|---|
| `command` + `readiness: true` | ✅ | ✅ |
| `tcp` / `http` + `readiness: true` | ✅ | ❌ (no native Docker probe) |
| any without `readiness: true` | ❌ (legacy) | ❌ |

## Bundled fixes uncovered while writing the e2e

The e2e exposed four bugs (one new to this PR, three preexisting on main that this PR is the first to actually exercise). All fixed in the same commit:

1. **CLI `apply` was stripping the `readiness` flag.** `src/commands/apply.rs` defined its own `HealthCheck` enum without the field, so the YAML was parsed then re-serialised to JSON without `readiness: true`. The server then defaulted it to `false` and the gate never triggered. Added `#[serde(default)] readiness: bool` on the three variants.

2. **Rolling update spawn/kill loop.** `handle_rolling_update` removed one parent instance per cycle but only marked the parent `Deleted` on the **next** cycle. In between, `apply_runtime` saw `replicas=1 / instances=0` and respawned a fresh container — straight into a kill/respawn loop that never converged. Restructured to drain and finalise in the same cycle.

3. **Anti-flap window never elapsed.** `evaluate_readiness` anchored the timer on `max(finished_at)` across success results, so every new probe slid the anchor forward to "now" and the 10s window was perpetually re-armed. Added `find_ready_since_by_deployment` which returns, per check_type, the first success **after the last failure** (or first success ever). The scheduler now feeds this stable anchor to `evaluate_readiness`.

4. **Docker `command` HC ignored the exit code.** `execute_command_check` returned `Success` as long as `docker exec` started — `test -f /no/file` exited 1 but reported healthy. Drain the exec stream then call `inspect_exec` to read `exit_code`: 0 = Success, anything else = Failed. (Cloud Hypervisor command HCs are not implemented yet; out of scope.)

## Tests (266 passed, was 235, +31)

- **8 unit tests** on `evaluate_readiness` (pure function, exhaustive decision table: not configured / pending no result / pending min healthy time / failing / ready / clock-skew / zero anti-flap).
- **5 unit tests** on `build_health_config` (no readiness / TCP readiness skipped / HTTP readiness skipped / command readiness translated / mixed list picks first command).
- **7 integration tests** on `is_ready_to_drain` with a real sqlx pool, real `health_check` rows, deterministic timestamps via `seconds_ago` offsets — no `sleep`.
- **1 E2E** (`tests/e2e/docker/t22_readiness_rolling_update.sh`) exercising the full system: HEALTHCHECK injection, `Status: starting → unhealthy → healthy` transitions, legacy behaviour preservation (no readiness → fast drain), readiness blocking the drain when the file is missing, drain progressing once `/var/run/kemeter/ready` appears.

All tests deterministic — no real sleeping.

## Doc

`documentation/guides/health-checks.md`:
- New "Readiness gate" subsection under "Rolling updates"
- New "Proxy integration (Traefik / Sozune)" subsection with the behaviour matrix
- New recipe "Zero-downtime rolling update for a slow-booting service"
- Updated rolling-update flow text to point at the readiness gate

## Test plan

- [x] `cargo test --bin ring` — **266 passed**
- [x] `cargo fmt --check` — clean
- [x] `cargo build --release` — clean
- [x] Rebased on latest `main` (7f7f478) — no conflicts
- [x] `tests/e2e/docker/t22_readiness_rolling_update.sh` against a real Docker host — **A + B + C + D PASS**
  - A: Docker HEALTHCHECK injection from `command` readiness HC + `Status: starting → unhealthy → healthy`
  - B: legacy fast-drain preserved when no readiness HC
  - C: parent survives 30s of un-ready child (gate holds)
  - D: parent drained once readiness file appears (gate opens after anti-flap window)