### PR TITLE
fix(docker): clean up orphan container on connect_network failure too

### DIFF
--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -328,15 +328,25 @@ pub(crate) async fn create_container(
                     endpoint_config: Some(endpoint_config),
                 };
 
-                docker
-                    .connect_network(&network_name, connect_request)
-                    .await
-                    .map_err(|e| {
-                        RuntimeError::InstanceCreationFailed(format!(
-                            "Docker failed to connect to network: {}",
-                            e
-                        ))
-                    })?;
+                if let Err(e) = docker.connect_network(&network_name, connect_request).await {
+                    // Same orphan guard as `start_container` below: Docker
+                    // accepted `create` (the container exists, in `Created`
+                    // state) but the follow-up call failed. Without this
+                    // cleanup, the orphan would be picked up by
+                    // `list_instances` on the next reconciliation tick as
+                    // if it were a healthy instance, masking the need to
+                    // retry and accumulating one stale container per failed
+                    // attempt.
+                    remove_container(docker.clone(), container.id.clone()).await;
+                    // Also drop the id from in-memory instances so the
+                    // caller doesn't carry a reference to a container that
+                    // no longer exists.
+                    deployment.instances.pop();
+                    return Err(RuntimeError::InstanceCreationFailed(format!(
+                        "Docker failed to connect to network: {}",
+                        e
+                    )));
+                }
             }
 
             let start_options = StartContainerOptionsBuilder::new().build();
@@ -350,6 +360,7 @@ pub(crate) async fn create_container(
                 // container that's neither running nor counted toward
                 // restart_count.
                 remove_container(docker.clone(), container.id.clone()).await;
+                deployment.instances.pop();
                 return Err(RuntimeError::InstanceCreationFailed(format!(
                     "Docker failed to start container: {}",
                     e

--- a/tests/e2e/docker/t23_create_container_error_loop.sh
+++ b/tests/e2e/docker/t23_create_container_error_loop.sh
@@ -73,4 +73,15 @@ if [ "$SCALED_UP_COUNT" -gt 10 ]; then
   fail "too many 'Scaled up' events ($SCALED_UP_COUNT) — scheduler is re-emitting them past CrashLoopBackOff"
 fi
 
+# 4) Orphan containers must be cleaned up. Each failed `start_container`
+#    used to leave a stale container in `Created` state behind it
+#    (PR #84 fix for the start path; this PR generalises the cleanup to
+#    every early-return inside `create_container`). After convergence,
+#    Docker must show zero containers for this deployment.
+ORPHAN_COUNT=$(docker ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+if [ "$ORPHAN_COUNT" -gt 0 ]; then
+  docker ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" --format "{{.ID}} {{.Status}}" >&2
+  fail "$ORPHAN_COUNT orphan container(s) left behind — create_container path doesn't clean up its failures"
+fi
+
 log "== T23: PASS =="


### PR DESCRIPTION
## Summary

PR #84 cleaned up the orphan container when `start_container` fails, but the same `create_container` function has another early-return path that was left untouched: if `connect_network` fails after Docker accepted `create_container`, the container stayed in `Created` state forever.

Each retry would leave a fresh orphan behind. Once enough piled up, `list_instances` saw them as "live" instances (PR #84 dropped `created` from the active filter, so this is no longer the case, but the orphans still wasted disk + show up in `docker ps -a`).

This PR symmetrises the cleanup:

- `connect_network` error path now does `remove_container` + `deployment.instances.pop()` before returning the error, mirroring the `start_container` path.
- `start_container` error path gets the matching `deployment.instances.pop()` so the in-memory deployment object doesn't carry a phantom id either (PR #84 already removed the container Docker-side; this is the missing in-memory tidy-up).

## Test plan

- [x] Extended `tests/e2e/docker/t23_create_container_error_loop.sh` with a hard-fail check on orphan containers: after the deployment converges to `crash_loop_back_off`, `docker ps -aq --filter "label=ring_deployment=<id>"` must return zero rows.
- [x] t23 PASS post-fix: `restart_count=5`, `status=crash_loop_back_off`, `scaled_up_events=0`, **0 orphans**.
- [x] `cargo test --bin ring` — 310/310.
- [x] `cargo fmt --check` clean.
- [x] Full Docker e2e suite — **24/24 PASS**, no regression.

## Note on the `connect_network` path

I didn't write a dedicated e2e for that specific path: forcing `connect_network` to fail reliably from a test would require either racing the Docker network removal between calls or a mock layer over bollard, neither cheap. The fix is mechanical (same pattern as the `start_container` path that does have coverage), and the orphan check in t23 would catch any regression to the broader `create_container` cleanup contract.