### PR TITLE
feat(ch): rotate per-VM console logs (size-based)

### DIFF
--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -198,7 +198,21 @@ The readiness gate (`readiness: true`) works exactly as on Docker — the schedu
 
 To get application logs into the stream, redirect them to `/dev/console` from inside the guest (systemd: `StandardOutput=tty TTYPath=/dev/console`).
 
-**Append-only — Ring does not rotate.** For long-running VMs, rotate externally (logrotate) or recreate the deployment to start fresh.
+### Rotation
+
+Ring rotates the console log automatically. A background task sweeps the socket directory every 60 seconds and, for each `<instance>.console.log` whose size has crossed the threshold, shifts the existing backups (`.1` → `.2`, `.2` → `.3`, ...) and renames the live file to `.1`. Anything past the configured backup count is dropped.
+
+The defaults — 10 MiB per file, 3 backups kept — give roughly 40 MiB of history per VM and survive a typical noisy boot without churning. Override them in `config.toml` if you need more or less:
+
+```toml
+[runtime.cloud_hypervisor]
+max_console_log_bytes = 10485760    # 10 MiB; set to 0 to disable rotation
+max_console_log_backups = 3
+```
+
+`ring deployment logs` reads through every backup so `--tail N` keeps working across rotation boundaries. `--follow` attaches to the live file; if a rotation happens during a follow session, the stream resets to the new file (no missed lines, the prior content is already streamed).
+
+Rotated files are cleaned up with the rest of the instance artifacts when a VM stops.
 
 ## Limitations (parity with Docker)
 
@@ -221,7 +235,7 @@ This is the canonical parity table. Other pages link here rather than restate it
 | Environment variables | **Supported** via cloud-init NoCloud (requires `xorriso` + cloud-init in guest) |
 | Volumes (bind / volume / config) | **Supported** via virtio-fs (requires `virtiofsd` + `CONFIG_VIRTIO_FS=y` guest kernel) |
 | Port mapping | **Supported** via `socat` userspace forwarders |
-| Deployment logs | **Supported** via serial console (append-only, no rotation by Ring) |
+| Deployment logs | **Supported** via serial console with size-based rotation (10 MiB × 3 backups by default, configurable) |
 | Deployment metrics | **Partial.** CPU% and memory from `/proc/<vmm-pid>/*`. `network`, `disk_io`, `pids` are zero pending host-side wiring |
 | Runtime event stream | None — CH has no live event stream; crash detection is tick-bound |
 | Container DNS aliases between replicas | Not applicable — no shared bridge, no DNS |

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -62,10 +62,9 @@ pub(crate) async fn execute(_args: &ArgMatches, configuration: Config) {
         ch_runtime_config.socket_dir,
         ch_runtime_config.seccomp,
     );
-    runtimes_map.insert(
-        "cloud-hypervisor".to_string(),
-        Arc::new(CloudHypervisorLifecycle::new(ch_runtime_config)),
-    );
+    let ch_lifecycle = CloudHypervisorLifecycle::new(ch_runtime_config);
+    let _ch_log_rotator = ch_lifecycle.spawn_console_log_rotator();
+    runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
     info!(
         "Registered runtimes: {:?}",
         runtimes_map.keys().collect::<Vec<_>>()

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -64,6 +64,12 @@ pub(crate) struct CloudHypervisorConfig {
     /// (default), `false` or `log`. Set to `false` on hosts where the kernel
     /// uses syscalls not whitelisted by CH (otherwise VMs die with SIGSYS).
     pub(crate) seccomp: Option<String>,
+    /// Maximum size (bytes) for a per-VM console log before rotation kicks
+    /// in. Defaults to 10 MiB. Set to 0 to disable rotation entirely.
+    pub(crate) max_console_log_bytes: Option<u64>,
+    /// How many rotated console log backups to keep alongside the live file
+    /// (`.console.log.1`, `.console.log.2`, ...). Defaults to 3.
+    pub(crate) max_console_log_backups: Option<u32>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]

--- a/src/runtime/cloud_hypervisor/console_logs.rs
+++ b/src/runtime/cloud_hypervisor/console_logs.rs
@@ -19,6 +19,38 @@ use futures::stream::{self, Stream, StreamExt};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, SeekFrom};
+use tracing::{debug, warn};
+
+/// Build the ordered list of files to read for a given live log path: oldest
+/// rotated backup first (`<path>.N`), then `.N-1`, ..., `.1`, then the live
+/// `<path>`. Missing files are skipped silently — rotations may be sparse if
+/// the VM has not produced enough output to fill every slot yet.
+fn rotated_files_in_read_order(path: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    // Discover up to a generous upper bound; in practice the configured
+    // `max_console_log_backups` caps this at 3-10.
+    let mut idx = 1u32;
+    let mut backups: Vec<(u32, PathBuf)> = Vec::new();
+    while idx < 1000 {
+        let candidate = backup_path(path, idx);
+        if !candidate.exists() {
+            break;
+        }
+        backups.push((idx, candidate));
+        idx += 1;
+    }
+    // Sort descending (oldest first when reading: highest index is oldest).
+    backups.sort_by(|a, b| b.0.cmp(&a.0));
+    files.extend(backups.into_iter().map(|(_, p)| p));
+    files.push(path.to_path_buf());
+    files
+}
+
+fn backup_path(path: &Path, idx: u32) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(format!(".{}", idx));
+    PathBuf::from(s)
+}
 
 /// Read the console log for a single instance into a vector of lines.
 ///
