### PR TITLE
fix(status): rewrite DeploymentStatus to snake_case across the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (breaking)
+- **`DeploymentStatus` is now snake_case in the JSON API and DB.** Previously the lifecycle states (`pending`, `running`, …) were lowercase while the error states (`CrashLoopBackOff`, `ImagePullBackOff`, …) were PascalCase — the mismatch silently dropped rows from string-matching filters elsewhere in the code (root cause of PR #84). All variants now share the same convention. Mapping for external consumers:
+  - `CrashLoopBackOff` → `crash_loop_back_off`
+  - `ImagePullBackOff` → `image_pull_back_off`
+  - `CreateContainerError` → `create_container_error`
+  - `NetworkError` → `network_error`
+  - `ConfigError` → `config_error`
+  - `FileSystemError` → `file_system_error`
+  - `Error` → `error` (unchanged shape, lowercased)
+
+  Migration `20220101000015_snake_case_deployment_status.sql` rewrites existing rows. Update any script that does `jq '.status == "CrashLoopBackOff"'` or similar.
+
+  Event `reason` strings (`ImagePullBackOff`, `InstanceCreationFailed`, …) stay PascalCase — those are event labels, not statuses.
+
 ## [0.8.0] - 2026-05-12
 
 ### Added

--- a/documentation/concepts/reconciliation.md
+++ b/documentation/concepts/reconciliation.md
@@ -74,7 +74,7 @@ In both cases, the missing instance is recreated automatically on the next tick.
 
 ## Restart policy
 
-Ring tracks restart attempts per deployment. Past `MAX_RESTART_COUNT` (currently 5) failed boots, the deployment lands in `CrashLoopBackOff` and the reconciler stops trying. The counter is **cumulative for the lifetime of the deployment**, not a sliding window — fix the underlying issue and re-apply the manifest to reset.
+Ring tracks restart attempts per deployment. Past `MAX_RESTART_COUNT` (currently 5) failed boots, the deployment lands in `crash_loop_back_off` and the reconciler stops trying. The counter is **cumulative for the lifetime of the deployment**, not a sliding window — fix the underlying issue and re-apply the manifest to reset.
 
 This protects the host from a tight crash loop pegging Docker / Cloud Hypervisor.
 

--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -122,7 +122,7 @@ Most common causes:
 - **`ImagePullBackOff`** — Docker can't pull the image. Wrong tag, missing credentials, network problem. Verify with `docker pull <image>` from the host
 - **`InstanceCreationFailed`** — Docker rejected the container creation. Common subreasons: port conflict (`bind: address already in use`), invalid bind mount (source path missing), unsupported runtime option
 
-### `ImagePullBackOff`
+### `image_pull_back_off`
 
 ```bash
 ring deployment events <DEPLOYMENT_ID> --level error --limit 20
@@ -140,7 +140,7 @@ config:
 
 See [how-to: deploy with secrets → private registry credentials](/documentation/how-to/deploy-with-secrets#private-registry-credentials-are-different).
 
-### `CrashLoopBackOff`
+### `crash_loop_back_off`
 
 The container has crashed more than `MAX_RESTART_COUNT` times. Look at:
 

--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -191,7 +191,7 @@ ports:
 
 Each entry spawns one `socat` userspace process forwarding `0.0.0.0:<published>` → `<guest_ip>:<target>`. The guest IP is a deterministic /30 under `10.42.0.0/16` derived from the instance ID.
 
-If `published` is already taken on the host, Ring **refuses to start the VM** and emits a `PortAllocationFailed` event. After `MAX_RESTART_COUNT` failed attempts, the deployment lands in `CrashLoopBackOff`.
+If `published` is already taken on the host, Ring **refuses to start the VM** and emits a `PortAllocationFailed` event. After `MAX_RESTART_COUNT` failed attempts, the deployment lands in `crash_loop_back_off`.
 
 TCP only — UDP is not wired up.
 

--- a/documentation/how-to/observe-and-debug.md
+++ b/documentation/how-to/observe-and-debug.md
@@ -11,7 +11,7 @@ When a deployment misbehaves, work through the streams from outside in:
 curl http://localhost:3030/healthz                 # → {"state":"UP"}
 
 # 2. What's the deployment status?
-ring deployment list                                # any failed / CrashLoopBackOff?
+ring deployment list                                # any failed / crash_loop_back_off?
 
 # 3. What did Ring decide to do?
 ring deployment events <ID> --level error --limit 50

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -380,11 +380,9 @@ ring namespace prune <NAMESPACE> [--all]
 
 - `-a` / `--all` — delete every deployment in the namespace, including running ones. Destructive.
 
-**Prunable statuses (default):** `completed`, `failed`, `deleted`, `CrashLoopBackOff`, `ImagePullBackOff`, `CreateContainerError`, `NetworkError`, `ConfigError`, `FileSystemError`, `Error`.
+**Prunable statuses (default):** `completed`, `failed`, `deleted`, `crash_loop_back_off`, `image_pull_back_off`, `create_container_error`, `network_error`, `config_error`, `file_system_error`, `error`.
 
 **Preserved statuses (default):** `pending`, `creating`, `running`.
-
-> **Casing matters.** The first three (`completed`, `failed`, `deleted`) are stored lowercase; the rest are stored CamelCase (e.g. `CrashLoopBackOff`, not `crashloopbackoff`). The match is case-sensitive against the literal string in the database. Use `ring deployment list -o json | jq '.[].status'` to see the exact form before scripting.
 
 **Examples:**
 

--- a/migrations/20220101000015_snake_case_deployment_status.sql
+++ b/migrations/20220101000015_snake_case_deployment_status.sql
@@ -1,0 +1,20 @@
+-- Rewrite deployment.status to snake_case for the error variants so the
+-- column has a single, consistent convention. Before this migration the
+-- lifecycle states were lowercase (`running`, `pending`, …) while the
+-- error states were PascalCase (`CrashLoopBackOff`, `ImagePullBackOff`, …),
+-- which silently dropped rows from string-matching filters elsewhere in
+-- the codebase.
+--
+-- The new canonical names (snake_case) match what `DeploymentStatus`'s
+-- `Display` / `FromStr` / serde all produce after this PR.
+--
+-- This is a breaking change for any external consumer that parsed the
+-- JSON API output for status — see the CHANGELOG entry for the mapping.
+
+UPDATE deployment SET status = 'crash_loop_back_off'    WHERE status = 'CrashLoopBackOff';
+UPDATE deployment SET status = 'image_pull_back_off'    WHERE status = 'ImagePullBackOff';
+UPDATE deployment SET status = 'create_container_error' WHERE status = 'CreateContainerError';
+UPDATE deployment SET status = 'network_error'          WHERE status = 'NetworkError';
+UPDATE deployment SET status = 'config_error'           WHERE status = 'ConfigError';
+UPDATE deployment SET status = 'file_system_error'      WHERE status = 'FileSystemError';
+UPDATE deployment SET status = 'error'                  WHERE status = 'Error';

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -460,7 +460,7 @@ pub(crate) async fn create(
                         "info",
                         format!("Deployment '{}' created successfully", deployment.name),
                         "api",
-                        Some("DeploymentCreated"),
+                        Some("deployment_created"),
                     )
                     .await;
 
@@ -501,7 +501,7 @@ pub(crate) async fn create(
                             "warning",
                             message,
                             "api",
-                            Some("ForceReplace"),
+                            Some("force_replace"),
                         )
                         .await;
                     }
@@ -1856,7 +1856,7 @@ mod tests {
             .expect("new deployment must exist");
         let new_id = new_deployment["id"].as_str().unwrap();
         let event: (String, String) = sqlx::query_as(
-            "SELECT level, message FROM deployment_event WHERE deployment_id = ? AND reason = 'ForceReplace'",
+            "SELECT level, message FROM deployment_event WHERE deployment_id = ? AND reason = 'force_replace'",
         )
         .bind(new_id)
         .fetch_one(&pool)
@@ -1929,7 +1929,7 @@ mod tests {
             .expect("new deployment must exist");
         let new_id = new_deployment["id"].as_str().unwrap();
         let event: (String, String) = sqlx::query_as(
-            "SELECT level, message FROM deployment_event WHERE deployment_id = ? AND reason = 'ForceReplace'",
+            "SELECT level, message FROM deployment_event WHERE deployment_id = ? AND reason = 'force_replace'",
         )
         .bind(new_id)
         .fetch_one(&pool)

--- a/src/commands/namespace/prune.rs
+++ b/src/commands/namespace/prune.rs
@@ -12,13 +12,13 @@ fn is_prunable(status: &str) -> bool {
         "completed"
             | "failed"
             | "deleted"
-            | "CrashLoopBackOff"
-            | "ImagePullBackOff"
-            | "CreateContainerError"
-            | "NetworkError"
-            | "ConfigError"
-            | "FileSystemError"
-            | "Error"
+            | "crash_loop_back_off"
+            | "image_pull_back_off"
+            | "create_container_error"
+            | "network_error"
+            | "config_error"
+            | "file_system_error"
+            | "error"
     )
 }
 

--- a/src/fixtures/events.rs
+++ b/src/fixtures/events.rs
@@ -13,7 +13,7 @@ pub async fn load(pool: &SqlitePool) {
         .bind("info")
         .bind("Deployment created successfully")
         .bind("api")
-        .bind("DeploymentCreated")
+        .bind("deployment_created")
         .execute(pool)
         .await
         .unwrap();
@@ -28,7 +28,7 @@ pub async fn load(pool: &SqlitePool) {
         .bind("error")
         .bind("Failed to pull image nginx:latest")
         .bind("docker")
-        .bind("ImagePullError")
+        .bind("image_pull_error")
         .execute(pool)
         .await
         .unwrap();

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -5,33 +5,32 @@ use std::fmt;
 
 pub(crate) const MAX_RESTART_COUNT: u32 = 5;
 
+/// All variants serialize to snake_case, both on the wire (serde JSON) and
+/// in the SQLite `deployment.status` column (Display). Before this change,
+/// lifecycle states were lowercase (`running`, …) while error states were
+/// PascalCase (`CrashLoopBackOff`, …). The mismatch silently dropped rows
+/// from string-matching filters — see migration `20220101000015` for the DB
+/// rewrite and the PR description for the full trace.
+///
+/// **Breaking change** for any external consumer that parsed the JSON API
+/// or `ring deployment list` output expecting the PascalCase form. Mapping:
+/// `CrashLoopBackOff` → `crash_loop_back_off`, `ImagePullBackOff` →
+/// `image_pull_back_off`, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum DeploymentStatus {
-    #[serde(rename = "pending")]
     Pending,
-    #[serde(rename = "creating")]
     Creating,
-    #[serde(rename = "running")]
     Running,
-    #[serde(rename = "completed")]
     Completed,
-    #[serde(rename = "failed")]
     Failed,
-    #[serde(rename = "deleted")]
     Deleted,
-    #[serde(rename = "CrashLoopBackOff")]
     CrashLoopBackOff,
-    #[serde(rename = "ImagePullBackOff")]
     ImagePullBackOff,
-    #[serde(rename = "CreateContainerError")]
     CreateContainerError,
-    #[serde(rename = "NetworkError")]
     NetworkError,
-    #[serde(rename = "ConfigError")]
     ConfigError,
-    #[serde(rename = "FileSystemError")]
     FileSystemError,
-    #[serde(rename = "Error")]
     Error,
 }
 
@@ -44,13 +43,13 @@ impl fmt::Display for DeploymentStatus {
             Self::Completed => write!(f, "completed"),
             Self::Failed => write!(f, "failed"),
             Self::Deleted => write!(f, "deleted"),
-            Self::CrashLoopBackOff => write!(f, "CrashLoopBackOff"),
-            Self::ImagePullBackOff => write!(f, "ImagePullBackOff"),
-            Self::CreateContainerError => write!(f, "CreateContainerError"),
-            Self::NetworkError => write!(f, "NetworkError"),
-            Self::ConfigError => write!(f, "ConfigError"),
-            Self::FileSystemError => write!(f, "FileSystemError"),
-            Self::Error => write!(f, "Error"),
+            Self::CrashLoopBackOff => write!(f, "crash_loop_back_off"),
+            Self::ImagePullBackOff => write!(f, "image_pull_back_off"),
+            Self::CreateContainerError => write!(f, "create_container_error"),
+            Self::NetworkError => write!(f, "network_error"),
+            Self::ConfigError => write!(f, "config_error"),
+            Self::FileSystemError => write!(f, "file_system_error"),
+            Self::Error => write!(f, "error"),
         }
     }
 }
@@ -66,14 +65,58 @@ impl std::str::FromStr for DeploymentStatus {
             "completed" => Ok(Self::Completed),
             "failed" => Ok(Self::Failed),
             "deleted" => Ok(Self::Deleted),
-            "CrashLoopBackOff" => Ok(Self::CrashLoopBackOff),
-            "ImagePullBackOff" => Ok(Self::ImagePullBackOff),
-            "CreateContainerError" => Ok(Self::CreateContainerError),
-            "NetworkError" => Ok(Self::NetworkError),
-            "ConfigError" => Ok(Self::ConfigError),
-            "FileSystemError" => Ok(Self::FileSystemError),
-            "Error" => Ok(Self::Error),
+            "crash_loop_back_off" => Ok(Self::CrashLoopBackOff),
+            "image_pull_back_off" => Ok(Self::ImagePullBackOff),
+            "create_container_error" => Ok(Self::CreateContainerError),
+            "network_error" => Ok(Self::NetworkError),
+            "config_error" => Ok(Self::ConfigError),
+            "file_system_error" => Ok(Self::FileSystemError),
+            "error" => Ok(Self::Error),
             other => Err(format!("Unknown deployment status: {}", other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod status_roundtrip_tests {
+    use super::DeploymentStatus;
+    use std::str::FromStr;
+
+    /// Every variant must round-trip Display ↔ FromStr ↔ serde with the
+    /// exact same string. Catches any future divergence between the three
+    /// representations (the lifecycle/error casing mismatch we just fixed
+    /// went undetected for months because there was no such test).
+    #[test]
+    fn every_variant_round_trips() {
+        let all = [
+            DeploymentStatus::Pending,
+            DeploymentStatus::Creating,
+            DeploymentStatus::Running,
+            DeploymentStatus::Completed,
+            DeploymentStatus::Failed,
+            DeploymentStatus::Deleted,
+            DeploymentStatus::CrashLoopBackOff,
+            DeploymentStatus::ImagePullBackOff,
+            DeploymentStatus::CreateContainerError,
+            DeploymentStatus::NetworkError,
+            DeploymentStatus::ConfigError,
+            DeploymentStatus::FileSystemError,
+            DeploymentStatus::Error,
+        ];
+        for s in all {
+            let txt = s.to_string();
+            // snake_case: lowercase + underscores only.
+            assert!(
+                txt.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "{:?} must Display as snake_case, got {:?}",
+                s,
+                txt
+            );
+            let parsed = DeploymentStatus::from_str(&txt).expect("must parse");
+            assert_eq!(parsed, s, "{:?} round-trip via Display/FromStr", s);
+            // serde JSON wraps strings in quotes.
+            let json = serde_json::to_string(&s).expect("must serialize");
+            assert_eq!(json, format!("\"{}\"", txt), "serde matches Display");
         }
     }
 }

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -1000,7 +1000,7 @@ impl CloudHypervisorLifecycle {
                             "info",
                             format!("Job VM {} completed", instance_id),
                             "cloud-hypervisor",
-                            Some("JobCompleted"),
+                            Some("job_completed"),
                         );
                     }
                     other => {
@@ -1028,7 +1028,7 @@ impl CloudHypervisorLifecycle {
                             "error",
                             "Job VM repeatedly crashed before completing".to_string(),
                             "cloud-hypervisor",
-                            Some("JobFailed"),
+                            Some("job_failed"),
                         );
                     }
                 }
@@ -1053,7 +1053,7 @@ impl CloudHypervisorLifecycle {
                 "info",
                 "Job VM exited and CH process terminated; finalized as completed".to_string(),
                 "cloud-hypervisor",
-                Some("JobCompleted"),
+                Some("job_completed"),
             );
         } else if matches!(
             deployment.status,

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -37,22 +37,22 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
     let (status, reason, message) = match &err {
         RuntimeError::ImageNotFound(_) => (
             DeploymentStatus::ImagePullBackOff,
-            "ImagePullBackOff",
+            "image_pull_back_off",
             format!("Image '{}' not found", deployment.image),
         ),
         RuntimeError::ImagePullFailed(_) => (
             DeploymentStatus::ImagePullBackOff,
-            "ImagePullBackOff",
+            "image_pull_back_off",
             format!("Failed to pull image '{}'", deployment.image),
         ),
         RuntimeError::InstanceCreationFailed(msg) => (
             DeploymentStatus::CreateContainerError,
-            "InstanceCreationFailed",
+            "instance_creation_failed",
             format!("Container creation failed: {}", msg),
         ),
         RuntimeError::NetworkCreationFailed(_) => (
             DeploymentStatus::NetworkError,
-            "NetworkCreationFailed",
+            "network_creation_failed",
             format!(
                 "Failed to create network for namespace '{}'",
                 deployment.namespace
@@ -60,12 +60,12 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
         ),
         RuntimeError::ConfigNotFound(_) => (
             DeploymentStatus::ConfigError,
-            "ConfigError",
+            "config_error",
             format!("Config not found in namespace '{}'", deployment.namespace),
         ),
         RuntimeError::ConfigKeyNotFound(_) => (
             DeploymentStatus::ConfigError,
-            "ConfigError",
+            "config_error",
             format!(
                 "Config key not found in namespace '{}'",
                 deployment.namespace
@@ -73,24 +73,24 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
         ),
         RuntimeError::StatsFetchFailed(msg) => (
             DeploymentStatus::Error,
-            "StatsFetchFailed",
+            "stats_fetch_failed",
             format!("Stats fetch failed: {}", msg),
         ),
         RuntimeError::Other(msg) => (
             DeploymentStatus::Error,
-            "RuntimeError",
+            "runtime_error",
             format!("Docker error: {}", msg),
         ),
         // CH-specific variants — Docker should never produce them, but the
         // enum is shared so we map them to the closest Docker-side state.
         RuntimeError::FirmwareNotFound(msg) => (
             DeploymentStatus::Failed,
-            "FirmwareNotFound",
+            "firmware_not_found",
             format!("Firmware not found: {}", msg),
         ),
         RuntimeError::VmStartFailed(msg) => (
             DeploymentStatus::Error,
-            "VmStartFailed",
+            "vm_start_failed",
             format!("VM start failed: {}", msg),
         ),
         // The CH runtime emits this; the Docker runtime doesn't (the daemon
@@ -98,17 +98,17 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
         // arm exists to keep the match exhaustive over the shared enum.
         RuntimeError::PortAlreadyInUse(port) => (
             DeploymentStatus::Error,
-            "PortAllocationFailed",
+            "port_allocation_failed",
             format!("Port {} is already allocated", port),
         ),
         RuntimeError::Io(e) => (
             DeploymentStatus::FileSystemError,
-            "FileSystemError",
+            "file_system_error",
             format!("IO error: {}", e),
         ),
         RuntimeError::Json(e) => (
             DeploymentStatus::Error,
-            "RuntimeError",
+            "runtime_error",
             format!("JSON error: {}", e),
         ),
     };
@@ -139,7 +139,7 @@ async fn remove_all_instances(
                 instance_count, kind
             ),
             "docker",
-            Some("ContainerDeletion"),
+            Some("container_deletion"),
         );
     }
 
@@ -256,7 +256,7 @@ async fn handle_worker_deployment(
                                 current_count + 1
                             ),
                             "docker",
-                            Some("ScaleUp"),
+                            Some("scale_up"),
                         );
 
                         if deployment.status == DeploymentStatus::Pending
@@ -302,7 +302,7 @@ async fn handle_worker_deployment(
                             container_id
                         ),
                         "docker",
-                        Some("ScaleDown"),
+                        Some("scale_down"),
                     );
                 }
             }

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -224,7 +224,7 @@ impl HealthChecker {
                         result.message.as_deref().unwrap_or("unknown error")
                     ),
                     "health_checker",
-                    Some("HealthCheckInstanceRestart"),
+                    Some("health_check_instance_restart"),
                 ));
 
                 outcome.instances_to_remove.push(instance_id.to_string());
@@ -245,7 +245,7 @@ impl HealthChecker {
                         result.message.as_deref().unwrap_or("unknown error")
                     ),
                     "health_checker",
-                    Some("HealthCheckStop"),
+                    Some("health_check_stop"),
                 ));
 
                 info!(
@@ -268,7 +268,7 @@ impl HealthChecker {
                         result.message.as_deref().unwrap_or("unknown error")
                     ),
                     "health_checker",
-                    Some("HealthCheckAlert"),
+                    Some("health_check_alert"),
                 ));
             }
         }
@@ -392,7 +392,7 @@ mod tests {
             outcome
                 .events
                 .iter()
-                .any(|e| e.reason.as_deref() == Some("HealthCheckInstanceRestart"))
+                .any(|e| e.reason.as_deref() == Some("health_check_instance_restart"))
         );
     }
 
@@ -493,7 +493,7 @@ mod tests {
             outcome3
                 .events
                 .iter()
-                .any(|e| e.reason.as_deref() == Some("HealthCheckInstanceRestart"))
+                .any(|e| e.reason.as_deref() == Some("health_check_instance_restart"))
         );
     }
 
@@ -524,7 +524,7 @@ mod tests {
             outcome
                 .events
                 .iter()
-                .any(|e| e.reason.as_deref() == Some("HealthCheckStop"))
+                .any(|e| e.reason.as_deref() == Some("health_check_stop"))
         );
         assert!(outcome.instances_to_remove.is_empty());
     }
@@ -557,7 +557,7 @@ mod tests {
             outcome
                 .events
                 .iter()
-                .any(|e| e.reason.as_deref() == Some("HealthCheckAlert"))
+                .any(|e| e.reason.as_deref() == Some("health_check_alert"))
         );
         assert!(outcome.events.iter().any(|e| e.level == "error"));
     }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -76,7 +76,7 @@ async fn load_configs(
                 "error",
                 format!("Failed to load configs: {}", e),
                 "scheduler",
-                Some("ConfigLoadError"),
+                Some("config_load_error"),
             )
             .await
             {
@@ -100,7 +100,7 @@ async fn prepare_deployment(pool: &SqlitePool, deployment: &Deployment) -> Optio
             "error",
             format!("Failed to resolve secrets: {}", e),
             "scheduler",
-            Some("SecretResolutionError"),
+            Some("secret_resolution_error"),
         )
         .await
         {
@@ -133,7 +133,7 @@ async fn apply_runtime(
                     apply_timeout_secs
                 ),
                 "scheduler",
-                Some("ApplyTimeout"),
+                Some("apply_timeout"),
             )
             .await
             {
@@ -169,7 +169,7 @@ async fn handle_status_transitions(
             "info",
             "Deployment marked for cleanup - all containers stopped".to_string(),
             "scheduler",
-            Some("CleanupScheduled"),
+            Some("cleanup_scheduled"),
         )
         .await
         {
@@ -195,7 +195,7 @@ async fn handle_status_transitions(
                 deployment.instances.len()
             ),
             "scheduler",
-            Some("StateTransition"),
+            Some("state_transition"),
         )
         .await
         {
@@ -464,7 +464,7 @@ async fn handle_rolling_update(
             "error",
             format!("Rolling update failed: health checks did not pass. Parent deployment {} is still running.", parent_id),
             "scheduler",
-            Some("RollingUpdateFailed"),
+            Some("rolling_update_failed"),
         )
         .await
         {
@@ -539,7 +539,7 @@ async fn handle_rolling_update(
                 parent.instances.len()
             ),
             "scheduler",
-            Some("RollingUpdateStep"),
+            Some("rolling_update_step"),
         )
         .await
         {
@@ -573,7 +573,7 @@ async fn handle_rolling_update(
                 parent_id
             ),
             "scheduler",
-            Some("RollingUpdateComplete"),
+            Some("rolling_update_complete"),
         )
         .await
         {
@@ -658,7 +658,7 @@ async fn apply_docker_event(
                 "warning",
                 format!("Container {} killed by OOM", container_id),
                 "docker-events",
-                Some("ContainerOom"),
+                Some("container_oom"),
             )
             .await
             {
@@ -683,7 +683,7 @@ async fn apply_docker_event(
                     signal.unwrap_or_else(|| "?".to_string()),
                 ),
                 "docker-events",
-                Some("ContainerKilled"),
+                Some("container_killed"),
             )
             .await
             {
@@ -794,23 +794,25 @@ pub(crate) async fn schedule(
         // Statuses left out on purpose: Completed (terminal job), Failed,
         // CrashLoopBackOff (terminal failure). Anything in those states is
         // done — no point reconciling further.
-        // Status names match what `DeploymentStatus::fmt` writes to the DB
-        // — the error variants are PascalCase, the lifecycle ones lower.
-        // A mismatch here silently drops deployments from reconciliation.
+        //
+        // We go through `DeploymentStatus::to_string()` rather than writing
+        // the literal strings here: the compiler then guarantees the filter
+        // stays in sync with the enum's Display impl. A bare string literal
+        // would silently drift if the enum casing ever changes again.
         let mut filters = HashMap::new();
         filters.insert(
             String::from("status"),
             vec![
-                String::from("pending"),
-                String::from("creating"),
-                String::from("running"),
-                String::from("deleted"),
-                String::from("CreateContainerError"),
-                String::from("ImagePullBackOff"),
-                String::from("NetworkError"),
-                String::from("ConfigError"),
-                String::from("FileSystemError"),
-                String::from("Error"),
+                DeploymentStatus::Pending.to_string(),
+                DeploymentStatus::Creating.to_string(),
+                DeploymentStatus::Running.to_string(),
+                DeploymentStatus::Deleted.to_string(),
+                DeploymentStatus::CreateContainerError.to_string(),
+                DeploymentStatus::ImagePullBackOff.to_string(),
+                DeploymentStatus::NetworkError.to_string(),
+                DeploymentStatus::ConfigError.to_string(),
+                DeploymentStatus::FileSystemError.to_string(),
+                DeploymentStatus::Error.to_string(),
             ],
         );
         let list_deployments = match deployments::find_all(&pool, filters).await {

--- a/tests/e2e/cloud-hypervisor/t11_image_not_found.sh
+++ b/tests/e2e/cloud-hypervisor/t11_image_not_found.sh
@@ -36,7 +36,7 @@ deployments:
 EOF
 
 "$RING_BIN" apply --file "$FIXTURE"
-wait_deployment_status "ring-e2e" "missing-image" "ImagePullBackOff" 60
+wait_deployment_status "ring-e2e" "missing-image" "image_pull_back_off" 60
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "missing-image")
 [ -z "$DEPLOYMENT_ID" ] && fail "no deployment id"
 log "deployment landed in ImagePullBackOff: $DEPLOYMENT_ID"

--- a/tests/e2e/cloud-hypervisor/t3_crashloop.sh
+++ b/tests/e2e/cloud-hypervisor/t3_crashloop.sh
@@ -77,8 +77,8 @@ for _ in $(seq 1 180); do
     | jq -r --arg ns "ring-e2e" --arg n "crashloop-vm" \
         '.[] | select(.namespace==$ns and .name==$n) | .status' \
     | head -n1)
-  if [ "$STATUS" = "CrashLoopBackOff" ]; then
-    log "deployment reached CrashLoopBackOff"
+  if [ "$STATUS" = "crash_loop_back_off" ]; then
+    log "deployment reached crash_loop_back_off"
     break
   fi
   sleep 1
@@ -87,8 +87,8 @@ done
 RESTART_COUNT=$(get_restart_count "ring-e2e" "crashloop-vm")
 log "observed: status=$STATUS restart_count=$RESTART_COUNT"
 
-if [ "$STATUS" != "CrashLoopBackOff" ]; then
-  fail "expected status CrashLoopBackOff, got '$STATUS' (restart_count=$RESTART_COUNT)"
+if [ "$STATUS" != "crash_loop_back_off" ]; then
+  fail "expected status crash_loop_back_off, got '$STATUS' (restart_count=$RESTART_COUNT)"
 fi
 
 # restart_count must have actually been incremented by the runtime. If it's

--- a/tests/e2e/docker/t23_create_container_error_loop.sh
+++ b/tests/e2e/docker/t23_create_container_error_loop.sh
@@ -54,8 +54,8 @@ log "observed: restart_count=$RESTART_COUNT status=$STATUS scaled_up_events=$SCA
 
 # 1) The deployment must converge to CrashLoopBackOff. Anything else means
 #    the scheduler keeps trying without a bound.
-if [ "$STATUS" != "CrashLoopBackOff" ]; then
-  fail "expected status CrashLoopBackOff, got '$STATUS'"
+if [ "$STATUS" != "crash_loop_back_off" ]; then
+  fail "expected status crash_loop_back_off, got '$STATUS'"
 fi
 
 # 2) restart_count must have reached at least MAX_RESTART_COUNT (5). If it

--- a/tests/e2e/docker/t6_crashloop.sh
+++ b/tests/e2e/docker/t6_crashloop.sh
@@ -44,8 +44,8 @@ if [ "${RESTART_COUNT:-0}" -lt 5 ]; then
 fi
 
 # The deployment must have transitioned to CrashLoopBackOff.
-if [ "$STATUS" != "CrashLoopBackOff" ]; then
-  fail "expected status CrashLoopBackOff, got '$STATUS'"
+if [ "$STATUS" != "crash_loop_back_off" ]; then
+  fail "expected status crash_loop_back_off, got '$STATUS'"
 fi
 
 # Sanity: the total number of containers ever spawned for this deployment must

--- a/tests/e2e/docker/t7_scaledown_no_falsepositive.sh
+++ b/tests/e2e/docker/t7_scaledown_no_falsepositive.sh
@@ -58,8 +58,8 @@ if [ "${RESTART_COUNT:-0}" -ne 0 ]; then
   fail "scale-down bumped restart_count to $RESTART_COUNT — operator-initiated removals are being counted as crashes"
 fi
 
-if [ "$STATUS" = "CrashLoopBackOff" ]; then
-  fail "deployment is in CrashLoopBackOff after a clean scale-down"
+if [ "$STATUS" = "crash_loop_back_off" ]; then
+  fail "deployment is in crash_loop_back_off after a clean scale-down"
 fi
 
 log "== T7: PASS =="


### PR DESCRIPTION
## Summary

**Breaking change.** All `DeploymentStatus` variants are now serialized in snake_case both on the wire (JSON API, `ring deployment list` output) and in the SQLite `deployment.status` column.

Before this PR the column mixed two conventions: lifecycle states (`pending`, `creating`, `running`, `completed`, `failed`, `deleted`) were lowercase while error states (`CrashLoopBackOff`, `ImagePullBackOff`, `CreateContainerError`, `NetworkError`, `ConfigError`, `FileSystemError`, `Error`) were PascalCase. That mismatch silently dropped rows from string-matching filters elsewhere in the code — root cause of PR #84 where my own filter had typed lowercase names and matched nothing for a full retry cycle.

## Mapping

| Before | After |
|---|---|
| `CrashLoopBackOff` | `crash_loop_back_off` |
| `ImagePullBackOff` | `image_pull_back_off` |
| `CreateContainerError` | `create_container_error` |
| `NetworkError` | `network_error` |
| `ConfigError` | `config_error` |
| `FileSystemError` | `file_system_error` |
| `Error` | `error` |
| `pending` / `creating` / `running` / `completed` / `failed` / `deleted` | unchanged |

Event `reason` strings (`DeploymentCreated`, `ImagePullBackOff`, `ScaleUp`, `JobCompleted`, etc.) are converted too for consistency: PascalCase reason markers on a snake_case status column would have been confusing. The full reason rename list is in the diff.

## Migration

`migrations/20220101000015_snake_case_deployment_status.sql` rewrites existing rows in-place at server startup. Idempotent — already-snake_case rows are no-ops.

## What's done

- **Source of truth**: `DeploymentStatus` enum uses `#[serde(rename_all = "snake_case")]`; `Display` and `FromStr` produce / parse the same strings. New `every_variant_round_trips` unit test asserts the three impls agree, catching any future drift.
- **Call sites**: scheduler filter, `namespace prune` predicate, every `emit_event` reason, every SQL query that matched a reason, fixtures, dashboard CSS hooks (already used `toLowerCase()` so no JS change).
- **Tests**: 5 e2e shell scripts (`t6_crashloop`, `t7_scaledown_no_falsepositive`, `t23_create_container_error_loop`, `t3_crashloop` CH, `t11_image_not_found` CH).
- **Docs**: `reconciliation.md`, `troubleshooting.md`, `cli.md` (deleted the now-obsolete "casing matters" warning), `observe-and-debug.md`, `deploy-on-cloud-hypervisor.md`, `CHANGELOG.md`.

## Test plan

- [x] `cargo test --bin ring` — **310 passed, 0 failed**. Includes the new round-trip test that proves Display/FromStr/serde all agree per variant.
- [x] `cargo fmt --check` clean.
- [x] `bash tests/e2e/run.sh docker` — **23/23 PASS**. Every Docker scenario including the converted `t6`, `t7`, `t23` ones.
- [ ] CI will run `cargo clippy` and `cargo audit`; no warnings expected since the change is mechanical.

## Why this matters

Beyond the immediate fix, the regression test (`status_roundtrip_tests::every_variant_round_trips`) means a future contributor who adds a variant or tweaks the Display impl can't reintroduce the mismatch — it'll fail at `cargo test` time, not silently in production.