### PR TITLE
fix(ch): reject host port conflicts before boot like docker compose

### DIFF
--- a/documentation/runtimes/cloud-hypervisor.md
+++ b/documentation/runtimes/cloud-hypervisor.md
@@ -368,9 +368,18 @@ Why a userspace proxy and not iptables? `socat` runs without extra capabilities,
 
 Each `socat` lives as long as its VM. On `deployment delete` (or scaledown / rolling update / crashloop eviction), Ring sends SIGKILL to the matching socat processes and frees the listening ports. CH itself owns the tap device and removes it on VM shutdown.
 
+### Port conflict handling
+
+Before booting a VM, Ring tries to bind every `published` port on `0.0.0.0`. If a port is already held by another process, the VM **is not started**: the deployment receives a `PortAllocationFailed` event and is retried by the scheduler (the conflicting process might release the port). After `MAX_RESTART_COUNT` failed attempts the deployment lands in `CrashLoopBackOff`. This mirrors docker compose's "port is already allocated" rejection and replaces the previous silent failure where `socat` exited and the VM stayed up with an unreachable port.
+
+```bash
+# Inspect what happened:
+ring deployment events <id> --level error
+# → PortAllocationFailed: port 8080 is already allocated
+```
+
 ### Limitations
 
-- **No automatic conflict detection** — if `published` is already bound on the host, `socat` fails to start and the port silently does not become available; the VM still boots. Inspect `ring deployment events` if a port doesn't respond.
 - **TCP only** — `socat`'s configuration is `TCP4-LISTEN`/`TCP4`. UDP forwarding requires a separate config and is not wired up yet.
 - **No bandwidth shaping or connection limits** — the forwarder is permissive by design.
 

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -341,6 +341,19 @@ impl CloudHypervisorLifecycle {
             return Err(RuntimeError::ImageNotFound(deployment.image.clone()));
         }
 
+        // Pre-check every published port before doing any expensive work
+        // (image copy, virtiofsd spawn, VM boot). Mirrors docker compose's
+        // "port is already allocated" rejection: if the host can't bind the
+        // port now, the VM is doomed to be unreachable on it. Failing here
+        // means the scheduler increments restart_count and eventually
+        // surfaces a CrashLoopBackOff with a clear PortAllocationFailed
+        // event in the deployment history.
+        for p in &deployment.ports {
+            if !port_forwarder::host_port_available(p.published) {
+                return Err(RuntimeError::PortAlreadyInUse(p.published));
+            }
+        }
+
         let instance_image = self.instance_image_path(instance_id);
         if !instance_image.exists() {
             let output = Command::new("cp")
@@ -632,20 +645,20 @@ impl CloudHypervisorLifecycle {
         }
 
         // Spawn one socat per declared port now that the guest IP is reachable
-        // (cloud-init has had time to bring eth0 up). We don't fail the boot
-        // if a port can't be forwarded — the VM is up; the caller can see
-        // the missing port in `ring deployment events` if we emit one. For
-        // now a warn! is enough to keep the scheduler from flapping.
+        // (cloud-init has had time to bring eth0 up). The host-port
+        // availability was pre-checked before VM boot, but a race with an
+        // unrelated process binding the port in the meantime is still
+        // possible — in that case we tear the VM down rather than leave it
+        // running with a black-hole port. `forwarders` is a local owned
+        // Vec; on early return its Drop kills any socat we already spawned.
         if let Some(net) = &net_alloc {
             let mut forwarders = Vec::with_capacity(deployment.ports.len());
             for p in &deployment.ports {
                 match port_forwarder::spawn_forwarder(&net.guest_ip, p.published, p.target).await {
                     Ok(fw) => forwarders.push(fw),
                     Err(e) => {
-                        warn!(
-                            "Failed to publish port {}->{}:{} for VM {}: {}",
-                            p.published, net.guest_ip, p.target, instance_id, e
-                        );
+                        self.stop_vm(instance_id).await;
+                        return Err(e);
                     }
                 }
             }
@@ -836,6 +849,10 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
                         RuntimeError::ImageNotFound(_) => {
                             (Some(DeploymentStatus::ImagePullBackOff), "ImageNotFound")
                         }
+                        // Port conflict is transient (the port might free up)
+                        // but worth surfacing distinctly so the user can tell
+                        // it apart from a generic VM start failure.
+                        RuntimeError::PortAlreadyInUse(_) => (None, "PortAllocationFailed"),
                         _ => (None, "VmStartFailed"),
                     };
 

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -93,6 +93,14 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
             "VmStartFailed",
             format!("VM start failed: {}", msg),
         ),
