### PR TITLE
feat: support host network mode for docker deployments

### DIFF
--- a/documentation/concepts/namespaces-and-networking.md
+++ b/documentation/concepts/namespaces-and-networking.md
@@ -42,6 +42,19 @@ When `replicas > 1`, every replica shares a network alias equal to the **deploym
 
 The network is **not** removed when the last deployment in a namespace is deleted. `ring namespace prune` doesn't touch it either. Manual cleanup: `docker network prune --filter "name=ring_"`.
 
+### Escape hatch: host network mode
+
+A single deployment can opt out of the per-namespace bridge and run directly on the host's network namespace:
+
+```yaml
+network:
+  mode: host
+```
+
+The container then bypasses the bridge entirely — it sees the host's interfaces, can bind privileged ports without a NAT hop, and observes real client IPs. The trade-off is no network isolation and no `ports:` mapping (the process binds the host directly). Ring restricts host mode to a single replica and rejects deployments that combine it with `ports:`.
+
+This is the right tool for L4/L7 reverse proxies, VPN gateways, mDNS / multicast workloads, and packet-capture sidecars. For everything else, keep the default `bridge`. See [how-to: use host network mode](/documentation/how-to/use-host-network).
+
 ## Cloud Hypervisor: per-VM /30 subnets
 
 The Cloud Hypervisor runtime uses a different model entirely. There is no shared bridge per namespace.

