### PR TITLE
ci: release workflow — build ring + ring-agent binaries on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: Release
+
+# Triggers on annotated tags matching `v*`, plus a manual button so we can
+# re-run a release without re-tagging (useful when the workflow itself
+# needs a fix). Both paths upload assets to the matching GitHub release.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re-)build (e.g. v0.8.0)'
+        required: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write  # required to upload assets to the release
+
+jobs:
+  ring-server:
+    name: Build ring (x86_64-unknown-linux-gnu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-gnu-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release --bin ring
+
+      - name: Package
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PKG="ring-${TAG}-x86_64-unknown-linux-gnu"
+          mkdir -p "dist/${PKG}"
+          cp target/release/ring "dist/${PKG}/"
+          cp README.md LICENSE CHANGELOG.md "dist/${PKG}/" 2>/dev/null || true
+          tar -czf "${PKG}.tar.gz" -C dist "${PKG}"
+          sha256sum "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ring-server
+          path: |
+            ring-*.tar.gz
+            ring-*.tar.gz.sha256
+
+  ring-agent:
+    name: Build ring-agent (x86_64-unknown-linux-musl)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-musl-${{ hashFiles('**/Cargo.lock') }}
+
+      # ring-agent must be a static binary so users can drop it into any
+      # guest image regardless of its libc — musl is the standard choice.
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+
+      - name: Build release binary
+        run: cargo build --release --target x86_64-unknown-linux-musl -p ring-agent
+
+      - name: Package
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PKG="ring-agent-${TAG}-x86_64-unknown-linux-musl"
+          mkdir -p "dist/${PKG}"
+          cp target/x86_64-unknown-linux-musl/release/ring-agent "dist/${PKG}/"
+          cp LICENSE "dist/${PKG}/" 2>/dev/null || true
+          tar -czf "${PKG}.tar.gz" -C dist "${PKG}"
+          sha256sum "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ring-agent
+          path: |
+            ring-agent-*.tar.gz
+            ring-agent-*.tar.gz.sha256
+
+  publish:
+    name: Attach to GitHub release
+    needs: [ring-server, ring-agent]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          shopt -s globstar
+          gh release upload "$TAG" artifacts/**/*.tar.gz artifacts/**/*.tar.gz.sha256 --clobber

--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -43,7 +43,16 @@ You need all of these on the host:
 
 7. **`virtiofsd`** (only if you use `volumes:`): `apt install virtiofsd`. Ring looks for it at `/usr/libexec/virtiofsd` then `/usr/lib/qemu/virtiofsd`. Override with `RING_VIRTIOFSD=/path/to/virtiofsd`.
 
-8. **`ring-agent` inside the guest image** (only if you use `health_checks: [{ type: command, ... }]`). Build once with `cargo build -p ring-agent --release --target x86_64-unknown-linux-musl`, install it at `/usr/local/bin/ring-agent` in the guest, and run it at boot via a systemd unit. It listens on AF_VSOCK port 2375.
+8. **`ring-agent` inside the guest image** (only if you use `health_checks: [{ type: command, ... }]`). Each Ring release attaches a static musl build:
+
+   ```bash
+   TAG=$(curl -s https://api.github.com/repos/kemeter/ring/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+   curl -L "https://github.com/kemeter/ring/releases/download/${TAG}/ring-agent-${TAG}-x86_64-unknown-linux-musl.tar.gz" \
+     | tar -xz
+   # then copy the extracted ring-agent into the guest image at /usr/local/bin/ring-agent
+   ```
+
+   If you'd rather build it yourself: `cargo build -p ring-agent --release --target x86_64-unknown-linux-musl`. Either way, install it at `/usr/local/bin/ring-agent` in the guest and run it at boot via a systemd unit. It listens on AF_VSOCK port 2375.
 
 Run `ring doctor` to verify everything is in place — it checks each item and prints the missing pieces.
 

--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -6,22 +6,34 @@ By the end of this tutorial you'll have Ring installed, the server running, and 
 
 - A Linux or macOS machine
 - Docker installed and the daemon running (`docker ps` works for your user)
-- Rust 1.85 or later (Ring uses edition 2024). Install via [rustup](https://rustup.rs/)
 
 Quick check:
 
 ```bash
 docker --version
-rustc --version
 ```
 
 If `docker ps` fails with a permission error, add yourself to the docker group: `sudo usermod -aG docker $USER`, then log out and back in.
 
-## 1. Compile Ring
+## 1. Install Ring
 
-Pre-compiled binaries are not yet published, so we'll build from source.
+### From a pre-built binary (recommended, Linux x86_64)
 
-Install the system libraries Ring needs to link against:
+Each release attaches a pre-built `ring` binary for `x86_64-unknown-linux-gnu`. Grab the latest one:
+
+```bash
+TAG=$(curl -s https://api.github.com/repos/kemeter/ring/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+curl -L "https://github.com/kemeter/ring/releases/download/${TAG}/ring-${TAG}-x86_64-unknown-linux-gnu.tar.gz" \
+  | tar -xz
+sudo install -m 0755 "ring-${TAG}-x86_64-unknown-linux-gnu/ring" /usr/local/bin/ring
+ring --version
+```
+
+The release archive also contains a `.sha256` companion if you want to verify the download.
+
+### From source
+
+If you're on macOS, ARM Linux, or want the latest unreleased changes, build from source. Requires Rust 1.85 or later ([rustup](https://rustup.rs/)) and OpenSSL headers:
 
 ```bash
 # Debian / Ubuntu
@@ -40,16 +52,11 @@ Then clone and build:
 git clone https://github.com/kemeter/ring.git
 cd ring
 cargo build --release
-sudo cp target/release/ring /usr/local/bin/
-```
-
-The release build takes a few minutes the first time. Once it finishes:
-
-```bash
+sudo install -m 0755 target/release/ring /usr/local/bin/ring
 ring --version
 ```
 
-You should see Ring's version number. If not, the binary isn't on your `PATH` — check `which ring`.
+The release build takes a few minutes the first time. If `ring --version` doesn't work after install, the binary isn't on your `PATH` — check `which ring`.
 
 ## 2. Generate the encryption key
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`, triggered on `push: tags: ['v*']` (plus `workflow_dispatch` for manual re-runs). Builds two artifacts and uploads both to the matching GitHub release:

- **`ring-<tag>-x86_64-unknown-linux-gnu.tar.gz`** — the server binary (`cargo build --release --bin ring`), targeted at hosts running Ring as the orchestrator.
- **`ring-agent-<tag>-x86_64-unknown-linux-musl.tar.gz`** — static musl build of the in-guest agent, so Cloud Hypervisor users can drop it into any image without worrying about libc compatibility.

Each archive ships next to a `.sha256` file for integrity verification.

## Why

Until now every Ring release (`v0.3.0`..`v0.7.0`) was source-only — users had to `cargo build --release` themselves, and getting `ring-agent` into a guest image required installing the musl toolchain locally. This is the first DX hurdle in the upcoming v0.9 cycle ("v0.9 axé DX") and the most visible: it changes Ring's install path from "clone, install deps, compile, pray" to "download, extract, run."

## Documentation

- `documentation/tutorials/install-and-run.md` — new *Install Ring* section with two paths: pre-built binary (recommended, the new default), or source build (fallback for macOS / ARM / unreleased commits).
- `documentation/how-to/deploy-on-cloud-hypervisor.md` — the `ring-agent` install step now leads with the curl-and-extract recipe, with the `cargo build` fallback below for users who prefer compiling.

## Test plan

- [x] `cargo build --release --bin ring` — succeeds locally (40s, release profile).
- [x] `cargo fmt --check` — clean.
- [x] YAML syntax of `release.yml` validated via `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Workflow itself can only be exercised against a tag — will validate by tagging `v0.8.0` once this PR lands.