### PR TITLE
feat(logs): classify level from kernel/cloud-init/firmware markers

### DIFF
--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -214,6 +214,16 @@ max_console_log_backups = 3
 
 Rotated files are cleaned up with the rest of the instance artifacts when a VM stops.
 
+### Log levels
+
+Each line is tagged with a best-effort level (`error`, `warning`, `info`, `debug`, `unknown`) when you request the structured API response (`GET /deployments/{id}/logs` returns JSON; the CLI rendering currently shows the message body only). The classifier recognises:
+
+- **Kernel** — the `<N>` syslog priority prefix (`<0>`..`<3>` → error, `<4>` → warning, `<5>`/`<6>` → info, `<7>` → debug) and crash markers (`BUG:`, `Oops:`, `Kernel panic`).
+- **cloud-init / systemd** — uppercase level words (`ERROR`, `CRITICAL`, `WARNING`, `WARN`, `NOTICE`, `INFO`, `DEBUG`) as they appear in the journal stream piped to the console.
+- **Web apps & boot firmware** — bracketed markers in either case (`[error]` / `[ERROR]`, `[warning]` / `[WARN]`, `[notice]` / `[NOTICE]`, `[info]` / `[INFO]`, `[DEBUG]`, `info:`). `hypervisor-fw`'s own boot lines (`[INFO] Page tables setup`) fall under this rule.
+
+Anything that doesn't match falls back to `unknown`.
+
 ## Limitations (parity with Docker)
 
 This is the canonical parity table. Other pages link here rather than restate it.

--- a/src/runtime/lifecycle_trait.rs
+++ b/src/runtime/lifecycle_trait.rs
@@ -20,15 +20,115 @@ pub(crate) struct Log {
     pub(crate) timestamp: Option<String>,
 }
 
+/// Best-effort log level classification. Recognises three families of
+/// conventions that show up in a Ring stream:
+///
+/// 1. **Web app** — nginx/Apache-style bracketed markers (`[error]`,
+///    `[warning]`, `[notice]`, `[info]`, or `info:` prefixes).
+/// 2. **Linux kernel** — the `<N>` syslog priority prefix (0..=3 → error,
+///    4 → warning, 5..=6 → info, 7 → debug) and crash markers (`BUG:`,
+///    `oops:`, `panic:`, `Kernel panic`).
+/// 3. **systemd / cloud-init / generic CLI** — uppercase level words like
+///    `ERROR`, `ERR`, `CRITICAL`, `WARN`, `WARNING`, `NOTICE`, `INFO`,
+///    `DEBUG` as they appear in cloud-init log lines and systemd journal
+///    output piped to the console.
+///
+/// Unrecognised content falls back to `"unknown"`. Match order goes from
+/// the most specific to the most generic so a kernel `<3>` priority
+/// doesn't get demoted to `info` by a stray `INFO` appearing later in the
+/// same line.
 pub(crate) fn classify_log(log: &str) -> String {
+    // Web app conventions (existing behaviour — keep first to preserve
+    // backwards compat with anything that already depended on it).
     if log.contains("[error]") {
-        "error".to_string()
-    } else if log.contains("[warning]") {
-        "warning".to_string()
-    } else if log.contains("[notice]") || log.contains("[info]") || log.contains("info:") {
-        "info".to_string()
+        return "error".to_string();
+    }
+    if log.contains("[warning]") {
+        return "warning".to_string();
+    }
+    if log.contains("[notice]") || log.contains("[info]") || log.contains("info:") {
+        return "info".to_string();
+    }
+
+    // Kernel crash markers are unambiguous — match before generic words.
+    if log.contains("Kernel panic")
+        || log.contains("BUG:")
+        || log.contains("Oops:")
+        || log.contains("oops:")
+        || log.contains("panic:")
+    {
+        return "error".to_string();
+    }
+
+    // Kernel syslog priority prefix `<N>` at the start of the line (or after
+    // a leading timestamp like `[    0.123456] <3>...`). Priority 0-3 maps
+    // to error, 4 to warning, 5-6 to info, 7 to debug — matches RFC 5424.
+    if let Some(level) = parse_syslog_priority(log) {
+        return level.to_string();
+    }
+
+    // Bracketed uppercase markers (e.g. `hypervisor-fw` boot log uses
+    // `[INFO]`, `[WARN]`, `[ERROR]`).
+    if log.contains("[ERROR]") || log.contains("[CRITICAL]") {
+        return "error".to_string();
+    }
+    if log.contains("[WARNING]") || log.contains("[WARN]") {
+        return "warning".to_string();
+    }
+    if log.contains("[NOTICE]") || log.contains("[INFO]") {
+        return "info".to_string();
+    }
+    if log.contains("[DEBUG]") {
+        return "debug".to_string();
+    }
+
+    // systemd / cloud-init / generic uppercase markers. Word-boundary check
+    // by surrounding spaces/punctuation so `INFORMATION` doesn't match `INFO`.
+    for (needle, lvl) in [
+        ("ERROR", "error"),
+        ("CRITICAL", "error"),
+        (" ERR ", "error"),
+        ("WARNING", "warning"),
+        (" WARN ", "warning"),
+        ("NOTICE", "info"),
+        (" INFO ", "info"),
+        ("INFO:", "info"),
+        (" DEBUG ", "debug"),
+        ("DEBUG:", "debug"),
+    ] {
+        if log.contains(needle) {
+            return lvl.to_string();
+        }
+    }
+
+    "unknown".to_string()
+}
+
+/// Map the leading `<N>` syslog priority of a kernel/systemd line to a
+/// Ring level. Tolerates an optional leading kernel timestamp `[<secs>]`.
+fn parse_syslog_priority(log: &str) -> Option<&'static str> {
+    let trimmed = log.trim_start();
+    // Optional `[ time ] ` prefix from kernel logs (kmsg console).
+    let after_ts = if let Some(rest) = trimmed.strip_prefix('[') {
+        match rest.find(']') {
+            Some(idx) => rest[idx + 1..].trim_start(),
+            None => trimmed,
+        }
     } else {
-        "unknown".to_string()
+        trimmed
+    };
+    let rest = after_ts.strip_prefix('<')?;
+    let close = rest.find('>')?;
+    let digits = &rest[..close];
+    if digits.len() != 1 {
+        return None;
+    }
+    match digits.chars().next()? {
+        '0' | '1' | '2' | '3' => Some("error"),
+        '4' => Some("warning"),
+        '5' | '6' => Some("info"),
+        '7' => Some("debug"),
+        _ => None,
     }
 }
 