--- a/documentation/how-to/use-host-network.md
+++ b/documentation/how-to/use-host-network.md
@@ -1,0 +1,198 @@
+# Use host network mode
+
+By default Ring attaches every Docker container to a per-namespace bridge network. Some workloads need to bypass that and run directly on the host's network stack — this page covers when, how, and the constraints Ring enforces.
+
+For the underlying model, see [Namespaces and networking](/documentation/concepts/namespaces-and-networking). For the field schema, see [Manifest reference → `network`](/documentation/reference/manifest#network).
+
+## When to use it
+
+Host networking trades isolation for visibility into the host's stack. It is the right choice when the workload needs **any** of:
+
+- To bind privileged ports (80/443) and see real client IPs without a NAT hop — L4/L7 reverse proxies, ingress controllers.
+- The host's network namespace itself — `tcpdump`-style sidecars, eBPF probes, IDS.
+- To manage host-level routing or TUN devices — VPN gateways (WireGuard, Tailscale, OpenVPN).
+- Broadcast / multicast on the host LAN — mDNS responders, Consul gossip, SSDP.
+
+If none of those apply, **keep the default `bridge`**. Host mode bypasses Docker's port mappings and removes container-level network isolation.
+
+## Minimal example — HAProxy on 80/443
+
+```yaml
+deployments:
+  edge-haproxy:
+    name: edge-haproxy
+    namespace: edge
+    runtime: docker
+    image: "haproxy:2.9"
+    replicas: 1
+    network:
+      mode: host
+    volumes:
+      - type: bind
+        source: /etc/haproxy/haproxy.cfg
+        destination: /usr/local/etc/haproxy/haproxy.cfg
+        driver: local
+        permission: ro
+```
+
+Apply it:
+
+```bash
+ring apply -f edge-haproxy.yaml
+```
+
+The container shares the host's network namespace. HAProxy binds 80/443 on the host directly — no `ports:` mapping. Client connections show real source IPs in HAProxy logs.
+
+## Constraints Ring enforces
+
+The API rejects the deployment up front if any of these hold:
+
+| You wrote… | Why Ring rejects it |
+|---|---|
+| `ports:` is non-empty | Host networking bypasses Docker's port bindings — `ports:` would be silently ignored. |
+| `replicas: 2` or more | All replicas would compete for the same host ports. |
+| `runtime: cloud-hypervisor` | Host mode is Docker-only. The CH runtime has its own network model (per-VM /30 subnet under `10.42.0.0/16`). |
+
+The rejection happens at `ring apply` time with a 400 response — no half-deployed state to clean up.
+
+Example rejection:
+
+```text
+$ ring apply -f bad.yaml
+HTTP 400 error: network.mode=host is incompatible with port mappings: host networking bypasses Docker's port bindings, so `ports` would be silently ignored. Remove `ports` and let the container bind directly on the host.
+```
+
+## Common recipes
+
+### Tailscale subnet router
+
+```yaml
+deployments:
+  tailscale:
+    name: tailscale
+    namespace: edge
+    runtime: docker
+    image: "tailscale/tailscale:latest"
+    replicas: 1
+    network:
+      mode: host
+    config:
+      user:
+        privileged: true        # required for /dev/net/tun
+    environment:
+      TS_AUTHKEY:
+        secretRef: "tailscale-authkey"
+      TS_EXTRA_ARGS: "--advertise-routes=10.0.0.0/24"
+    volumes:
+      - type: bind
+        source: /var/lib/tailscale
+        destination: /var/lib/tailscale
+        driver: local
+        permission: rw
+      - type: bind
+        source: /dev/net/tun
+        destination: /dev/net/tun
+        driver: local
+        permission: rw
+```
+
+`privileged: true` is needed for `/dev/net/tun` access. The auth key is stored as a Ring secret — see [how-to: deploy with secrets](/documentation/how-to/deploy-with-secrets).
+
+### mDNS responder
+
+```yaml
+deployments:
+  avahi:
+    name: avahi
+    namespace: edge
+    runtime: docker
+    image: "flungo/avahi:latest"
+    replicas: 1
+    network:
+      mode: host       # required: mDNS uses 224.0.0.251 multicast on the host LAN
+```
+
+Bridge networking would put Avahi on a virtual network that has no path to the LAN's multicast group — clients on the LAN would never see the broadcasts.
+
+### Packet-capture sidecar
+
+```yaml
+deployments:
+  tcpdump:
+    name: tcpdump
+    namespace: observability
+    runtime: docker
+    image: "nicolaka/netshoot:latest"
+    replicas: 1
+    network:
+      mode: host
+    config:
+      user:
+        privileged: true
+    command:
+      - "tcpdump"
+      - "-i"
+      - "any"
+      - "-w"
+      - "/captures/dump.pcap"
+    volumes:
+      - type: bind
+        source: /var/log/captures
+        destination: /captures
+        driver: local
+        permission: rw
+```
+
+## What changes vs. bridge mode
+
+| Aspect | `bridge` (default) | `host` |
+|---|---|---|
+| Network namespace | Per-namespace bridge `ring_{namespace}` | Host's |
+| Port mapping | `ports:` forwarded to Docker `PortBindings` | `ports:` rejected — the process binds the host directly |
+| Service discovery (same namespace) | Docker DNS resolves deployment name | None — use the host's loopback / LAN |
+| Client source IP visibility | NAT'd to bridge gateway | Real client IP |
+| Multicast / broadcast | Trapped on the bridge | Sees host LAN traffic |
+| Replicas | Multiple replicas share the namespace via Docker DNS | One replica per deployment (port conflicts) |
+
+## Health checks
+
+Health checks work as usual, but `localhost` now means **the host**, not the container:
+
+```yaml
+network:
+  mode: host
+health_checks:
+  - type: http
+    url: "http://localhost:8080/health"
+    readiness: true
+    interval: "10s"
+    timeout: "5s"
+    on_failure: restart
+```
+
+The probe runs from the host network stack (same as the workload), so anything the workload bound on the host is reachable on `localhost:<port>`.
+
+## When you also want a reverse proxy in front
+
+A common pattern: the proxy uses host mode (privileged ports, real client IPs), and the backends stay on bridge networking. The proxy reaches backends by their `ring_<namespace>` bridge — but **only if you connect the proxy's container to that bridge yourself**, since host-mode containers don't join Docker networks.
+
+Three workable shapes:
+
+1. **Backends publish on loopback.** Each backend deployment uses `ports: [{ published: 8081, target: 8080 }]`. The host-mode proxy proxies to `127.0.0.1:8081`. Simple, doesn't use Docker DNS.
+2. **Backends behind a non-host proxy.** Run Traefik / Sozune in bridge mode (port 8080 published), and run an HAProxy in host mode that forwards 80/443 → `127.0.0.1:8080`. The host-mode layer is thin; service discovery stays on the bridge.
+3. **Skip the proxy entirely.** If the workload itself terminates 80/443 (caddy, traefik standalone, nginx), put it in host mode and route directly.
+
+See [how-to: expose HTTP traffic](/documentation/how-to/expose-http-traffic) for the Sozune-based variant.
+
+## Limits
+
+- **Docker-only.** The Cloud Hypervisor runtime rejects `network.mode=host` — its network model is different (per-VM /30, no shared bridge).
+- **One replica.** Port conflicts make `replicas > 1` impossible; Ring rejects it at the API.
+- **No isolation.** Host-mode containers can bind to any free port on the host and see all host network traffic. Treat them like a host-level daemon for security purposes.
+
+## See also
+
+- [Manifest reference → `network`](/documentation/reference/manifest#network)
+- [Namespaces and networking](/documentation/concepts/namespaces-and-networking) — bridge / CH models
+- [How-to: isolate namespaces and route traffic](/documentation/how-to/isolate-namespaces-network) — bridge-mode recipes
+- [How-to: expose HTTP traffic](/documentation/how-to/expose-http-traffic) — Sozune in front of backends

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -114,6 +114,7 @@ Once you're past the basics, pick a [how-to guide](#how-to-guides) for the speci
 - [Observe and debug](/documentation/how-to/observe-and-debug)
 - [Isolate namespaces and route traffic](/documentation/how-to/isolate-namespaces-network)
 - [Expose HTTP traffic](/documentation/how-to/expose-http-traffic)
+- [Use host network mode](/documentation/how-to/use-host-network)
 - [Manage users](/documentation/how-to/manage-users)
 - [Run Ring as a service](/documentation/how-to/run-as-service)
 - [Deploy on Cloud Hypervisor](/documentation/how-to/deploy-on-cloud-hypervisor)

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -63,6 +63,7 @@ A map of deployment declarations. The map key is internal — Ring keys the depl
 | `resources` | object | unset | CPU / memory limits and requests. Semantics differ between runtimes. See [resources](#resources). |
 | `health_checks` | object list | `[]` | TCP / HTTP / command health probes. See [health checks](#health-checks). |
 | `config` | object | `{}` | Runtime config: image pull policy, registry credentials. **Docker only** — every field of `config` is silently ignored on the CH runtime, since there is no image to pull. |
+| `network` | object | `{ mode: bridge }` | Network mode. See [network](#network). **Docker only.** |
 
 ## `environment`
 
@@ -165,6 +166,31 @@ ports:
 Ring forwards these to Docker's `HostConfig.PortBindings` (Docker runtime) or to a `socat` forwarder (Cloud Hypervisor runtime). If `published` is already in use on the host, the start fails — the conflict is surfaced as an `error` event on the deployment, not at `ring apply` time.
 
 If you do **not** publish a port, the container is reachable only from inside its namespace. See [how-to: isolate namespaces and route traffic](/documentation/how-to/isolate-namespaces-network).
+
+## `network`
+
+Selects the container's network namespace.
+
+```yaml
+network:
+  mode: host
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `mode` | enum | `bridge` | `bridge` (default) or `host`. |
+
+**`bridge`** — the deployment is attached to a per-namespace bridge network (`ring_{namespace}`). This is the standard Docker behavior and matches what Ring did before this field existed.
+
+**`host`** — the container shares the host's network namespace directly. It can bind to host ports without `ports:` mapping, sees real client IPs, and can use multicast / broadcast. Useful for L4/L7 reverse proxies (HAProxy, Nginx as edge), packet-capture sidecars, VPN gateways (WireGuard, Tailscale), and service-discovery agents (mDNS, Consul gossip).
+
+When `mode: host`, the API rejects the deployment if:
+
+- `ports:` is non-empty — host networking bypasses Docker's port bindings, so the mapping would be silently ignored. Remove `ports:` and let the container bind directly.
+- `replicas: > 1` — all replicas would compete for the same host ports.
+- `runtime: cloud-hypervisor` — host mode is Docker-only. The CH runtime has its own network model.
+
+See [how-to: use host network mode](/documentation/how-to/use-host-network) for the full walk-through.
 
 ## `labels`
 

--- a/migrations/20220101000014_network_mode.sql
+++ b/migrations/20220101000014_network_mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE deployment ADD COLUMN network_mode TEXT DEFAULT NULL;

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -18,7 +18,8 @@ use crate::api::server::Db;
 use crate::models::deployment_event;
 use crate::models::deployments;
 use crate::models::deployments::{
-    DeploymentConfig, DeploymentPort, DeploymentStatus, EnvValue, Resource,
+    DeploymentConfig, DeploymentPort, DeploymentStatus, EnvValue, NetworkConfig, NetworkMode,
+    Resource,
 };
 use crate::models::namespace;
 use crate::models::users::User;
@@ -34,6 +35,38 @@ fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
             "invalid runtime, supported: [docker, cloud-hypervisor]",
         )),
     }
+}
+
+fn validate_network_constraints(input: &DeploymentInput) -> Result<(), String> {
+    let Some(network) = &input.network else {
+        return Ok(());
+    };
+    if !matches!(network.mode, NetworkMode::Host) {
+        return Ok(());
+    }
+
+    if input.runtime != "docker" {
+        return Err(format!(
+            "network.mode=host is only supported on the docker runtime, got '{}'",
+            input.runtime
+        ));
+    }
+
+    if !input.ports.is_empty() {
+        return Err(
+            "network.mode=host is incompatible with port mappings: host networking bypasses Docker's port bindings, so `ports` would be silently ignored. Remove `ports` and let the container bind directly on the host."
+                .to_string(),
+        );
+    }
+
+    if input.replicas > 1 {
+        return Err(format!(
+            "network.mode=host is incompatible with replicas > 1 (got {}): all replicas would compete for the same host ports. Reduce replicas to 1.",
+            input.replicas
+        ));
+    }
+
+    Ok(())
 }
 
 fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
@@ -228,6 +261,8 @@ pub(crate) struct DeploymentInput {
     resources: Option<Resource>,
     #[serde(default)]
     ports: Vec<DeploymentPort>,
+    #[serde(default)]
+    network: Option<NetworkConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -254,6 +289,11 @@ pub(crate) async fn create(
     match input.validate() {
         Ok(()) => {
             if let Err(msg) = validate_runtime_constraints(&input) {
+                let message = Message { message: msg };
+                return (StatusCode::BAD_REQUEST, Json(message)).into_response();
+            }
+
+            if let Err(msg) = validate_network_constraints(&input) {
                 let message = Message { message: msg };
                 return (StatusCode::BAD_REQUEST, Json(message)).into_response();
             }
@@ -409,6 +449,7 @@ pub(crate) async fn create(
                 ports: input.ports,
                 pending_events: vec![],
                 parent_id: rolling_parent_id,
+                network: input.network.clone(),
             };
 
             match deployments::create(&pool, &deployment).await {
@@ -1931,6 +1972,136 @@ mod tests {
         assert_eq!(ports[0]["target"], 80);
         assert_eq!(ports[1]["published"], 3000);
         assert_eq!(ports[1]["target"], 3000);
+    }
+
+    #[tokio::test]
+    async fn create_with_host_network_mode() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "haproxy",
+                "namespace": "edge",
+                "image": "haproxy:2.9",
+                "network": { "mode": "host" }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["network"]["mode"], "host");
+    }
+
+    #[tokio::test]
+    async fn create_host_mode_rejects_ports() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "haproxy",
+                "namespace": "edge",
+                "image": "haproxy:2.9",
+                "network": { "mode": "host" },
+                "ports": [{ "published": 80, "target": 80 }]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+        let body: Message = response.json();
+        assert!(
+            body.message.contains("network.mode=host") && body.message.contains("port"),
+            "unexpected message: {}",
+            body.message
+        );
+    }
+
+    #[tokio::test]
+    async fn create_host_mode_rejects_replicas_above_one() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "haproxy",
+                "namespace": "edge",
+                "image": "haproxy:2.9",
+                "network": { "mode": "host" },
+                "replicas": 2
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+        let body: Message = response.json();
+        assert!(
+            body.message.contains("replicas"),
+            "unexpected message: {}",
+            body.message
+        );
+    }
+
+    #[tokio::test]
+    async fn create_host_mode_rejected_on_cloud_hypervisor() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "cloud-hypervisor",
+                "name": "vm",
+                "namespace": "edge",
+                "image": "/tmp/fake.raw",
+                "network": { "mode": "host" }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+        let body: Message = response.json();
+        assert!(
+            body.message.contains("docker runtime"),
+            "unexpected message: {}",
+            body.message
+        );
+    }
+
+    #[tokio::test]
+    async fn create_with_bridge_network_mode_explicit() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "network": { "mode": "bridge" },
+                "ports": [{ "published": 8080, "target": 80 }],
+                "replicas": 2
+            }))
+            .await;
+
+        // bridge mode is the existing default — ports and replicas remain valid.
+        assert_eq!(response.status_code(), StatusCode::CREATED);
     }
 
     #[tokio::test]

--- a/src/api/dto/deployment.rs
+++ b/src/api/dto/deployment.rs
@@ -1,5 +1,5 @@
 use crate::models::deployments::{
-    Deployment, DeploymentConfig, DeploymentPort, EnvValue, Resource,
+    Deployment, DeploymentConfig, DeploymentPort, EnvValue, NetworkConfig, Resource,
 };
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
@@ -53,6 +53,8 @@ pub(crate) struct DeploymentOutput {
     /// new one is healthy, then the scheduler tears it down.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) network: Option<NetworkConfig>,
 }
 
 impl DeploymentOutput {
@@ -93,6 +95,7 @@ impl DeploymentOutput {
             resources: deployment.resources,
             image_digest: deployment.image_digest,
             parent_id: deployment.parent_id,
+            network: deployment.network,
         }
     }
 }

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -80,6 +80,19 @@ struct Deployment {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     ports: Vec<Port>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    network: Option<NetworkConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct NetworkConfig {
+    #[serde(default = "default_network_mode")]
+    mode: String,
+}
+
+fn default_network_mode() -> String {
+    "bridge".to_string()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -627,6 +640,7 @@ mod tests {
             resources: None,
             health_checks: Vec::new(),
             ports: Vec::new(),
+            network: None,
         };
 
         assert!(deployment.validate().is_ok());
@@ -847,6 +861,7 @@ deployments:
             resources: None,
             health_checks: Vec::new(),
             ports: Vec::new(),
+            network: None,
         };
 
         let mut env_vars = HashMap::new();

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -101,6 +101,41 @@ pub(crate) struct DeploymentPort {
     pub(crate) target: u16,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum NetworkMode {
+    #[default]
+    Bridge,
+    Host,
+}
+
+impl NetworkMode {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bridge => "bridge",
+            Self::Host => "host",
+        }
+    }
+}
+
+impl std::str::FromStr for NetworkMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "bridge" => Ok(Self::Bridge),
+            "host" => Ok(Self::Host),
+            other => Err(format!("Unknown network mode: {}", other)),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub(crate) struct NetworkConfig {
+    #[serde(default)]
+    pub(crate) mode: NetworkMode,
+}
+
 fn default_image_pull_policy() -> String {
     "Always".to_string()
 }
@@ -213,6 +248,8 @@ pub(crate) struct Deployment {
     pub(crate) pending_events: Vec<crate::models::deployment_event::DeploymentEvent>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub(crate) network: Option<NetworkConfig>,
 }
 
 impl Deployment {
@@ -257,6 +294,7 @@ struct DeploymentRow {
     image_digest: Option<String>,
     parent_id: Option<String>,
     ports: Option<String>,
+    network_mode: Option<String>,
 }
 
 fn parse_environment(json_str: &str, deployment_id: &str) -> HashMap<String, EnvValue> {
@@ -340,6 +378,21 @@ impl From<DeploymentRow> for Deployment {
                 .unwrap_or_default(),
             pending_events: vec![],
             parent_id: row.parent_id,
+            network: row.network_mode.as_deref().and_then(|s| {
+                use std::str::FromStr;
+                NetworkMode::from_str(s)
+                    .map(|mode| NetworkConfig { mode })
+                    .map_err(|e| {
+                        log::warn!(
+                            "Failed to parse network_mode '{}' for deployment {}: {}",
+                            s,
+                            id,
+                            e
+                        );
+                        e
+                    })
+                    .ok()
+            }),
         }
     }
 }
@@ -347,7 +400,7 @@ impl From<DeploymentRow> for Deployment {
 const SELECT_COLUMNS: &str = "
     id, created_at, updated_at, status, restart_count,
     namespace, name, image, command, config, runtime, kind,
-    replicas, labels, environment, volumes, health_checks, resources, image_digest, parent_id, ports
+    replicas, labels, environment, volumes, health_checks, resources, image_digest, parent_id, ports, network_mode
 ";
 
 const ALLOWED_FILTER_COLUMNS: &[&str] = &["namespace", "status", "kind"];
@@ -421,11 +474,16 @@ pub(crate) async fn create(
         .map(|r| serde_json::to_string(r).unwrap_or_else(|_| "null".to_string()));
     let ports_json = serde_json::to_string(&deployment.ports).unwrap_or_else(|_| "[]".to_string());
 
+    let network_mode = deployment
+        .network
+        .as_ref()
+        .map(|n| n.mode.as_str().to_string());
+
     sqlx::query(
         "INSERT INTO deployment (
             id, created_at, status, restart_count, namespace, name, image,
-            command, config, runtime, kind, replicas, labels, environment, volumes, health_checks, resources, image_digest, parent_id, ports
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            command, config, runtime, kind, replicas, labels, environment, volumes, health_checks, resources, image_digest, parent_id, ports, network_mode
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .bind(&deployment.id)
     .bind(&deployment.created_at)
@@ -447,6 +505,7 @@ pub(crate) async fn create(
     .bind(&deployment.image_digest)
     .bind(&deployment.parent_id)
     .bind(&ports_json)
+    .bind(&network_mode)
     .execute(pool)
     .await?;
 
@@ -548,5 +607,42 @@ mod tests {
         assert!(parse_memory_string("abc").is_err());
         assert!(parse_memory_string("Mi").is_err());
         assert!(parse_memory_string("").is_err());
+    }
+
+    #[test]
+    fn network_mode_default_is_bridge() {
+        assert_eq!(NetworkMode::default(), NetworkMode::Bridge);
+    }
+
+    #[test]
+    fn network_config_default_mode_is_bridge() {
+        let cfg: NetworkConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.mode, NetworkMode::Bridge);
+    }
+
+    #[test]
+    fn network_config_deserializes_host_mode() {
+        let cfg: NetworkConfig = serde_json::from_str(r#"{"mode":"host"}"#).unwrap();
+        assert_eq!(cfg.mode, NetworkMode::Host);
+    }
+
+    #[test]
+    fn network_config_deserializes_bridge_mode() {
+        let cfg: NetworkConfig = serde_json::from_str(r#"{"mode":"bridge"}"#).unwrap();
+        assert_eq!(cfg.mode, NetworkMode::Bridge);
+    }
+
+    #[test]
+    fn network_mode_rejects_unknown_value() {
+        let parsed: Result<NetworkConfig, _> = serde_json::from_str(r#"{"mode":"macvlan"}"#);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn network_mode_as_str_round_trips() {
+        use std::str::FromStr;
+        for mode in [NetworkMode::Bridge, NetworkMode::Host] {
+            assert_eq!(NetworkMode::from_str(mode.as_str()).unwrap(), mode);
+        }
     }
 }

--- a/src/runtime/cloud_hypervisor/cloud_init.rs
+++ b/src/runtime/cloud_hypervisor/cloud_init.rs
@@ -435,6 +435,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: None,
+            network: None,
         }
     }
 

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -1334,6 +1334,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: None,
+            network: None,
         };
 
         let (vcpus, memory_mb) = parse_resources(&deployment);
@@ -1373,6 +1374,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: None,
+            network: None,
         };
 
         let (vcpus, memory_mb) = parse_resources(&deployment);
@@ -1559,6 +1561,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: None,
+            network: None,
         }
     }
 

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -1,5 +1,7 @@
 use super::{DockerImage, tiny_id};
-use crate::models::deployments::{Deployment, EnvValue, parse_cpu_string, parse_memory_string};
+use crate::models::deployments::{
+    Deployment, EnvValue, NetworkMode, parse_cpu_string, parse_memory_string,
+};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::error::RuntimeError;
 use bollard::{
@@ -204,8 +206,15 @@ pub(crate) async fn create_container(
         deployment.image_digest = digest;
     }
 
+    let use_host_network = matches!(
+        deployment.network.as_ref().map(|n| n.mode),
+        Some(NetworkMode::Host)
+    );
+
     let network_name = format!("ring_{}", deployment.namespace);
-    create_network(docker.clone(), network_name.clone()).await?;
+    if !use_host_network {
+        create_network(docker.clone(), network_name.clone()).await?;
+    }
 
     let temporary_id = tiny_id();
     let container_name = format!(
@@ -257,6 +266,11 @@ pub(crate) async fn create_container(
     let host_config = HostConfig {
         mounts: Some(mounts),
         privileged: privileged_config,
+        network_mode: if use_host_network {
+            Some("host".to_string())
+        } else {
+            None
+        },
         port_bindings: if port_bindings.is_empty() {
             None
         } else {
@@ -303,25 +317,27 @@ pub(crate) async fn create_container(
             debug!("Docker create container {:?}", container.id);
             deployment.instances.push(container.id.to_string());
 
-            let endpoint_config = EndpointSettings {
-                aliases: Some(vec![deployment.name.clone(), container_name.clone()]),
-                ..Default::default()
-            };
+            if !use_host_network {
+                let endpoint_config = EndpointSettings {
+                    aliases: Some(vec![deployment.name.clone(), container_name.clone()]),
+                    ..Default::default()
+                };
 
-            let connect_request = NetworkConnectRequest {
-                container: container.id.clone(),
-                endpoint_config: Some(endpoint_config),
-            };
+                let connect_request = NetworkConnectRequest {
+                    container: container.id.clone(),
+                    endpoint_config: Some(endpoint_config),
+                };
 
-            docker
-                .connect_network(&network_name, connect_request)
-                .await
-                .map_err(|e| {
-                    RuntimeError::InstanceCreationFailed(format!(
-                        "Docker failed to connect to network: {}",
-                        e
-                    ))
-                })?;
+                docker
+                    .connect_network(&network_name, connect_request)
+                    .await
+                    .map_err(|e| {
+                        RuntimeError::InstanceCreationFailed(format!(
+                            "Docker failed to connect to network: {}",
+                            e
+                        ))
+                    })?;
+            }
 
             let start_options = StartContainerOptionsBuilder::new().build();
             docker

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -325,6 +325,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: None,
+            network: None,
         }
     }
 

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -967,6 +967,7 @@ mod tests {
             ports: vec![],
             pending_events: vec![],
             parent_id: Some("parent-id".to_string()),
+            network: None,
         }
     }
 

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -69,6 +69,7 @@ const PAGE_ORDER: Record<string, string[]> = {
     'observe-and-debug',
     'isolate-namespaces-network',
     'expose-http-traffic',
+    'use-host-network',
     'manage-users',
     'run-as-service',
     'deploy-on-cloud-hypervisor',


### PR DESCRIPTION
Closes #75.

## Summary

Adds an optional `network` block on the deployment manifest, letting a Docker deployment opt into Docker's `host` network mode instead of the default per-namespace bridge.

```yaml
deployments:
  edge-haproxy:
    runtime: docker
    image: "haproxy:2.9"
    network:
      mode: host       # default: bridge (current behavior)
```

Unlocks workloads that today can't run through Ring at all: L4/L7 reverse proxies binding 80/443, VPN gateways (WireGuard, Tailscale), mDNS / multicast agents, packet-capture sidecars.

## Behavior

- `bridge` (default): unchanged — container attached to `ring_{namespace}` as before.
- `host`: `HostConfig.NetworkMode = "host"`, `create_network` / `connect_network` skipped.

### Validation (rejected at API, 400)

The API rejects host mode up front when:

| Case | Reason |
|---|---|
| `ports:` non-empty | Host networking bypasses `PortBindings` — would be silently ignored. |
| `replicas > 1` | All replicas would compete for the same host ports. |
| `runtime: cloud-hypervisor` | Docker-only. CH has its own network model. |

Each rejection returns a clear error message in the body, surfaced by `ring apply`.

## Implementation

- **Model** (`src/models/deployments.rs`): `NetworkMode { Bridge, Host }` + `NetworkConfig`. `#[serde(default)]` → existing payloads stay valid.
- **DB migration** (`migrations/20220101000014_network_mode.sql`): single `network_mode TEXT` nullable column (no JSON — only one field for now).
- **Docker runtime** (`src/runtime/docker/container.rs`): branches on `use_host_network` to set `network_mode` and skip the bridge wiring.
- **API + DTO**: `network: Option<NetworkConfig>` plumbed through `DeploymentInput`, `Deployment`, `DeploymentOutput`.
- **CLI** (`src/commands/apply.rs`): forwards the `network` block from YAML.

## Tests

- **Unit** (`src/models/deployments.rs`): default is `Bridge`, serde round-trip, rejection of unknown modes.
- **API** (`src/api/action/deployment/create.rs`):
  - `create_with_host_network_mode` — happy path, 201 + echo `network.mode=host`.
  - `create_host_mode_rejects_ports` — 400 with explanatory message.
  - `create_host_mode_rejects_replicas_above_one` — 400.
  - `create_host_mode_rejected_on_cloud_hypervisor` — 400.
  - `create_with_bridge_network_mode_explicit` — bridge mode with ports + replicas still works (backwards-compat).

Full suite: **288/288 passing**.

## Docs (Diátaxis)

- **Reference** — `documentation/reference/manifest.md`: new `## network` section + table row.
- **How-to** — `documentation/how-to/use-host-network.md`: when to use it, HAProxy example, recipes for Tailscale / mDNS / tcpdump, contrast with bridge mode, integration with a reverse proxy.
- **Concept** — `documentation/concepts/namespaces-and-networking.md`: "Escape hatch" subsection inside the Docker section.
- **Index** — entry added; site nav (`website/src/lib/docs.ts`) updated.