### PR TITLE
fix(scheduler): converge CreateContainerError to CrashLoopBackOff

### DIFF
--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -340,15 +340,21 @@ pub(crate) async fn create_container(
             }
 
             let start_options = StartContainerOptionsBuilder::new().build();
-            docker
+            if let Err(e) = docker
                 .start_container(&container.id, Some(start_options))
                 .await
-                .map_err(|e| {
-                    RuntimeError::InstanceCreationFailed(format!(
-                        "Docker failed to start container: {}",
-                        e
-                    ))
-                })?;
+            {
+                // Docker accepted `create` but `start` failed — leaving the
+                // container in `Created` state. Remove it before returning
+                // the error so the next retry isn't shadowed by an orphan
+                // container that's neither running nor counted toward
+                // restart_count.
+                remove_container(docker.clone(), container.id.clone()).await;
+                return Err(RuntimeError::InstanceCreationFailed(format!(
+                    "Docker failed to start container: {}",
+                    e
+                )));
+            }
 
             info!(
                 "Docker container {} created and started successfully",

--- a/src/runtime/docker/instances.rs
+++ b/src/runtime/docker/instances.rs
@@ -6,13 +6,18 @@ fn build_list_options(status: &str) -> bollard::query_parameters::ListContainers
     match status {
         "all" => ListContainersOptionsBuilder::new().all(true).build(),
         "active" => {
+            // We deliberately drop `created` here. A container stuck in
+            // `created` (Docker accepted the spec but `start` failed — e.g.
+            // OCI runtime can't exec the binary) is *not* a live instance.
+            // Counting it as active masked the failure: the scheduler saw
+            // `current_count == target_count`, skipped the retry path, and
+            // restart_count never climbed to MAX_RESTART_COUNT. With it out
+            // of the filter, the next tick sees 0 instances, re-tries,
+            // increments restart_count, and eventually flips the deployment
+            // to CrashLoopBackOff like any other crash loop.
             let filters = HashMap::from([(
                 "status".to_string(),
-                vec![
-                    "running".to_string(),
-                    "created".to_string(),
-                    "restarting".to_string(),
-                ],
+                vec!["running".to_string(), "restarting".to_string()],
             )]);
             ListContainersOptionsBuilder::new()
                 .all(true)

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -784,13 +784,33 @@ pub(crate) async fn schedule(
         // hit CrashLoopBackOff in the same cycle as the crash that caused it.
         drain_docker_events(&pool, &mut event_rx, &intentional_shutdowns).await;
 
+        // The scheduler picks up every status that can still progress on the
+        // next tick. Pending/Creating need their first apply, Running needs
+        // reconciliation, Deleted needs cleanup, and the transient error
+        // states need to keep retrying until `restart_count` reaches
+        // `MAX_RESTART_COUNT` — at which point the runtime flips the
+        // deployment to `CrashLoopBackOff` and stops being included here.
+        //
+        // Statuses left out on purpose: Completed (terminal job), Failed,
+        // CrashLoopBackOff (terminal failure). Anything in those states is
+        // done — no point reconciling further.
+        // Status names match what `DeploymentStatus::fmt` writes to the DB
+        // — the error variants are PascalCase, the lifecycle ones lower.
+        // A mismatch here silently drops deployments from reconciliation.
         let mut filters = HashMap::new();
         filters.insert(
             String::from("status"),
             vec![
+                String::from("pending"),
                 String::from("creating"),
                 String::from("running"),
                 String::from("deleted"),
+                String::from("CreateContainerError"),
+                String::from("ImagePullBackOff"),
+                String::from("NetworkError"),
+                String::from("ConfigError"),
+                String::from("FileSystemError"),
+                String::from("Error"),
             ],
         );
         let list_deployments = match deployments::find_all(&pool, filters).await {

--- a/tests/e2e/docker/t23_create_container_error_loop.sh
+++ b/tests/e2e/docker/t23_create_container_error_loop.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# T23: a deployment whose container is accepted by Docker `create` but rejected
+# by `start` (OCI runtime cannot exec the binary, e.g. command points at a
+# missing file) must converge to CrashLoopBackOff rather than spamming "Scaled
+# up from 0 to 1 replicas" events forever.
+#
+# Today this test FAILS: the scheduler's `Scaled up` event is emitted on every
+# reconciliation tick because Docker says `create` succeeded; `restart_count`
+# never climbs to MAX_RESTART_COUNT for this failure mode; the events timeline
+# fills with hundreds of identical entries. Captured live in the dashboard with
+# ~49 duplicate events over a couple of minutes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T23: CreateContainerError must converge to CrashLoopBackOff =="
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/oci-create-error.yaml"
+
+# 60s is well past MAX_RESTART_COUNT (5) at a 1s scheduler interval, plus a
+# safety margin for the Docker event listener to bump restart_count.
+log "waiting 60s for the scheduler to react to repeated start failures..."
+sleep 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "oci-create-error")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+RESTART_COUNT=$(get_restart_count "ring-e2e" "oci-create-error")
+STATUS=$("$RING_BIN" deployment list --output json \
+  | jq -r --arg ns "ring-e2e" --arg n "oci-create-error" \
+      '.[] | select(.namespace==$ns and .name==$n) | .status' \
+  | head -n1)
+
+# Count "Scaled up" events. The current bug emits one per reconciliation
+# tick, so a 60-second window produces dozens. After the fix the scheduler
+# should either stop emitting them or de-duplicate, plus reach
+# CrashLoopBackOff and stop reconciling entirely.
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+EVENTS_JSON=$(curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID/events" \
+  -H "Authorization: Bearer $TOKEN")
+SCALED_UP_COUNT=$(echo "$EVENTS_JSON" \
+  | jq -r '[.[] | select(.message | test("Scaled up from"))] | length')
+
+log "observed: restart_count=$RESTART_COUNT status=$STATUS scaled_up_events=$SCALED_UP_COUNT"
+
+# 1) The deployment must converge to CrashLoopBackOff. Anything else means
+#    the scheduler keeps trying without a bound.
+if [ "$STATUS" != "CrashLoopBackOff" ]; then
+  fail "expected status CrashLoopBackOff, got '$STATUS'"
+fi
+
+# 2) restart_count must have reached at least MAX_RESTART_COUNT (5). If it
+#    doesn't, the failure mode isn't counted — that's the root cause of the
+#    event spam.
+if [ "${RESTART_COUNT:-0}" -lt 5 ]; then
+  fail "expected restart_count >= 5, got $RESTART_COUNT — Docker start failures are not counted"
+fi
+
+# 3) "Scaled up" events must be bounded. Even a fix that only sets
+#    CrashLoopBackOff still leaves up to MAX_RESTART_COUNT scale-up attempts
+#    in the log. Anything beyond ~10 means the scheduler kept reconciling
+#    past the CrashLoopBackOff threshold.
+if [ "$SCALED_UP_COUNT" -gt 10 ]; then
+  fail "too many 'Scaled up' events ($SCALED_UP_COUNT) — scheduler is re-emitting them past CrashLoopBackOff"
+fi
+
+log "== T23: PASS =="

--- a/tests/e2e/fixtures/oci-create-error.yaml
+++ b/tests/e2e/fixtures/oci-create-error.yaml
@@ -1,0 +1,11 @@
+deployments:
+  oci-create-error:
+    name: oci-create-error
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Docker accepts `create` (the container record is made) but `start`
+    # fails because the OCI runtime can't exec a binary that doesn't
+    # exist. Sets the deployment to CreateContainerError every cycle.
+    command: ["/nonexistent-binary"]
+    replicas: 1


### PR DESCRIPTION
## Summary

A deployment whose container is accepted by Docker `create` but rejected by `start` (typically an OCI runtime failure — bad command, missing binary, exec format error) used to get stuck in `CreateContainerError` forever: `restart_count` capped at 1, the scheduler never re-tried, the deployment never reached `CrashLoopBackOff`. The events timeline filled with the same message at every reconciliation tick.

Three issues compounded:

1. **Scheduler filter dropped error states.** `src/scheduler/scheduler.rs` only loaded deployments in `creating` / `running` / `deleted`. Once a deployment flipped to `CreateContainerError` (or any other transient error state), it was no longer visited — no retry, no progress to `CrashLoopBackOff`. Fix: include `Pending`, `CreateContainerError`, `ImagePullBackOff`, `NetworkError`, `ConfigError`, `FileSystemError`, `Error` in the filter. Status names match the DB's PascalCase exactly (a lowercase mismatch silently drops rows).

2. **`active` instance filter counted `created` containers as live.** `src/runtime/docker/instances.rs` listed containers in `running` / `created` / `restarting` as active. A container stuck in `Created` (start failed) was therefore counted as a healthy instance: `current_count == target_count`, scheduler skipped the retry path, `restart_count` never climbed. Fix: drop `created` — a non-running container that isn't restarting isn't live.

3. **Orphan `Created` containers accumulated.** Each failed `start` left a container behind. Fix: in `src/runtime/docker/container.rs`, when `start_container` fails, `remove_container` the orphan before returning the error.

## Test plan

- [x] **New e2e `tests/e2e/docker/t23_create_container_error_loop.sh`** boots a deployment whose `command` points at a missing binary (Docker accepts create, OCI runtime rejects start). After 60s, asserts:
  - status converged to `CrashLoopBackOff`
  - `restart_count >= 5` (i.e. `MAX_RESTART_COUNT`)
  - `Scaled up` events stay bounded (≤10)
- [x] Confirmed test catches the bug **before** the fix (`restart_count=1`, status stuck at `CreateContainerError`).
- [x] Confirmed test PASSes **after** the fix (`restart_count=5`, status `CrashLoopBackOff`).
- [x] Regression: `t1_create_delete` PASS — basic boot still works.
- [x] Regression: `t6_crashloop` PASS — classic exit-1 loop still converges identically (containers go through `running` → `exited`, never bloqued in `created`).
- [x] `cargo build --bin ring` clean, `cargo fmt --check` clean.