+        // The CH runtime emits this; the Docker runtime doesn't (the daemon
+        // rejects port conflicts itself through InstanceCreationFailed). The
+        // arm exists to keep the match exhaustive over the shared enum.
+        RuntimeError::PortAlreadyInUse(port) => (
+            DeploymentStatus::Error,
+            "PortAllocationFailed",
+            format!("Port {} is already allocated", port),
+        ),
         RuntimeError::Io(e) => (
             DeploymentStatus::FileSystemError,
             "FileSystemError",

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -24,6 +24,12 @@ pub enum RuntimeError {
     /// access, transient API socket error). Worth retrying.
     #[error("VM start failed: {0}")]
     VmStartFailed(String),
+    /// A published host port is already bound by another process. Matches
+    /// the Docker daemon's "port is already allocated" rejection: surface the
+    /// conflict to the user immediately instead of booting a VM whose ports
+    /// would silently never be reachable.
+    #[error("port {0} is already allocated")]
+    PortAlreadyInUse(u16),
     #[error("runtime error: {0}")]
     Other(String),
     #[error(transparent)]

--- a/src/runtime/port_forwarder.rs
+++ b/src/runtime/port_forwarder.rs
@@ -20,11 +20,23 @@
 //! rules; documented in ROADMAP.
 
 use crate::runtime::error::RuntimeError;
+use std::net::TcpListener;
 use std::process::Stdio;
 use tokio::process::{Child, Command};
 
+/// True when the host can currently bind `0.0.0.0:<port>`. We bind then drop
+/// immediately — `socat` re-binds milliseconds later thanks to `SO_REUSEADDR`.
+/// The window between drop and re-bind is the same race docker's daemon
+/// itself has when checking port availability, and it's harmless: if someone
+/// snatches the port in between, the socat process exits and the caller
+/// already has a clear "port allocated" path to fall back to.
+pub(crate) fn host_port_available(port: u16) -> bool {
+    TcpListener::bind(("0.0.0.0", port)).is_ok()
+}
+
 /// One running `socat` instance forwarding `published_port` on the host to
 /// `<guest_ip>:target_port` inside the VM. Dropping it kills the daemon.
+#[derive(Debug)]
 pub(crate) struct PortForwarder {
     pub published_port: u16,
     pub target_port: u16,
@@ -47,6 +59,14 @@ pub(crate) async fn spawn_forwarder(
     published_port: u16,
     target_port: u16,
 ) -> Result<PortForwarder, RuntimeError> {
+    // Match docker compose's contract: refuse to start the workload when a
+    // requested host port is already bound. Without this pre-check, socat
+    // would silently exit after `Bind: Address already in use`, the VM
+    // would still boot, and the port would be a black hole.
+    if !host_port_available(published_port) {
+        return Err(RuntimeError::PortAlreadyInUse(published_port));
+    }
+
     // -d -d gives info-level diagnostics to stderr (handy when this fails
     // because the host port is already bound). `reuseaddr` lets us restart
     // a forwarder fast across deployment recreations without TIME_WAIT.
@@ -155,5 +175,24 @@ mod tests {
         assert_eq!(fw.published_port, host_port);
         assert_eq!(fw.target_port, 5432);
         drop(fw);
+    }
+
+    #[tokio::test]
+    async fn spawn_forwarder_rejects_a_port_already_in_use() {
+        // We do not need socat for this — the pre-check rejects before any
+        // process is spawned. Skipping when socat is absent would hide a
+        // regression that only surfaces in environments where socat exists.
+        let host_port = pick_free_port();
+        let _holder = TcpListener::bind(format!("0.0.0.0:{}", host_port))
+            .expect("test setup: holder must bind the port");
+
+        let err = spawn_forwarder("10.0.0.1", host_port, 5432)
+            .await
+            .expect_err("spawn_forwarder should refuse a bound port");
+
+        match err {
+            RuntimeError::PortAlreadyInUse(p) => assert_eq!(p, host_port),
+            other => panic!("expected PortAlreadyInUse, got {:?}", other),
+        }
     }
 }

--- a/tests/e2e/cloud-hypervisor/t20_port_conflict.sh
+++ b/tests/e2e/cloud-hypervisor/t20_port_conflict.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# T20-CH: a CH deployment that asks for a host port already bound by
+# another process must fail to start — matching docker compose's
+# "port is already allocated" contract.
+#
+# Without the pre-check, socat would silently die after `Bind: Address
+# already in use`, the VM would still boot, and the host port would be a
+# black hole. The pre-check in `port_forwarder::host_port_available`
+# rejects the boot up front and surfaces a `PortAllocationFailed` event;
+# the scheduler then retries (a port may free up) and falls into
+# `CrashLoopBackOff` after MAX_RESTART_COUNT (5).
+#
+# What we assert:
+#   1. A `PortAllocationFailed` event is emitted within a few scheduler
+#      ticks.
+#   2. The deployment ends up in a terminal state (`crashloopbackoff` or
+#      `error`) once the retries are exhausted.
+#   3. The blocker process never gets dispossessed of its port — i.e. the
+#      pre-check is non-destructive.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T20-CH: port conflict rejected like docker compose =="
+
+setup_ch
+start_ring
+ring_login
+
+# Pick a host port and squat on it for the whole test.
+BLOCKED_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+log "blocking host port $BLOCKED_PORT"
+python3 - <<PY &
+import socket, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", $BLOCKED_PORT))
+s.listen(1)
+time.sleep(600)
+PY
+BLOCKER_PID=$!
+# Ensure the blocker dies even on early failure paths.
+trap 'kill $BLOCKER_PID 2>/dev/null || true; cleanup_ring' EXIT
+
+# Wait until the blocker has actually bound the port (otherwise the VM
+# boot would race with the listener spinning up and produce a false PASS).
+for _ in $(seq 1 20); do
+  if ! python3 -c "import socket; s=socket.socket(); s.bind(('0.0.0.0', $BLOCKED_PORT))" 2>/dev/null; then
+    log "blocker is holding port $BLOCKED_PORT"
+    break
+  fi
+  sleep 0.2
+done
+
+FIXTURE="$RING_TEST_DIR/port-conflict.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  port-conflict:
+    name: port-conflict
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    ports:
+      - { published: $BLOCKED_PORT, target: 80 }
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# Wait for the deployment to appear so we have its id.
+DEP_ID=""
+for _ in $(seq 1 30); do
+  DEP_ID=$(get_deployment_id "ring-e2e" "port-conflict" || true)
+  [ -n "$DEP_ID" ] && break
+  sleep 1
+done
+[ -z "$DEP_ID" ] && fail "deployment row never appeared"
+log "deployment id: $DEP_ID"
+
+# === 1) PortAllocationFailed event surfaces ===
+TOKEN=$(jq -r '.default.token' "$RING_CONFIG_DIR/auth.json")
+log "waiting for PortAllocationFailed event..."
+EVENTS_RAW=""
+for _ in $(seq 1 60); do
+  EVENTS_RAW=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "${RING_URL}/deployments/${DEP_ID}/events" || true)
+  COUNT=$(echo "$EVENTS_RAW" | jq 'if type == "array" then [.[] | select(.reason=="PortAllocationFailed")] | length else 0 end' 2>/dev/null || echo 0)
+  [ "${COUNT:-0}" -ge 1 ] && break
+  sleep 1
+done
+if [ "${COUNT:-0}" -lt 1 ]; then
+  echo "[e2e] last events response:" >&2
+  echo "$EVENTS_RAW" | jq . >&2 2>/dev/null || echo "$EVENTS_RAW" >&2
+  fail "no PortAllocationFailed event after 60s — pre-check did not fire or event was misnamed"
+fi
+log "$COUNT PortAllocationFailed event(s) recorded"
+
+# === 2) Deployment lands in a terminal state ===
+# MAX_RESTART_COUNT is 5 and the scheduler tick is 1s in e2e, so 60s is a
+# comfortable upper bound for the deployment to exhaust retries and flip
+# to CrashLoopBackOff. The exact name of the status depends on the
+# rust-side enum; accept any of the known terminal variants.
+log "waiting for deployment to reach a terminal state..."
+TERMINAL=""
+for _ in $(seq 1 120); do
+  TERMINAL=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg id "$DEP_ID" '.[] | select(.id==$id) | .status' \
+    | head -n1)
+  # Lowercase for matching — the API can emit PascalCase
+  # (`CrashLoopBackOff`) or the rust-side debug form depending on the
+  # serializer; comparing case-insensitively keeps the assertion stable.
+  case "$(echo "$TERMINAL" | tr '[:upper:]' '[:lower:]')" in
+    crashloopbackoff|error|failed)
+      log "deployment reached terminal status '$TERMINAL'"
+      break
+      ;;
+  esac
+  sleep 1
+done
+case "$(echo "$TERMINAL" | tr '[:upper:]' '[:lower:]')" in
+  crashloopbackoff|error|failed)
+    ;;
+  *)
+    fail "deployment never reached a terminal state (last status: '$TERMINAL') — retries did not exhaust"
+    ;;
+esac
+
+# === 3) The blocker still owns the port ===
+# If the pre-check used SO_REUSEPORT or otherwise stole the port from the
+# blocker, this test passes only because it ran fast. Verify the blocker
+# is still alive and still bound.
+if ! kill -0 "$BLOCKER_PID" 2>/dev/null; then
+  fail "blocker process exited — pre-check should be non-destructive"
+fi
+if python3 -c "import socket; s=socket.socket(); s.bind(('0.0.0.0', $BLOCKED_PORT))" 2>/dev/null; then
+  fail "port $BLOCKED_PORT is no longer bound by the blocker"
+fi
+log "blocker still holds port $BLOCKED_PORT — pre-check is non-destructive"
+
+"$RING_BIN" deployment delete "$DEP_ID" 2>/dev/null || true
+
+log "== T20-CH: PASS =="


