### PR TITLE
fix(ci): pass --repo to gh release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,4 +118,10 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           shopt -s globstar
-          gh release upload "$TAG" artifacts/**/*.tar.gz artifacts/**/*.tar.gz.sha256 --clobber
+          # `gh release upload` normally infers the repo from the local git
+          # remote, but this job has no checkout (just downloaded artifacts),
+          # so we pass --repo explicitly to skip the git lookup.
+          gh release upload "$TAG" \
+            --repo "${{ github.repository }}" \
+            --clobber \
+            artifacts/**/*.tar.gz artifacts/**/*.tar.gz.sha256


### PR DESCRIPTION
## Summary

The release workflow's `publish` job failed on v0.8.0 with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job doesn't `actions/checkout` (it only downloads the build artifacts), so `gh release upload` couldn't infer the target repo from a local git remote. Passing `--repo ${{ github.repository }}` explicitly skips that lookup.

## Test plan

- [x] YAML validated locally.
- [ ] Verify by re-running the v0.8.0 release workflow via `workflow_dispatch` once this PR lands — it will pick up the new YAML and re-attach the binaries to the existing release.