@@ -194,6 +294,98 @@ mod tests {
         assert_eq!(classify_log("[notice] This is a notice log"), "info");
         assert_eq!(classify_log("info: This is a notice log"), "info");
         assert_eq!(classify_log("Coucou"), "unknown");
+    }
+
+    #[test]
+    fn classify_kernel_syslog_priority() {
+        // <3> = error
+        assert_eq!(classify_log("<3>EXT4-fs (vda1): mounting failed"), "error");
+        // <4> = warning
+        assert_eq!(classify_log("<4>random: crng init done"), "warning");
+        // <6> = info
+        assert_eq!(classify_log("<6>Booting Linux on physical CPU 0x0"), "info");
+        // <7> = debug
+        assert_eq!(classify_log("<7>device-mapper: ioctl"), "debug");
+    }
+
+    #[test]
+    fn classify_kernel_priority_after_timestamp() {
+        // Kernel kmsg console: `[    1.234567] <3>message`
+        assert_eq!(
+            classify_log("[    1.234567] <3>EXT4-fs: mount error"),
+            "error"
+        );
+    }
+
+    #[test]
+    fn classify_kernel_crash_markers() {
+        assert_eq!(classify_log("Kernel panic - not syncing: VFS"), "error");
+        assert_eq!(
+            classify_log("BUG: unable to handle kernel paging request"),
+            "error"
+        );
+        assert_eq!(classify_log("Oops: 0002 [#1] SMP"), "error");
+    }
+
+    #[test]
+    fn classify_cloud_init_levels() {
+        // cloud-init lines typically look like:
+        // "Mon, 10 Jan 2024 12:34:56 +0000 - util.py[WARNING]: ..."
+        // or "2024-01-10 12:34:56,123 - util.py [DEBUG] ..."
+        assert_eq!(
+            classify_log("util.py[WARNING]: hostname not set"),
+            "warning"
+        );
+        assert_eq!(
+            classify_log("cloud-init[123]: ERROR: failed to fetch data"),
+            "error"
+        );
+        assert_eq!(
+            classify_log("CRITICAL: cloud-init failed permanently"),
+            "error"
+        );
+        assert_eq!(classify_log("INFO: handling cloud-config"), "info");
+    }
+
+    #[test]
+    fn classify_systemd_journal_levels() {
+        // systemd lines piped to console: `systemd[1]: Started <service>.`
+        // not specially levelled — but service output often is:
+        assert_eq!(classify_log("sshd: WARN sshguard active"), "warning");
+        assert_eq!(classify_log("nginx ERROR upstream timeout"), "error");
+        assert_eq!(
+            classify_log("application started DEBUG flag enabled"),
+            "debug"
+        );
+    }
+
+    #[test]
+    fn classify_priority_order_kernel_beats_lowercase() {
+        // A kernel <3> at the start must dominate even if `INFO` appears
+        // later in the same line.
+        assert_eq!(
+            classify_log("<3>BUG triggered, INFO: extra context follows"),
+            "error"
+        );
+    }
+
+    #[test]
+    fn classify_bracketed_uppercase_levels() {
+        // `hypervisor-fw` boot log produces lines like `[INFO] Page tables`.
+        assert_eq!(
+            classify_log("[INFO] Setting up 4 GiB identity mapping"),
+            "info"
+        );
+        assert_eq!(classify_log("[WARN] Suboptimal config"), "warning");
+        assert_eq!(classify_log("[ERROR] could not load file"), "error");
+        assert_eq!(classify_log("[DEBUG] trace state"), "debug");
+    }
+
+    #[test]
+    fn classify_information_does_not_match_info() {
+        // Substring guard: `INFORMATION` must not classify as info — the
+        // word-boundary spaces / colon around `INFO` matter.
+        assert_eq!(classify_log("nothing INFORMATION here"), "unknown");
     }
 
     #[test]