### PR DESCRIPTION
## Summary

Before this PR, deploying a Cloud Hypervisor workload with a `ports:` entry whose `published` was already bound by another process would:

1. Boot the VM successfully.
2. Spawn `socat`, which exits immediately with `bind: Address already in use`.
3. Drop a single `warn!` in the ring log.
4. Leave the deployment in `running`, with the host port behaving as a black hole.

That's the behaviour the doc itself flagged as "no automatic conflict detection — silently does not become available". This PR aligns with **docker compose**: the conflict is detected up front, the VM is not started, and the deployment surfaces a clear `PortAllocationFailed` event before falling into `CrashLoopBackOff`.

## What changes

- **`port_forwarder::host_port_available(port: u16) -> bool`** — new helper that tries `TcpListener::bind` on `0.0.0.0:<port>` and immediately drops the listener. `spawn_forwarder` calls it first and returns `RuntimeError::PortAlreadyInUse(port)` instead of proceeding.
- **`RuntimeError::PortAlreadyInUse(u16)`** — new typed variant. The Docker `handle_create_error` and CH lifecycle both pattern-match it explicitly so the deployment event carries the dedicated `PortAllocationFailed` reason (CH) or `PortAllocationFailed` reason in the Docker arm (the Docker daemon already rejects port conflicts on its own; the arm is there for exhaustiveness).
- **CH `start_vm_process`** — pre-checks every `deployment.ports[].published` before any expensive work (image copy, virtiofsd spawn, VM boot). Returns `PortAlreadyInUse` early. The post-boot socat spawn path also now stops the VM and propagates the error in the (rare) race where the port gets taken between the pre-check and the actual socat bind.
- The CH error-classification block emits `PortAllocationFailed` as the event reason. Status stays transient (no terminal flip) so the scheduler retries — `MAX_RESTART_COUNT = 5` attempts, then `CrashLoopBackOff`. A user that frees the port within those retries gets a normal boot.
- Pre-check is **non-destructive**: the bind/drop window is the same one Docker uses itself, and `SO_REUSEADDR` lets `socat` re-bind right after. The blocking process never loses its port.