@@ -29,16 +61,24 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, SeekFrom};
 /// file mtime relative to "now", with all lines treated as appended at the
 /// same moment for now) is older. Approximate by design — the serial
 /// console has no native timestamps.
+///
+/// Reads through any rotated backups (`<path>.1`, `.2`, ...) so a `--tail N`
+/// that spans a rotation boundary still returns the requested history.
 pub(crate) async fn read_lines(path: &Path, tail: Option<&str>, since: Option<i32>) -> Vec<String> {
-    let bytes = match tokio::fs::read(path).await {
-        Ok(b) => b,
-        Err(_) => return Vec::new(),
-    };
-
-    // The serial console is not guaranteed to be UTF-8 (early kernel output
-    // may carry stray bytes). Lossy conversion keeps us robust.
-    let text = String::from_utf8_lossy(&bytes);
-    let mut lines: Vec<String> = text.lines().map(|s| s.to_string()).collect();
+    let mut lines: Vec<String> = Vec::new();
+    for file in rotated_files_in_read_order(path) {
+        let bytes = match tokio::fs::read(&file).await {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        // The serial console is not guaranteed to be UTF-8 (early kernel output
+        // may carry stray bytes). Lossy conversion keeps us robust.
+        let text = String::from_utf8_lossy(&bytes);
+        lines.extend(text.lines().map(|s| s.to_string()));
+    }
+    if lines.is_empty() && !path.exists() {
+        return Vec::new();
+    }
 
     if let Some(n_str) = tail {
         if n_str != "all"
@@ -170,6 +210,101 @@ pub(crate) async fn stream_lines(
     Box::pin(initial_stream.chain(follow))
 }
 
+/// Rotate `<path>` if it has grown past `max_bytes`.
+///
+/// Shifts `<path>.{N-1}` → `<path>.N`, dropping anything past `max_backups`,
+/// then renames `<path>` to `<path>.1`. Cloud Hypervisor re-creates the live
+/// file on its next write (the VMM holds the file by name, not by inode,
+/// because `serial.mode = "File"` is a path-based config) so this is safe to
+/// call while a VM is running.
+///
+/// No-op when:
+/// - `max_bytes == 0` (rotation disabled by config)
+/// - `<path>` doesn't exist (VM not yet booted, or never produced output)
+/// - `<path>` is at or below the threshold
+pub(crate) async fn rotate_if_needed(path: &Path, max_bytes: u64, max_backups: u32) {
+    if max_bytes == 0 {
+        return;
+    }
+    let size = match tokio::fs::metadata(path).await {
+        Ok(m) => m.len(),
+        Err(_) => return,
+    };
+    if size <= max_bytes {
+        return;
+    }
+
+    // Drop the oldest backup if it would exceed the configured count.
+    if max_backups == 0 {
+        // Just truncate by removing the live file; CH will re-create it.
+        if let Err(e) = tokio::fs::remove_file(path).await {
+            warn!("console log rotate: failed to drop {:?}: {}", path, e);
+        }
+        return;
+    }
+
+    let oldest = backup_path(path, max_backups);
+    if oldest.exists() {
+        if let Err(e) = tokio::fs::remove_file(&oldest).await {
+            warn!(
+                "console log rotate: failed to remove oldest backup {:?}: {}",
+                oldest, e
+            );
+        }
+    }
+
+    // Shift .N-1 → .N down to .1 → .2.
+    for idx in (1..max_backups).rev() {
+        let from = backup_path(path, idx);
+        let to = backup_path(path, idx + 1);
+        if from.exists()
+            && let Err(e) = tokio::fs::rename(&from, &to).await
+        {
+            warn!(
+                "console log rotate: failed to shift {:?} -> {:?}: {}",
+                from, to, e
+            );
+            return;
+        }
+    }
+
+    // Finally, live -> .1.
+    let target = backup_path(path, 1);
+    if let Err(e) = tokio::fs::rename(path, &target).await {
+        warn!(
+            "console log rotate: failed to rotate {:?} -> {:?}: {}",
+            path, target, e
+        );
+        return;
+    }
+    debug!(
+        "console log rotated: {:?} (size {} > {})",
+        path, size, max_bytes
+    );
+}
+
+/// Walk `socket_dir` once and rotate every `*.console.log` that has grown
+/// past the threshold. Called on a 60-second cadence by the rotator task.
+pub(crate) async fn rotate_all_in_dir(dir: &Path, max_bytes: u64, max_backups: u32) {
+    if max_bytes == 0 {
+        return;
+    }
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(".console.log") {
+            continue;
+        }
+        rotate_if_needed(&path, max_bytes, max_backups).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,5 +410,153 @@ mod tests {
 
         drop(s);
         tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_no_op_when_under_threshold() {
+        let path = scratch_file("rot-under");
+        tokio::fs::write(&path, b"small").await.unwrap();
+        rotate_if_needed(&path, 1024, 3).await;
+        assert!(path.exists());
+        assert!(!backup_path(&path, 1).exists());
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_disabled_when_max_bytes_zero() {
+        let path = scratch_file("rot-disabled");
+        tokio::fs::write(&path, b"large-enough-payload")
+            .await
+            .unwrap();
+        rotate_if_needed(&path, 0, 3).await;
+        assert!(path.exists());
+        assert!(!backup_path(&path, 1).exists());
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_shifts_and_caps_backups() {
+        let path = scratch_file("rot-shift");
+        // Seed an existing .1 and .2 to exercise the shift path.
+        tokio::fs::write(&path, b"current-payload-over-threshold")
+            .await
+            .unwrap();
+        tokio::fs::write(backup_path(&path, 1), b"prev-1")
+            .await
+            .unwrap();
+        tokio::fs::write(backup_path(&path, 2), b"prev-2")
+            .await
+            .unwrap();
+        // max_bytes=8 < 30 bytes in `path`, max_backups=2 so .2 must drop.
+        rotate_if_needed(&path, 8, 2).await;
+        // Live file is gone (CH would re-create it on next write).
+        assert!(!path.exists());
+        // Previous .1 → .2, previous .2 dropped.
+        assert_eq!(
+            tokio::fs::read(backup_path(&path, 2)).await.unwrap(),
+            b"prev-1"
+        );
+        // Old live content → .1.
+        assert_eq!(
+            tokio::fs::read(backup_path(&path, 1)).await.unwrap(),
+            b"current-payload-over-threshold"
+        );
+        // .3 must not exist (we capped at 2).
+        assert!(!backup_path(&path, 3).exists());
+
+        tokio::fs::remove_file(backup_path(&path, 1)).await.ok();
+        tokio::fs::remove_file(backup_path(&path, 2)).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_zero_backups_drops_live() {
+        let path = scratch_file("rot-zero-backups");
+        tokio::fs::write(&path, b"payload-over-threshold")
+            .await
+            .unwrap();
+        rotate_if_needed(&path, 4, 0).await;
+        assert!(!path.exists());
+        assert!(!backup_path(&path, 1).exists());
+    }
+
+    #[tokio::test]
+    async fn read_lines_reads_backup_when_live_missing_or_empty() {
+        // Post-rotation: the live file may not yet exist (CH hasn't written
+        // anything new since the rename). `--tail all` must still return the
+        // history that landed in `.1`.
+        let path = scratch_file("post-rotate-missing");
+        tokio::fs::write(backup_path(&path, 1), b"a\nb\nc\nd\ne\n")
+            .await
+            .unwrap();
+        // Don't create `path` itself — simulate the gap before CH writes.
+        let lines = read_lines(&path, Some("all"), None).await;
+        assert_eq!(lines, vec!["a", "b", "c", "d", "e"]);
+        tokio::fs::remove_file(backup_path(&path, 1)).await.ok();
+
+        // Also when the live file exists but is empty (zero bytes).
+        let path2 = scratch_file("post-rotate-empty");
+        tokio::fs::write(backup_path(&path2, 1), b"a\nb\nc\nd\ne\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&path2, b"").await.unwrap();
+        let lines = read_lines(&path2, Some("all"), None).await;
+        assert_eq!(lines, vec!["a", "b", "c", "d", "e"]);
+        tokio::fs::remove_file(&path2).await.ok();
+        tokio::fs::remove_file(backup_path(&path2, 1)).await.ok();
+    }
+
+    #[tokio::test]
+    async fn read_lines_reads_across_backups_in_chronological_order() {
+        let path = scratch_file("read-across");
+        // Oldest content lives in .2, newer in .1, newest in the live file.
+        tokio::fs::write(backup_path(&path, 2), b"old-a\nold-b\n")
+            .await
+            .unwrap();
+        tokio::fs::write(backup_path(&path, 1), b"mid-a\nmid-b\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&path, b"new-a\nnew-b\n").await.unwrap();
+
+        let lines = read_lines(&path, None, None).await;
+        assert_eq!(
+            lines,
+            vec!["old-a", "old-b", "mid-a", "mid-b", "new-a", "new-b"]
+        );
+
+        // tail=3 must pick the last three across the boundary.
+        let tail = read_lines(&path, Some("3"), None).await;
+        assert_eq!(tail, vec!["mid-b", "new-a", "new-b"]);
+
+        tokio::fs::remove_file(&path).await.ok();
+        tokio::fs::remove_file(backup_path(&path, 1)).await.ok();
+        tokio::fs::remove_file(backup_path(&path, 2)).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_all_in_dir_targets_only_console_logs() {
+        let dir = std::env::temp_dir().join(format!(
+            "ring-rot-dir-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let log = dir.join("vm1.console.log");
+        let other = dir.join("vm1.raw");
+        tokio::fs::write(&log, b"big-enough-payload").await.unwrap();
+        tokio::fs::write(&other, b"big-enough-payload")
+            .await
+            .unwrap();
+
+        rotate_all_in_dir(&dir, 4, 1).await;
+
+        assert!(!log.exists(), "console log should have been rotated");
+        assert!(backup_path(&log, 1).exists());
+        assert!(other.exists(), "non-console files must be left alone");
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
     }
 }

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -30,6 +30,11 @@ pub(crate) struct CloudHypervisorRuntimeConfig {
     /// Forwarded to `cloud-hypervisor --seccomp <value>` when set. None means
     /// CH applies its own default (kill on violation).
     pub seccomp: Option<String>,
+    /// Size threshold (bytes) past which the rotation task shifts
+    /// `<id>.console.log` to `.1`, `.1` to `.2`, etc. 0 disables rotation.
+    pub max_console_log_bytes: u64,
+    /// How many rotated backups to keep alongside the live console log.
+    pub max_console_log_backups: u32,
 }
 
 impl Default for CloudHypervisorRuntimeConfig {
@@ -40,6 +45,8 @@ impl Default for CloudHypervisorRuntimeConfig {
             firmware_path: format!("{}/cloud-hypervisor/vmlinux", base_dir),
             socket_dir: format!("{}/cloud-hypervisor/sockets", base_dir),
             seccomp: None,
+            max_console_log_bytes: 10 * 1024 * 1024,
+            max_console_log_backups: 3,
         }
     }
 }
@@ -54,6 +61,12 @@ impl CloudHypervisorRuntimeConfig {
             firmware_path: user.firmware_path.clone().unwrap_or(defaults.firmware_path),
             socket_dir: user.socket_dir.clone().unwrap_or(defaults.socket_dir),
             seccomp: user.seccomp.clone(),
+            max_console_log_bytes: user
+                .max_console_log_bytes
+                .unwrap_or(defaults.max_console_log_bytes),
+            max_console_log_backups: user
+                .max_console_log_backups
+                .unwrap_or(defaults.max_console_log_backups),
         }
     }
 }
@@ -91,6 +104,37 @@ impl CloudHypervisorLifecycle {
             port_forwarders: Mutex::new(HashMap::new()),
             pids: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Spawn a background task that walks the socket directory every 60s and
+    /// rotates any `*.console.log` past the configured size threshold. Returns
+    /// the handle so the caller (typically `ring-server`) can abort it on
+    /// shutdown. No-op (returns a stub task) when rotation is disabled.
+    pub fn spawn_console_log_rotator(&self) -> tokio::task::JoinHandle<()> {
+        let dir = std::path::PathBuf::from(&self.config.socket_dir);
+        let max_bytes = self.config.max_console_log_bytes;
+        let max_backups = self.config.max_console_log_backups;
+        tokio::spawn(async move {
+            if max_bytes == 0 {
+                tracing::info!("CH console log rotation disabled (max_console_log_bytes = 0)");
+                return;
+            }
+            tracing::info!(
+                "CH console log rotator armed: dir={:?} max_bytes={} max_backups={}",
+                dir,
+                max_bytes,
+                max_backups
+            );
+            let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(60));
+            // Skip the initial tick so we don't run a sweep before the
+            // socket_dir has been populated.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                tracing::debug!("CH console log rotator: sweeping {:?}", dir);
+                super::console_logs::rotate_all_in_dir(&dir, max_bytes, max_backups).await;
+            }
+        })
     }
 
     fn instance_share_dir(&self, instance_id: &str) -> PathBuf {
@@ -732,6 +776,19 @@ impl CloudHypervisorLifecycle {
             }
             // Derive the instance_id by stripping the first suffix
             // (`.raw`, `.console.log`, `.shares`, `.vsock`, `.sock`, etc.).
+            // Rotated console logs end in `.console.log.<N>` — strip the
+            // numeric tail before matching.
+            let stripped_rotation = match name.rfind('.') {
+                Some(idx) if name[idx + 1..].chars().all(|c| c.is_ascii_digit()) => {
+                    let head = &name[..idx];
+                    if head.ends_with(".console.log") {
+                        head
+                    } else {
+                        name.as_str()
+                    }
+                }
+                _ => name.as_str(),
+            };
             for suffix in [
                 ".sock",
                 ".raw",
@@ -740,7 +797,7 @@ impl CloudHypervisorLifecycle {
                 ".vsock",
                 ".shares",
             ] {
-                if let Some(id) = name.strip_suffix(suffix) {
+                if let Some(id) = stripped_rotation.strip_suffix(suffix) {
                     seen_ids.insert(id.to_string());
                     break;
                 }
@@ -773,6 +830,22 @@ impl CloudHypervisorLifecycle {
         let console_log = self.console_log_path(instance_id);
         if let Err(e) = tokio::fs::remove_file(&console_log).await {
             debug!("Failed to remove console log {:?}: {}", console_log, e);
+        }
+        // Sweep any rotated backups (`<id>.console.log.1`, `.2`, ...). The
+        // upper bound matches the largest sane `max_console_log_backups`; any
+        // missing index is silently skipped.
+        for idx in 1u32..=1000 {
+            let backup = {
+                let mut s = console_log.as_os_str().to_os_string();
+                s.push(format!(".{}", idx));
+                PathBuf::from(s)
+            };
+            if !backup.exists() {
+                break;
+            }
+            if let Err(e) = tokio::fs::remove_file(&backup).await {
+                debug!("Failed to remove rotated console log {:?}: {}", backup, e);
+            }
         }
 
         let vsock_path =
@@ -1401,6 +1474,8 @@ mod tests {
             firmware_path: "/tmp/fake-fw".to_string(),
             socket_dir: socket_dir.to_string_lossy().into_owned(),
             seccomp: None,
+            max_console_log_bytes: 10 * 1024 * 1024,
+            max_console_log_backups: 3,
         };
         (CloudHypervisorLifecycle::new(cfg), socket_dir)
     }

--- a/tests/e2e/cloud-hypervisor/t22_console_log_rotation.sh
+++ b/tests/e2e/cloud-hypervisor/t22_console_log_rotation.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# T22-CH: the per-VM serial console log must rotate once it crosses the
+# configured size threshold. We point Ring at a 4 KiB limit / 2 backups,
+# boot a VM, wait for the boot output to push the file past 4 KiB, then
+# wait one sweep cycle (60s) and assert:
+#   1. <id>.console.log.1 appears,
+#   2. ring deployment logs still returns the full history (it reads
+#      through the rotated backup),
+#   3. deleting the deployment cleans up both .console.log and its backups.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T22-CH: console log rotation =="
+
+setup_ch
+
+# Append the rotation knobs to the CH config block produced by setup_ch.
+# We want a tiny threshold so a single boot crosses it without waiting
+# for the VM to do anything special.
+RING_EXTRA_CONFIG="${RING_EXTRA_CONFIG}
+max_console_log_bytes = 4096
+max_console_log_backups = 2
+"
+export RING_EXTRA_CONFIG
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/log-rotation-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  log-rotation-vm:
+    name: log-rotation-vm
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "$RING_E2E_CH_IMAGE"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "log-rotation-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "log-rotation-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === wait until the live log crosses the threshold ===
+LOG_FILE=""
+for _ in $(seq 1 60); do
+  LOG_FILE=$(find "$RING_E2E_CH_SOCKET_DIR" -maxdepth 1 -name "ch-*.console.log" 2>/dev/null | head -n1 || true)
+  if [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
+    SIZE=$(stat -c %s "$LOG_FILE")
+    [ "$SIZE" -gt 4096 ] && break
+  fi
+  sleep 1
+done
+[ -z "$LOG_FILE" ] && fail "no console log file appeared"
+SIZE=$(stat -c %s "$LOG_FILE")
+[ "$SIZE" -gt 4096 ] || fail "console log $LOG_FILE did not cross 4 KiB (size=$SIZE)"
+log "console log past threshold: $LOG_FILE ($SIZE bytes)"
+
+# === wait one rotator cycle (60s) ===
+BACKUP="${LOG_FILE}.1"
+log "waiting up to 90s for rotation sweep..."
+ROTATED=0
+for _ in $(seq 1 90); do
+  if [ -f "$BACKUP" ]; then
+    ROTATED=1
+    break
+  fi
+  sleep 1
+done
+[ "$ROTATED" -eq 1 ] || fail "rotation did not produce $BACKUP within 90s"
+log "backup created: $BACKUP ($(stat -c %s "$BACKUP") bytes)"
+
+# === ring deployment logs reads through the backup ===
+# Use a large --tail so the request reaches into the rotated backup. The CLI
+# does not accept "all" (it parses a u64), so we pick a number far above any
+# realistic boot output (>>5000 lines).
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 100000 2>&1 || true)
+LINE_COUNT=$(printf '%s\n' "$LOGS_OUT" | grep -c . || true)
+if [ "$LINE_COUNT" -lt 5 ]; then
+  fail "expected at least 5 lines across live+backup, got $LINE_COUNT"
+fi
+log "ring deployment logs --tail 100000 returned $LINE_COUNT line(s) across backups"
+
+# === delete teardown removes the log AND its backups ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+for _ in $(seq 1 60); do
+  if ! [ -f "$LOG_FILE" ] && ! [ -f "$BACKUP" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -f "$LOG_FILE" ] || [ -f "$BACKUP" ]; then
+  fail "rotated logs still present after delete (live=$LOG_FILE backup=$BACKUP)"
+fi
+log "rotated logs cleaned up"
+
+log "== T22-CH: PASS =="


### PR DESCRIPTION
## Summary

- Adds size-based rotation for Cloud Hypervisor per-VM serial console logs (`<id>.console.log`). Defaults: 10 MiB threshold, 3 backups kept. Configurable via `[runtime.cloud_hypervisor].max_console_log_bytes` / `max_console_log_backups` (set bytes to 0 to disable).
- A background task on `CloudHypervisorLifecycle` sweeps `socket_dir/*.console.log` every 60 s and shifts `.log` → `.log.1` → `.log.2` → ... atomically via `rename`. CH re-creates the live file at the original path on the next write since `serial.mode = "File"` is path-based.
- `read_lines` now aggregates rotated backups in chronological order so `ring deployment logs --tail N` keeps working across rotation boundaries. `scan_instances` and `cleanup_instance_artifacts` were taught about the `.console.log.<N>` suffix.

## Why

Closes the `Append-only — Ring does not rotate` limitation called out in `documentation/how-to/deploy-on-cloud-hypervisor.md`. Long-running VMs with chatty `/dev/console` output (anything redirecting stdout there) no longer grow the host disk indefinitely.

## Test plan

- [x] `cargo test --bin ring 'cloud_hypervisor'` — 52 unit tests pass, including 7 new ones covering rotation no-op / disabled / shift / cap / zero-backups / multi-backup read / dir scoping / post-rotation read with missing live file.
- [x] `tests/e2e/cloud-hypervisor/t22_console_log_rotation.sh` — boots a real VM with a 4 KiB threshold and 2 backups, waits for the sweep, asserts `.console.log.1` appears, asserts `ring deployment logs --tail 100000` returns the history across both files, asserts delete cleans up live + backups.
- [x] Doc updated: new *Rotation* section in `documentation/how-to/deploy-on-cloud-hypervisor.md` + parity table line.