--- a/tests/e2e/cloud-hypervisor/t7_logs.sh
+++ b/tests/e2e/cloud-hypervisor/t7_logs.sh
@@ -87,6 +87,21 @@ if [ "$TAIL_LINES" -gt 8 ]; then
 fi
 log "--tail 5 returned $TAIL_LINES line(s) (within bounds)"
 
+# === level classification: at least one non-unknown level after boot ===
+# The CLI rendering drops `level` from the human format, so we hit the
+# raw API endpoint that returns the full structured Log objects.
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+JSON_LOGS=$(curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID/logs?tail=200" \
+  -H "Authorization: Bearer $TOKEN")
+LEVEL_COUNTS=$(echo "$JSON_LOGS" | jq -r '[.[] | .level] | group_by(.) | map({level: .[0], n: length})')
+log "log levels: $LEVEL_COUNTS"
+NON_UNKNOWN=$(echo "$JSON_LOGS" | jq -r '[.[] | select(.level != "unknown")] | length')
+if [ "$NON_UNKNOWN" -lt 1 ]; then
+  echo "$JSON_LOGS" | jq '.[0:5]' >&2
+  fail "every log line classified as 'unknown' — kernel/cloud-init markers should have produced at least one info/warning/error"
+fi
+log "$NON_UNKNOWN log line(s) classified as info/warning/error/debug"
+
 # === delete teardown removes the log file ===
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 for _ in $(seq 1 60); do


### PR DESCRIPTION
## Summary

Extends `classify_log` (the runtime-agnostic log level classifier used by both Docker and Cloud Hypervisor) so the level field stops collapsing to `unknown` for the bulk of a microVM boot stream.

New patterns recognised, in priority order:
1. **Web app brackets** — `[error]`, `[warning]`, `[notice]`, `[info]`, `info:` (existing behaviour, preserved).
2. **Kernel crash markers** — `Kernel panic`, `BUG:`, `Oops:`/`oops:`, `panic:` → `error`.
3. **Kernel syslog priority** — leading `<N>` (with optional `[timestamp]` prefix from kmsg console). `<0>`..`<3>` → `error`, `<4>` → `warning`, `<5>`/`<6>` → `info`, `<7>` → `debug`. Matches RFC 5424.
4. **Uppercase bracketed levels** — `[ERROR]`, `[CRITICAL]`, `[WARN]`/`[WARNING]`, `[NOTICE]`/`[INFO]`, `[DEBUG]`. Covers `hypervisor-fw` boot output (`[INFO] Page tables setup`).
5. **cloud-init / systemd / generic markers** — `ERROR`, `CRITICAL`, ` ERR `, `WARNING`, ` WARN `, `NOTICE`, ` INFO `/`INFO:`, ` DEBUG `/`DEBUG:`. Word-boundary spacing avoids false positives like `INFORMATION` matching `INFO`.

## Why

Closes the `level classification` item under *Logs CH* in the ROADMAP. On a Cirros boot, the API used to return 31/31 lines as `unknown`; with this PR, 26/30 land as `info` and only stray unindexed lines remain `unknown`. Same classifier is used by the Docker runtime, so any structured log consumer benefits.

## Test plan

- [x] `cargo test --bin ring 'lifecycle_trait::tests'` — 10 unit tests pass, 8 new ones covering kernel syslog priority, kernel timestamp+priority combo, kernel crash markers, cloud-init levels, systemd journal patterns, bracketed uppercase, priority order (kernel wins over a later INFO in the same line), and the `INFORMATION` substring guard.
- [x] `tests/e2e/cloud-hypervisor/t7_logs.sh` extended and PASS — hits `GET /deployments/{id}/logs` directly (CLI rendering drops `level`) and asserts at least one line is classified as `info`/`warning`/`error`/`debug` on a real boot.
- [x] Documentation: new *Log levels* subsection in `documentation/how-to/deploy-on-cloud-hypervisor.md` explaining the three families and that the structured level is only surfaced via the API for now.