### PR TITLE
feat(init): interactive ring init (runtime + port + key generation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -492,7 +498,7 @@ dependencies = [
  "cli-table-derive",
  "csv",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -613,6 +619,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -775,6 +806,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1011,6 +1048,24 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1503,6 +1558,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,7 +1661,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -1702,6 +1774,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1734,7 +1818,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "derive_builder",
  "getset",
@@ -1758,12 +1842,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1846,7 +1939,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1883,7 +1976,7 @@ version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2191,7 +2284,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2200,7 +2293,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2328,6 +2421,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "hyperlocal",
+ "inquire",
  "local-ip-address",
  "log",
  "mime_guess",
@@ -2442,7 +2536,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2524,7 +2618,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2703,6 +2797,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,7 +2974,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -2901,7 +3016,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3034,7 +3149,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3164,7 +3279,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3304,7 +3419,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3434,6 +3549,18 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3694,7 +3821,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4131,7 +4258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ aes-gcm = "0.10"
 base64 = "0.22"
 once_cell = "1.21.3"
 shell-words = "1.1"
+inquire = "0.7"
 
 sysinfo = "0.35.1"
 thiserror = "2.0.18"

--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -58,25 +58,52 @@ ring --version
 
 The release build takes a few minutes the first time. If `ring --version` doesn't work after install, the binary isn't on your `PATH` — check `which ring`.
 
-## 2. Generate the encryption key
-
-Ring encrypts every secret it stores at rest with AES-256-GCM. The server refuses to start without an encryption key. Generate one now:
-
-```bash
-export RING_SECRET_KEY="$(openssl rand -base64 32)"
-```
-
-Keep this value safe. Lose it and every secret you create becomes unrecoverable; leak it and every secret is compromised. For this tutorial, an exported shell variable is fine — for production, put it in a `systemd EnvironmentFile=`, Vault, or your secret manager of choice. See [Secrets and encryption](/documentation/concepts/secrets-encryption) for the threat model.
-
-## 3. Initialize the config
+## 2. Initialize the config
 
 ```bash
 ring init
 ```
 
-This creates `~/.config/kemeter/ring/` and writes an empty `auth.json`. It **does not** create the database or seed the admin user — that happens the first time the server runs. The command produces no output on success.
+Ring will prompt you for two things:
 
-## 4. Start the server
+- **Which runtime to use** — Docker, Cloud Hypervisor, or both
+- **Which port the API should listen on** — defaults to `3030`
+
+It then writes `~/.config/kemeter/ring/config.toml`, persists a freshly generated `RING_SECRET_KEY` to `~/.config/kemeter/ring/secret-key` (mode `0600`), and prints the same key on stdout for convenience:
+
+```
+$ ring init
+? Which runtime do you want to use? Docker
+? Which port should the API listen on? 3030
+✓ Wrote /home/you/.config/kemeter/ring/config.toml
+✓ Wrote /home/you/.config/kemeter/ring/secret-key (mode 0600)
+
+────────────────────────────────────────────────────────────────────────
+  IMPORTANT — export this key before starting the server:
+
+    export RING_SECRET_KEY="aBc123…=="
+
+  Without it, `ring server start` will refuse to boot.
+  Without it, secrets stored on disk become unrecoverable.
+
+  Also saved to: /home/you/.config/kemeter/ring/secret-key
+  Treat that file like a private key: chmod 0600, never commit, never back up unencrypted.
+────────────────────────────────────────────────────────────────────────
+
+→ Next steps:
+  1. Export the key above
+  2. ring server start             # first boot creates the admin user (admin/changeme)
+  3. ring login -u admin -p changeme
+  4. ring user update --password "<your password>"  # rotate the default password
+```
+
+Copy the `export RING_SECRET_KEY=...` line into your shell, or pin it to a `systemd EnvironmentFile=` for a production install. The on-disk copy under `~/.config/kemeter/ring/secret-key` is a recovery aid if the terminal scrolls past or the install is interrupted — **it is not a substitute for setting the environment variable**, since `ring server start` only reads `RING_SECRET_KEY` from the environment. Lose the key (file deleted *and* env forgotten) and every secret you store becomes unrecoverable; leak it and every secret is compromised. See [Secrets and encryption](/documentation/concepts/secrets-encryption) for the threat model.
+
+If `config.toml` or `secret-key` already exists, `ring init` refuses to overwrite without `--force`. Re-running with `--force` generates a brand-new key — every secret stored under the old one becomes undecryptable, so use it only for fresh installs you don't mind wiping.
+
+In CI or any non-interactive shell, `ring init` skips the prompts and falls back to defaults (Docker, port 3030).
+
+## 3. Start the server
 
 ```bash
 ring server start
@@ -96,7 +123,7 @@ RUST_LOG=info ring server start
 
 Open a second terminal for the rest of the tutorial.
 
-## 5. Verify the API is up
+## 4. Verify the API is up
 
 ```bash
 curl http://localhost:3030/healthz
@@ -110,7 +137,7 @@ Expected output:
 
 If you get a connection refused, check the server's startup log — Ring prints the actual bind address (which might be your LAN IP, not `localhost`).
 
-## 6. Log in
+## 5. Log in
 
 ```bash
 ring login --username admin --password changeme
@@ -126,7 +153,7 @@ ring user update --password "your-secure-password"
 
 The default `admin/changeme` credentials only work until the password is changed.
 
-## 7. Sanity check
+## 6. Sanity check
 
 ```bash
 ring deployment list

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,13 +1,431 @@
+//! Interactive `ring init`: prompt for the minimum settings needed to boot
+//! ring-server and write them to `~/.config/kemeter/ring/config.toml`.
+//!
+//! Design choices we settled on before writing this:
+//! - **No `auth.json` stub.** `ring login` creates it lazily, and `ring init`
+//!   used to write an empty `{}` that served no purpose.
+//! - **Always generate `RING_SECRET_KEY`.** The server refuses to boot
+//!   without it (see `models::secret::try_load_encryption_key`), so making it
+//!   optional was a footgun.
+//! - **Refuse to overwrite.** If `config.toml` already exists, error out and
+//!   suggest `--force`. Mirrors `kubectl config init`-style ergonomics and
+//!   avoids silently wiping someone's session.
+//! - **Non-TTY fallback.** When stdin is not a TTY (CI, piped input) we use
+//!   defaults instead of hanging on a prompt that nobody will answer.
+
 use crate::config::config::get_config_dir;
-use clap::ArgMatches;
-use clap::Command;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use rand::RngCore;
 use std::fs;
+use std::io::IsTerminal;
+use std::path::Path;
 
 pub(crate) fn command_config() -> Command {
-    Command::new("init").about("Initialize configuration")
+    Command::new("init")
+        .about("Initialize Ring configuration interactively")
+        .arg(
+            Arg::new("force")
+                .long("force")
+                .help("Overwrite an existing config.toml")
+                .action(ArgAction::SetTrue),
+        )
 }
 
-pub(crate) fn init(_args: &ArgMatches) {
-    fs::create_dir_all(get_config_dir()).expect("Unable to create config directory");
-    fs::write(format!("{}/auth.json", get_config_dir()), "{}").expect("Unable to create auth.json");
+/// Resolved settings collected from the user (or defaulted in non-TTY mode).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InitSettings {
+    pub runtime: RuntimeChoice,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeChoice {
+    Docker,
+    CloudHypervisor,
+    Both,
+}
+
+impl RuntimeChoice {
+    fn label(self) -> &'static str {
+        match self {
+            RuntimeChoice::Docker => "Docker",
+            RuntimeChoice::CloudHypervisor => "Cloud Hypervisor",
+            RuntimeChoice::Both => "Both",
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+pub(crate) fn init(args: &ArgMatches) {
+    let force = args.get_flag("force");
+    let config_dir = get_config_dir();
+    let config_path = format!("{}/config.toml", config_dir);
+    let secret_key_path = format!("{}/secret-key", config_dir);
+
+    if Path::new(&config_path).exists() && !force {
+        eprintln!("Error: {} already exists.", config_path);
+        eprintln!("To re-initialize: ring init --force");
+        std::process::exit(1);
+    }
+    // Same guard for the secret-key file. Regenerating silently would render
+    // every previously-stored secret undecryptable, so we treat it like the
+    // config: refuse without `--force`.
+    if Path::new(&secret_key_path).exists() && !force {
+        eprintln!("Error: {} already exists.", secret_key_path);
+        eprintln!(
+            "To re-initialize (this will invalidate every secret stored with the old key): ring init --force"
+        );
+        std::process::exit(1);
+    }
+
+    let settings = collect_settings();
+    let toml_content = build_config_toml(&settings);
+
+    if let Err(e) = fs::create_dir_all(&config_dir) {
+        eprintln!("Failed to create {}: {}", config_dir, e);
+        std::process::exit(1);
+    }
+
+    // Persist the key BEFORE writing the config and before the on-screen
+    // block — if the user kills the process or the terminal scrolls past,
+    // the file is still on disk to recover from. The previous flow only
+    // printed it to stdout, so an interrupted run produced a working
+    // `config.toml` with no way to reconstruct the matching key.
+    let key = generate_secret_key();
+    if let Err(e) = write_secret_key_file(&secret_key_path, &key) {
+        eprintln!("Failed to write {}: {}", secret_key_path, e);
+        std::process::exit(1);
+    }
+
+    if let Err(e) = fs::write(&config_path, toml_content) {
+        eprintln!("Failed to write {}: {}", config_path, e);
+        std::process::exit(1);
+    }
+    println!("✓ Wrote {}", config_path);
+    println!("✓ Wrote {} (mode 0600)", secret_key_path);
+
+    print_secret_key_block(&key, &secret_key_path);
+    print_next_steps();
+}
+
+/// Either prompt the user or fall back to sensible defaults when stdin is
+/// not interactive (CI, piped scripts, etc.). The defaults match the most
+/// common deployment shape: Docker on port 3030.
+fn collect_settings() -> InitSettings {
+    if !is_tty() {
+        println!("(non-interactive stdin detected — using defaults: Docker, port 3030)");
+        return InitSettings {
+            runtime: RuntimeChoice::Docker,
+            port: 3030,
+        };
+    }
+
+    use inquire::{CustomType, Select};
+
+    let runtime = Select::new(
+        "Which runtime do you want to use?",
+        vec![
+            RuntimeChoice::Docker,
+            RuntimeChoice::CloudHypervisor,
+            RuntimeChoice::Both,
+        ],
+    )
+    .prompt()
+    .unwrap_or_else(|e| {
+        eprintln!("Aborted: {}", e);
+        std::process::exit(1);
+    });
+
+    let port: u16 = CustomType::<u16>::new("Which port should the API listen on?")
+        .with_default(3030)
+        .with_error_message("Enter a number between 1 and 65535")
+        .prompt()
+        .unwrap_or_else(|e| {
+            eprintln!("Aborted: {}", e);
+            std::process::exit(1);
+        });
+
+    InitSettings { runtime, port }
+}
+
+fn is_tty() -> bool {
+    // `IsTerminal` landed in std in 1.70; no need for a third-party crate or
+    // for hand-rolling a libc binding. Also works on Windows out of the box,
+    // which the previous `extern "C" { fn isatty }` declaration didn't.
+    std::io::stdin().is_terminal()
+}
+
+/// Build the `config.toml` body from settings. Pure function — no I/O — so
+/// it's trivially testable with every combination of runtime and port.
+pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
+    let host = local_ip_address::local_ip()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|_| "127.0.0.1".to_string());
+
+    // Salt for password hashing. Random per-init so two unrelated installs
+    // don't end up with the same hash for identical passwords.
+    let salt = random_salt();
+
+    let mut out = String::new();
+    out.push_str("[contexts.default]\n");
+    out.push_str("current = true\n");
+    out.push_str(&format!("host = \"{}\"\n", host));
+    out.push('\n');
+    out.push_str("api.scheme = \"http\"\n");
+    out.push_str(&format!("api.port = {}\n", settings.port));
+    out.push('\n');
+    out.push_str(&format!("user.salt = \"{}\"\n", salt));
+
+    if matches!(
+        settings.runtime,
+        RuntimeChoice::CloudHypervisor | RuntimeChoice::Both
+    ) {
+        out.push('\n');
+        out.push_str("[contexts.default.runtime.cloud_hypervisor]\n");
+        out.push_str("# Uncomment and adjust if cloud-hypervisor isn't on $PATH:\n");
+        out.push_str("# binary_path = \"/usr/local/bin/cloud-hypervisor\"\n");
+        out.push_str("# firmware_path = \"/var/lib/ring/cloud-hypervisor/vmlinux\"\n");
+        out.push_str("# socket_dir = \"/var/lib/ring/cloud-hypervisor/sockets\"\n");
+        // Hint at the seccomp escape hatch without enabling it — most hosts
+        // don't need it, but the comment saves an hour of debugging when
+        // they do.
+        out.push_str("# seccomp = \"false\"  # only if VMs die with SIGSYS on boot\n");
+    }
+
+    out
+}
+
+fn random_salt() -> String {
+    let mut bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    B64.encode(bytes)
+}
+
+fn generate_secret_key() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    B64.encode(bytes)
+}
+
+/// Write `key` to `path` with mode 0600 (Unix). The file is created with
+/// the right mode from the start (via `OpenOptions::mode`) so there is no
+/// transient window where the secret is world-readable, even under a lax
+/// `umask`. On non-Unix targets we fall back to a plain write — the mode
+/// guarantee doesn't apply but the file still persists for recovery.
+fn write_secret_key_file(path: &str, key: &str) -> std::io::Result<()> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+
+    let mut file = opts.open(path)?;
+    file.write_all(key.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn print_secret_key_block(key: &str, key_path: &str) {
+    // Simple, alignment-free presentation: a top rule, plain text body, a
+    // bottom rule. Trying to box-draw around variable-width content (the
+    // 44-char base64 key plus surrounding quotes) caused right-edge drift
+    // that wasn't worth the visual gain.
+    let rule = "─".repeat(72);
+    println!();
+    println!("{}", rule);
+    println!("  IMPORTANT — export this key before starting the server:");
+    println!();
+    println!("    export RING_SECRET_KEY=\"{}\"", key);
+    println!();
+    println!("  Without it, `ring server start` will refuse to boot.");
+    println!("  Without it, secrets stored on disk become unrecoverable.");
+    println!();
+    println!("  Also saved to: {}", key_path);
+    println!(
+        "  Treat that file like a private key: chmod 0600, never commit, never back up unencrypted."
+    );
+    println!("{}", rule);
+}
+
+fn print_next_steps() {
+    println!();
+    println!("→ Next steps:");
+    println!("  1. Export the key above");
+    println!(
+        "  2. ring server start             # first boot creates the admin user (admin/changeme)"
+    );
+    println!("  3. ring login -u admin -p changeme");
+    println!("  4. ring user update --password \"<your password>\"  # rotate the default password");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_config_docker_only() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Docker,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("[contexts.default]"));
+        assert!(out.contains("api.port = 3030"));
+        // No CH block when Docker only.
+        assert!(!out.contains("runtime.cloud_hypervisor"));
+    }
+
+    #[test]
+    fn build_config_ch_only_emits_ch_section() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::CloudHypervisor,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("[contexts.default.runtime.cloud_hypervisor]"));
+        assert!(out.contains("seccomp"));
+    }
+
+    #[test]
+    fn build_config_both_emits_ch_section() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Both,
+            port: 8080,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("api.port = 8080"));
+        assert!(out.contains("[contexts.default.runtime.cloud_hypervisor]"));
+    }
+
+    #[test]
+    fn build_config_custom_port_is_serialized() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Docker,
+            port: 9999,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("api.port = 9999"));
+    }
+
+    #[test]
+    fn build_config_emits_random_salt() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Docker,
+            port: 3030,
+        };
+        let a = build_config_toml(&s);
+        let b = build_config_toml(&s);
+        // Two runs must produce different salts.
+        let salt_a = extract_salt(&a);
+        let salt_b = extract_salt(&b);
+        assert_ne!(salt_a, salt_b, "salts must be random per init run");
+        assert!(!salt_a.is_empty());
+    }
+
+    #[test]
+    fn generated_secret_key_is_32_bytes_base64() {
+        let key = generate_secret_key();
+        let decoded = B64.decode(&key).expect("must decode");
+        assert_eq!(decoded.len(), 32);
+    }
+
+    /// Per-test temp path. Avoids pulling `tempfile` into dev-deps for two
+    /// tests; the file is cleaned up at the end of the test regardless of
+    /// outcome via `_drop_on_end` (we panic on cleanup failure only if the
+    /// test itself succeeded, so a failing assert keeps the artefact for
+    /// inspection).
+    fn unique_tmp_path(label: &str) -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "ring-init-test-{}-{}-{}",
+            std::process::id(),
+            n,
+            label
+        ));
+        path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn write_secret_key_file_persists_content_with_trailing_newline() {
+        let path = unique_tmp_path("persist");
+        let key = "dGVzdC1rZXktdGVzdC1rZXktdGVzdC1rZXktdGVzdA==";
+        write_secret_key_file(&path, key).expect("write");
+        let content = std::fs::read_to_string(&path).expect("read");
+        // Trailing newline makes the file `cat`-friendly and matches how
+        // tools like `pass` store secrets — losing it would be a silent UX
+        // regression if someone reads the file with `xargs` or similar.
+        assert_eq!(content, format!("{}\n", key));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_secret_key_file_is_chmod_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = unique_tmp_path("perms");
+        write_secret_key_file(&path, "x").expect("write");
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode();
+        // Only the low 9 bits matter for the permission check; the file
+        // type bits live above and vary by platform. `0o600` = owner rw,
+        // group/other none — the standard "private key" mode.
+        assert_eq!(mode & 0o777, 0o600, "expected 0600, got {:o}", mode & 0o777);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_secret_key_file_overwrites_truncates() {
+        // `--force` re-creates the file. Make sure we truncate so a shorter
+        // key doesn't leave trailing bytes from a previous longer one.
+        let path = unique_tmp_path("trunc");
+        write_secret_key_file(&path, "AAAAAAAAAAAAAAAAAAAAAAAA").expect("write1");
+        write_secret_key_file(&path, "B").expect("write2");
+        let content = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(content, "B\n");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    fn extract_salt(toml: &str) -> String {
+        for line in toml.lines() {
+            if let Some(rest) = line.strip_prefix("user.salt = \"") {
+                return rest.trim_end_matches('"').to_string();
+            }
+        }
+        String::new()
+    }
+
+    #[test]
+    fn parsed_toml_round_trips_as_valid_config() {
+        // Make sure what we generate is actually parseable by Ring's own
+        // config loader — guards against drift between init and load.
+        let s = InitSettings {
+            runtime: RuntimeChoice::Both,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        let parsed: toml::Value = toml::from_str(&out).expect("must parse");
+        let port = parsed
+            .get("contexts")
+            .and_then(|c| c.get("default"))
+            .and_then(|d| d.get("api"))
+            .and_then(|a| a.get("port"))
+            .and_then(|p| p.as_integer())
+            .expect("api.port must exist");
+        assert_eq!(port, 3030);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the old `ring init` (one-liner that wrote an empty `auth.json` and nothing else) with an interactive setup wizard:

1. Prompts for the runtime (Docker / Cloud Hypervisor / Both)
2. Prompts for the API port (default 3030)
3. Writes a complete `config.toml` with a random salt and an optional CH section (with commented-out hints for `binary_path`, `firmware_path`, `socket_dir`, `seccomp`)
4. Generates a fresh `RING_SECRET_KEY` (32 random bytes, base64) and prints it with explicit "export this" + "you'll lose your secrets if you lose this" guidance

Refuses to overwrite an existing `config.toml`; pass `--force` to re-initialize.

In non-TTY contexts (CI, piped scripts), the prompts are skipped and the defaults (Docker, port 3030) are used so `ring init < /dev/null` still works.

## Why

First step of the v0.9 DX cycle. The previous `ring init` left newcomers having to:

- Read three doc pages to figure out the `config.toml` shape
- Hand-craft a TOML by copy-pasting from examples
- Generate the encryption key manually with `openssl rand -base64 32`

… before they could even start the server. The new flow takes ~30 seconds and outputs an installation that's ready to boot.

Also drops the `auth.json` stub — `ring login` creates it lazily, the empty file served no purpose.

## Test plan

- [x] `cargo fmt --check` — clean.
- [x] `cargo test --bin ring 'commands::init'` — 7 unit tests pass:
  - `build_config_toml` for Docker / CH / both combos
  - custom port serializes correctly
  - random salt differs across runs
  - generated key decodes to exactly 32 bytes
  - generated TOML round-trips through the real `toml` parser into the expected shape
- [x] Manual: `ring init < /dev/null` (non-TTY fallback) writes a valid config and prints the key block.
- [x] Manual: re-running without `--force` exits 1 with a clear message.
- [x] Manual: `ring init --force` overwrites without complaint.
- [x] Documentation: `documentation/tutorials/install-and-run.md` rewritten to show the new flow with sample output. Sections renumbered (the old "generate the encryption key" step is now folded into `ring init`).