## Doc

`documentation/runtimes/cloud-hypervisor.md` — the "No automatic conflict detection" limitation is replaced by a new "Port conflict handling" section that describes the new behaviour and shows how to inspect the event.

## Tests

- **Unit** (`port_forwarder::tests::spawn_forwarder_rejects_a_port_already_in_use`): binds a free port from the test, hands the number to `spawn_forwarder`, asserts `Err(PortAlreadyInUse)`. Runs even without `socat` installed because the pre-check returns before spawning anything.
- **E2E** (`tests/e2e/cloud-hypervisor/t20_port_conflict.sh`): a Python blocker squats on a random ephemeral port, the test deploys a CH VM that publishes that exact port, and asserts (a) a `PortAllocationFailed` event lands on the deployment within 60 s, (b) the deployment reaches a terminal state (case-insensitive match on `crashloopbackoff` / `error` / `failed`), (c) the blocker process is still alive and still owns the port at the end. Cleans up the blocker on exit via a trap.

## Test plan

- [x] `cargo test --bin ring` — **267 passed** (was 266, +1 for the new port-conflict unit test)
- [x] `cargo fmt --check` — clean
- [x] `cargo build --bin ring` — clean (preexisting dead-code warnings only)
- [x] `bash tests/e2e/cloud-hypervisor/t20_port_conflict.sh` against a real CH host — **PASS** (event recorded, status `CrashLoopBackOff`, blocker still bound)