### PR TITLE
feat(scheduler): per-HC min_healthy_time for readiness anti-flap

### DIFF
--- a/documentation/guides/health-checks.md
+++ b/documentation/guides/health-checks.md
@@ -197,11 +197,34 @@ health_checks:
 Behaviour with at least one `readiness: true` check:
 
 - The child must produce **at least one `success` result** for **every** readiness check before the parent is touched.
-- Each readiness check must remain green for at least **10 seconds** (`min_healthy_time`, hardcoded — anti-flap window borrowed from Nomad).
+- Each readiness check must remain green for at least its **anti-flap window** (`min_healthy_time`, default **10 s**, configurable per check — see below).
 - Any `failed` or `timeout` on a readiness check resets the gate. The parent stays alive.
 - Non-readiness checks keep their existing role (liveness / restart / alert) and don't influence the gate.
 
 If no check is marked `readiness: true`, the legacy "drain on `Running`" behaviour is preserved — existing manifests are unaffected.
+
+#### Tuning the anti-flap window (`min_healthy_time`)
+
+The default 10 s is a sane minimum, but slow-warming services (JVM apps, large in-memory caches, services that prime a hot path before they're really ready) often want a longer window. Override it on a per-check basis:
+
+```yaml
+health_checks:
+  - type: http
+    url: "http://localhost:8080/ready"
+    interval: "5s"
+    timeout: "3s"
+    on_failure: alert
+    readiness: true
+    min_healthy_time: "30s"   # wait for 30 s of consecutive success before draining the parent
+```
+
+Notes:
+
+- The value uses the same syntax as `interval` / `timeout` (`"500ms"`, `"30s"`).
+- It only matters when `readiness: true`. On non-readiness checks the field is parsed but ignored.
+- When several readiness checks declare different `min_healthy_time` values, the scheduler takes the **maximum** — the most-cautious one wins, so the gate honours the slowest probe.
+- An unparseable value is logged at `warn` and the scheduler falls back to the 10 s default; the rollout is not blocked by a typo.
+- The window borrows the name and semantics from Nomad's `min_healthy_time`.
 
 ### Proxy integration (Traefik / Sozune)
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -257,6 +257,8 @@ health_checks:
 | `timeout` | yes | Probe timeout. Only `ms` and `s` suffixes parse. |
 | `threshold` | no (default `3`) | Consecutive failures before `on_failure` triggers. |
 | `on_failure` | yes | `restart` (recreate the instance), `stop` (delete the deployment), or `alert` (log only). |
+| `readiness` | no (default `false`) | When `true`, this check gates rolling updates and (for `command` on Docker) is translated into a native `HEALTHCHECK`. See [health checks → readiness gate](/documentation/guides/health-checks#readiness-gate-readiness-true). |
+| `min_healthy_time` | no (default `10s`) | Anti-flap window for the readiness gate: the check must be green for this long before the parent is drained. Per-check; the scheduler takes the maximum across readiness checks. Ignored when `readiness: false`. Same syntax as `interval` / `timeout`. |
 
 ### Type-specific fields
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -116,6 +116,8 @@ enum HealthCheck {
         on_failure: FailureAction,
         #[serde(default)]
         readiness: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
     Http {
         url: String,
@@ -126,6 +128,8 @@ enum HealthCheck {
         on_failure: FailureAction,
         #[serde(default)]
         readiness: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
     Command {
         command: String,
@@ -136,6 +140,8 @@ enum HealthCheck {
         on_failure: FailureAction,
         #[serde(default)]
         readiness: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
 }
 

--- a/src/models/health_check.rs
+++ b/src/models/health_check.rs
@@ -29,6 +29,13 @@ pub(crate) enum HealthCheck {
         /// Docker equivalent and are documented as Ring-only readiness.
         #[serde(default = "default_readiness")]
         readiness: bool,
+        /// Anti-flap window: the readiness gate requires this check to have
+        /// been green for at least this long before allowing a rolling
+        /// update to drain the parent. Parsed by `parse_duration` (e.g.
+        /// `"10s"`, `"500ms"`). Ignored when `readiness = false`. Defaults
+        /// to the scheduler's built-in window when unset.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
     #[serde(rename = "http")]
     Http {
@@ -40,6 +47,8 @@ pub(crate) enum HealthCheck {
         on_failure: FailureAction,
         #[serde(default = "default_readiness")]
         readiness: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
     #[serde(rename = "command")]
     Command {
@@ -51,6 +60,8 @@ pub(crate) enum HealthCheck {
         on_failure: FailureAction,
         #[serde(default = "default_readiness")]
         readiness: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_healthy_time: Option<String>,
     },
 }
 
@@ -146,6 +157,23 @@ impl HealthCheck {
             HealthCheck::Command { interval, .. } => interval,
         }
     }
+
+    /// Returns the configured anti-flap window for this check, if any.
+    /// Only meaningful when `is_readiness() == true`; the scheduler
+    /// aggregates across all readiness checks by taking the maximum.
+    pub(crate) fn min_healthy_time(&self) -> Option<&str> {
+        match self {
+            HealthCheck::Tcp {
+                min_healthy_time, ..
+            }
+            | HealthCheck::Http {
+                min_healthy_time, ..
+            }
+            | HealthCheck::Command {
+                min_healthy_time, ..
+            } => min_healthy_time.as_deref(),
+        }
+    }
 }
 
 impl Default for HealthCheck {
@@ -157,6 +185,7 @@ impl Default for HealthCheck {
             threshold: 3,
             on_failure: FailureAction::Restart,
             readiness: false,
+            min_healthy_time: None,
         }
     }
 }

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -665,6 +665,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: false,
+            min_healthy_time: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -680,6 +681,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: true,
+            min_healthy_time: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -693,6 +695,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: true,
+            min_healthy_time: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -706,6 +709,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: true,
+            min_healthy_time: None,
         }];
         let cfg = build_health_config(&hcs).expect("should translate");
         assert_eq!(
@@ -730,6 +734,7 @@ mod tests {
                 threshold: 3,
                 on_failure: FailureAction::Alert,
                 readiness: true,
+                min_healthy_time: None,
             },
             HealthCheck::Command {
                 command: "/usr/local/bin/ready.sh".to_string(),
@@ -738,6 +743,7 @@ mod tests {
                 threshold: 5,
                 on_failure: FailureAction::Alert,
                 readiness: true,
+                min_healthy_time: None,
             },
         ];
         let cfg = build_health_config(&hcs).expect("should translate the command HC");

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -344,6 +344,7 @@ mod tests {
                 threshold: 3,
                 on_failure: FailureAction::Restart,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -374,6 +375,7 @@ mod tests {
                 threshold: 1,
                 on_failure: FailureAction::Restart,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -409,6 +411,7 @@ mod tests {
                 threshold: 3,
                 on_failure: FailureAction::Restart,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -438,6 +441,7 @@ mod tests {
                 threshold: 3,
                 on_failure: FailureAction::Restart,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -467,6 +471,7 @@ mod tests {
                 threshold: 3,
                 on_failure: FailureAction::Restart,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -507,6 +512,7 @@ mod tests {
                 threshold: 1,
                 on_failure: FailureAction::Stop,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 
@@ -538,6 +544,7 @@ mod tests {
                 threshold: 1,
                 on_failure: FailureAction::Alert,
                 readiness: false,
+                min_healthy_time: None,
             }],
         );
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -266,14 +266,48 @@ async fn cleanup_deleted(pool: &SqlitePool, deleted: Vec<String>) {
     }
 }
 
-/// Anti-flap window: how long all readiness HCs must have been green
-/// before the rolling update is allowed to drain a parent instance.
-/// Mirrors Nomad's `min_healthy_time` default (10s). Hardcoded for now —
-/// expose as a per-deployment field if operators ever need to tune it.
-const MIN_HEALTHY_TIME: Duration = Duration::from_secs(10);
+/// Built-in anti-flap window when the manifest doesn't override it. Mirrors
+/// Nomad's `min_healthy_time` default. Override per readiness HC via the
+/// `min_healthy_time` field on the check; the scheduler takes the maximum
+/// across readiness checks so the most-cautious wins.
+const DEFAULT_MIN_HEALTHY_TIME: Duration = Duration::from_secs(10);
+
+/// Resolve the anti-flap window for a deployment: take the max of the
+/// per-HC `min_healthy_time` (parsed via `HealthCheck::parse_duration`)
+/// across readiness checks. Falls back to `DEFAULT_MIN_HEALTHY_TIME` when
+/// nothing is set. Malformed values are logged at warn and ignored — the
+/// rollout shouldn't stall just because someone typo'd a duration.
+fn min_healthy_time_for(child: &Deployment) -> Duration {
+    use crate::models::health_check::HealthCheck;
+
+    let mut window = DEFAULT_MIN_HEALTHY_TIME;
+    let mut overridden = false;
+
+    for hc in child.health_checks.iter().filter(|hc| hc.is_readiness()) {
+        if let Some(raw) = hc.min_healthy_time() {
+            match HealthCheck::parse_duration(raw) {
+                Ok(d) => {
+                    if !overridden || d > window {
+                        window = d;
+                    }
+                    overridden = true;
+                }
+                Err(e) => {
+                    warn!(
+                        "Invalid min_healthy_time '{}' on readiness HC for deployment {}: {} — using default",
+                        raw, child.id, e
+                    );
+                }
+            }
+        }
+    }
+
+    window
+}
 
 /// True when the child either has no readiness HC at all (legacy behaviour)
-/// or all of its readiness HCs have been green for `MIN_HEALTHY_TIME`.
+/// or all of its readiness HCs have been green for the configured anti-flap
+/// window.
 async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
     use crate::models::health_check::{ReadinessDecision, evaluate_readiness};
 
@@ -371,7 +405,8 @@ async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
         filtered.push((status, anchor));
     }
 
-    let decision = evaluate_readiness(expected, &filtered, chrono::Utc::now(), MIN_HEALTHY_TIME);
+    let min_healthy_time = min_healthy_time_for(child);
+    let decision = evaluate_readiness(expected, &filtered, chrono::Utc::now(), min_healthy_time);
 
     match decision {
         ReadinessDecision::Ready => true,
@@ -971,6 +1006,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: true,
+            min_healthy_time: None,
         }
     }
 
@@ -982,6 +1018,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: true,
+            min_healthy_time: None,
         }
     }
 
@@ -993,7 +1030,56 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: false,
+            min_healthy_time: None,
         }
+    }
+
+    fn child_with_min_healthy(id: &str, hc_min: Vec<(bool, Option<&str>)>) -> Deployment {
+        let hcs: Vec<HealthCheck> = hc_min
+            .into_iter()
+            .map(|(readiness, raw)| HealthCheck::Tcp {
+                port: 80,
+                interval: "10s".to_string(),
+                timeout: "5s".to_string(),
+                threshold: 3,
+                on_failure: FailureAction::Alert,
+                readiness,
+                min_healthy_time: raw.map(|s| s.to_string()),
+            })
+            .collect();
+        child_with_health_checks(id, hcs)
+    }
+
+    #[test]
+    fn min_healthy_time_default_when_no_override() {
+        let child = child_with_min_healthy("c", vec![(true, None)]);
+        assert_eq!(min_healthy_time_for(&child), DEFAULT_MIN_HEALTHY_TIME);
+    }
+
+    #[test]
+    fn min_healthy_time_uses_per_hc_value() {
+        let child = child_with_min_healthy("c", vec![(true, Some("30s"))]);
+        assert_eq!(min_healthy_time_for(&child), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn min_healthy_time_takes_max_across_readiness_checks() {
+        // Two readiness HCs: 15s and 45s — the most-cautious value wins.
+        let child = child_with_min_healthy("c", vec![(true, Some("15s")), (true, Some("45s"))]);
+        assert_eq!(min_healthy_time_for(&child), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn min_healthy_time_ignores_non_readiness_hcs() {
+        // A non-readiness HC's window must not influence the gate.
+        let child = child_with_min_healthy("c", vec![(false, Some("999s")), (true, Some("20s"))]);
+        assert_eq!(min_healthy_time_for(&child), Duration::from_secs(20));
+    }
+
+    #[test]
+    fn min_healthy_time_falls_back_on_malformed_value() {
+        let child = child_with_min_healthy("c", vec![(true, Some("not-a-duration"))]);
+        assert_eq!(min_healthy_time_for(&child), DEFAULT_MIN_HEALTHY_TIME);
     }
 
     #[tokio::test]
@@ -1028,6 +1114,31 @@ mod tests {
         let child = child_with_health_checks("child-4", vec![readiness_command("ready")]);
         // Success 30s ago — well past MIN_HEALTHY_TIME.
         insert_hc_result(&pool, "child-4", "command", "success", 30).await;
+        assert!(is_ready_to_drain(&pool, &child).await);
+    }
+
+    #[tokio::test]
+    async fn drain_respects_custom_min_healthy_time() {
+        // A 60s anti-flap window on the readiness HC: a 30s-old success is
+        // not enough anymore. The same data would have unblocked drain with
+        // the default 10s window.
+        let pool = new_test_pool().await;
+        let mut hcs = vec![readiness_command("ready")];
+        if let HealthCheck::Command {
+            min_healthy_time, ..
+        } = &mut hcs[0]
+        {
+            *min_healthy_time = Some("60s".to_string());
+        }
+        let child = child_with_health_checks("child-mht", hcs);
+        insert_hc_result(&pool, "child-mht", "command", "success", 30).await;
+        assert!(
+            !is_ready_to_drain(&pool, &child).await,
+            "30s should be too recent for a 60s anti-flap window"
+        );
+
+        // Bump the recorded success to 90s ago — now past the custom window.
+        insert_hc_result(&pool, "child-mht", "command", "success", 90).await;
         assert!(is_ready_to_drain(&pool, &child).await);
     }
 
@@ -1070,6 +1181,7 @@ mod tests {
             threshold: 3,
             on_failure: FailureAction::Alert,
             readiness: false, // not a readiness HC
+            min_healthy_time: None,
         });
         let child = child_with_health_checks("child-7", hcs);
         insert_hc_result(&pool, "child-7", "command", "success", 30).await;


### PR DESCRIPTION
## Summary

- Adds an optional `min_healthy_time` field to each `tcp` / `http` / `command` health check, parsed with the same `parse_duration` helper as `interval` and `timeout` (`\"10s\"`, `\"500ms\"`, …). When the field is omitted the scheduler falls back to the previous 10 s window — no behavior change for existing manifests.
- The readiness gate (`is_ready_to_drain`) now resolves the anti-flap window via `min_healthy_time_for(deployment)`, which takes the **maximum** across readiness checks (most-cautious wins) and logs malformed values at `warn` while keeping the default — a typo cannot block a rollout.
- Manifest reference + health-checks guide document the field with notes on the max-across-checks aggregation, the syntax, and the per-check scope. ROADMAP item ticked.

## Why per-HC and not per-deployment

The other tuning knobs that affect the same gate (`interval`, `timeout`, `threshold`) are already per-HC. Keeping `min_healthy_time` per-HC matches that shape, lets a deployment with both a fast HTTP probe and a slower command readiness probe declare different windows, and the aggregation rule (max) makes the combination predictable.

## Test plan

- [x] \`cargo test --bins\` — 277 / 277 (6 new: aggregation default, per-HC value, max across checks, ignore-non-readiness, malformed fallback, end-to-end drain with custom window)
- [x] \`cargo fmt --all -- --check\`
- [x] \`bash tests/e2e/cloud-hypervisor/t19_readiness_rolling_update.sh\` — scenarios B (legacy fast-drain) and C (gate blocks) still pass with the default window