### PR TITLE
fix(docker): converge kind: job CreateContainerError to Failed after MAX_RESTART_COUNT

### DIFF
--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -175,6 +175,25 @@ async fn handle_job_deployment(
         return deployment;
     }
 
+    // Terminal states: a one-shot job is done either way. Stop reconciling.
+    // `Failed` is the job equivalent of `CrashLoopBackOff` for workers — set
+    // below when restart_count hits MAX_RESTART_COUNT.
+    if matches!(
+        deployment.status,
+        DeploymentStatus::Completed | DeploymentStatus::Failed
+    ) {
+        return deployment;
+    }
+
+    // Cap retries the same way workers do, but flip to `Failed` (terminal,
+    // one-shot) instead of `CrashLoopBackOff` (long-running). A job that
+    // never managed to boot after MAX_RESTART_COUNT tries is functionally
+    // done — surface that to the operator.
+    if deployment.restart_count >= MAX_RESTART_COUNT {
+        deployment.status = DeploymentStatus::Failed;
+        return deployment;
+    }
+
     let all_instances = list_instances(&docker, deployment.id.to_string(), "all").await;
 
     if let Some(instance_id) = all_instances.first() {
@@ -189,15 +208,21 @@ async fn handle_job_deployment(
                 deployment.status = DeploymentStatus::Failed;
             }
         }
-    } else if deployment.status == DeploymentStatus::Creating
-        || deployment.status == DeploymentStatus::Pending
-    {
+    } else {
+        // No instance: either we've never created one (Creating / Pending)
+        // or the previous attempt left a transient error state (e.g.
+        // create_container_error after Docker rejected `start`). Either
+        // way, try again — the retry path is what eventually grows
+        // restart_count past MAX_RESTART_COUNT and converges to Failed.
         match create_container(&mut deployment, &docker, &resolved_mounts).await {
             Ok(_) => {
                 deployment.status = DeploymentStatus::Running;
             }
             Err(err) => {
-                handle_create_error(&mut deployment, err, false);
+                // `true` so the failure counts toward MAX_RESTART_COUNT.
+                // Without this, the job loops on `create_container_error`
+                // forever and the operator never sees a terminal state.
+                handle_create_error(&mut deployment, err, true);
             }
         }
     }

--- a/tests/e2e/docker/t24_job_create_container_error.sh
+++ b/tests/e2e/docker/t24_job_create_container_error.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# T24: a `kind: job` whose container is rejected by Docker `start` (OCI
+# runtime cannot exec the binary, e.g. command pointing at a missing
+# file) must converge to a terminal state — `failed` — rather than sit
+# in `create_container_error` indefinitely.
+#
+# Before the fix, `handle_job_deployment` only triggered creation when
+# status was `creating` / `pending` and called `handle_create_error`
+# with `increment_restart: false`. The first failed boot pushed status
+# to `create_container_error` and the deployment was never retried —
+# the operator had no signal that the job had actually failed.
+#
+# After the fix:
+#   1. The scheduler keeps reconciling `create_container_error` deployments
+#      (PR #84 already extends the status filter).
+#   2. `handle_job_deployment` retries from error states like `worker` does.
+#   3. `restart_count` is incremented on each failure (`increment_restart:
+#      true`), and once it reaches `MAX_RESTART_COUNT`, the runtime flips
+#      the deployment to `Failed` — terminal for a one-shot job.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T24: kind: job CreateContainerError must converge to Failed =="
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/job-oci-error.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  job-oci-error:
+    name: job-oci-error
+    namespace: ring-e2e
+    runtime: docker
+    kind: job
+    image: alpine:3.19
+    # Docker accepts `create` but `start` fails: OCI runtime can't exec
+    # a binary that doesn't exist.
+    command: ["/nonexistent-binary"]
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# 60s is well past MAX_RESTART_COUNT (5) at a 1s scheduler interval.
+log "waiting 60s for scheduler to converge..."
+sleep 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "job-oci-error")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+RESTART_COUNT=$(get_restart_count "ring-e2e" "job-oci-error")
+STATUS=$("$RING_BIN" deployment list --output json \
+  | jq -r --arg ns "ring-e2e" --arg n "job-oci-error" \
+      '.[] | select(.namespace==$ns and .name==$n) | .status' \
+  | head -n1)
+
+log "observed: status=$STATUS restart_count=$RESTART_COUNT"
+
+# 1) Terminal: must end up in `failed` (one-shot semantics, not the
+#    long-running `crash_loop_back_off` we use for workers).
+if [ "$STATUS" != "failed" ]; then
+  fail "expected status failed, got '$STATUS' — job is stuck in a non-terminal state"
+fi
+
+# 2) restart_count must have reached MAX_RESTART_COUNT (5). If it stayed
+#    at 0 or 1, the runtime swallowed the failures silently — that's
+#    the exact bug this test guards.
+if [ "${RESTART_COUNT:-0}" -lt 5 ]; then
+  fail "expected restart_count >= 5, got $RESTART_COUNT — job didn't actually retry"
+fi
+
+log "== T24: PASS =="


### PR DESCRIPTION
## Summary

A `kind: job` deployment whose container is accepted by Docker `create` but rejected by `start` (OCI runtime can't exec the binary — bad command, missing binary, exec format error) used to sit in `create_container_error` forever. `restart_count` never moved, the operator had no signal the job had actually failed, and the scheduler kept re-emitting events on every reconciliation tick.

This mirrors PR #84 (same root cause for workers) but for the job branch. Two changes in `handle_job_deployment`:

1. **Retry from error states**: the previous code only attempted `create_container` when status was `creating` / `pending`. Now we also retry from any transient error state — same logic the worker uses, gated by `restart_count < MAX_RESTART_COUNT`. PR #84 already extended the scheduler's status filter so error-state jobs reach this branch.

2. **Count the failures**: `handle_create_error` is now called with `increment_restart: true`. Without that bump, `restart_count` stayed at 0 forever, and the cap-and-converge logic added in (1) had nothing to trip on.

When `restart_count` hits `MAX_RESTART_COUNT`, the deployment flips to **`Failed`** — the terminal state for a one-shot job (the equivalent of `crash_loop_back_off` for workers, but semantically distinct: a job that never managed to boot is functionally done, not "in a loop").

Also short-circuits the apply loop early when status is `Completed` or `Failed` so terminal jobs stop being reconciled.

## Test plan

- [x] **New e2e `tests/e2e/docker/t24_job_create_container_error.sh`** boots a `kind: job` whose `command` points at a missing binary. After 60s, asserts:
  - status converged to `failed`
  - `restart_count >= 5` (i.e. MAX_RESTART_COUNT)
- [x] Confirmed t24 catches the bug **before** the fix (`status=create_container_error`, `restart_count=0`).
- [x] Confirmed t24 PASSes **after** the fix (`status=failed`, `restart_count=5`).
- [x] Full Docker suite: **24/24 PASS** (one flake on t16 from a transient Docker Hub pull failure — re-ran isolated, PASS. Not related to this PR).
- [x] `cargo test --bin ring` — 310/310. `cargo fmt --check` clean.

## Why this matters

Job semantics required this. A worker stuck looping is annoying but observable (the operator sees `crash_loop_back_off`). A job stuck in `create_container_error` looks like "still trying" — an operator can wait indefinitely without realizing the job is functionally dead. Now they get `failed` with the same reliability guarantee as workers get `crash_loop_back_off`.