### PR TITLE
feat(api): RFC 7807 validation responses for user create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed (breaking)
+- **Validation errors on `POST /users` and `PUT /users/{id}` now use RFC 7807.** The 422 response shape changed from the bare `validator`-derived `{"errors": <map>}` to `application/problem+json`:
+
+  ```json
+  {
+    "type": "about:blank",
+    "title": "Validation failed",
+    "status": 422,
+    "detail": "username: must be 2 to 50 characters\npassword: must be 8 to 128 characters",
+    "violations": [
+      { "property_path": "username", "message": "must be 2 to 50 characters", "code": "user.username.length" },
+      { "property_path": "password", "message": "must be 8 to 128 characters", "code": "user.password.length" }
+    ]
+  }
+  ```
+
+  Every violation carries a stable `code` slug (e.g. `user.username.format`) that clients can branch on without parsing the human message. All applicable rules run on every request — the response lists every failure in one shot instead of stopping at the first.
+
+  Username format is now `[a-zA-Z0-9][a-zA-Z0-9._-]*` (2-50 chars), matching GitHub-style conventions for human-facing identifiers. Password rules unchanged (8-128 chars).
+
 - **`DeploymentStatus` is now snake_case in the JSON API and DB.** Previously the lifecycle states (`pending`, `running`, …) were lowercase while the error states (`CrashLoopBackOff`, `ImagePullBackOff`, …) were PascalCase — the mismatch silently dropped rows from string-matching filters elsewhere in the code (root cause of PR #84). All variants now share the same convention. Mapping for external consumers:
   - `CrashLoopBackOff` → `crash_loop_back_off`
   - `ImagePullBackOff` → `image_pull_back_off`

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -48,6 +48,35 @@ If `cors_origins` is configured in `config.toml`, the API serves the listed orig
 
 Most endpoints are wrapped in a 10-second timeout, returning `408 Request Timeout` if the handler runs longer. The streaming endpoint `GET /deployments/{id}/logs` (used with `?follow=true`) is mounted in a separate router with **no** timeout, so SSE connections can stay open indefinitely.
 
+## Validation errors
+
+Endpoints that accept a JSON body validate it before applying any side effect. If the body is structurally valid (parses as JSON, matches the expected shape) but contains values that violate Ring's rules, the response is `422 Unprocessable Entity` in [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807):
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+
+{
+  "type": "about:blank",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "username: must be 2 to 50 characters\npassword: must be 8 to 128 characters",
+  "violations": [
+    { "property_path": "username", "message": "must be 2 to 50 characters", "code": "user.username.length" },
+    { "property_path": "password", "message": "must be 8 to 128 characters", "code": "user.password.length" }
+  ]
+}
+```
+
+Key points for clients:
+
+- **All violations are reported.** Every rule that applies to the input is evaluated; the response lists every failure in one shot rather than stopping at the first. A single field can produce multiple violations (e.g. `username: "@"` trips both length and format).
+- **Stable `code` slugs.** `user.username.length`, `user.username.format`, `user.password.length`, etc. Branch on `code` rather than parsing `message` — `message` is human text and may change for clarity.
+- **`detail`** mirrors what a CLI tool prints: one line per violation, `<property_path>: <message>`. Useful for logging without parsing the structured `violations` array.
+- A malformed request body (invalid JSON, missing required field) returns `400 Bad Request` instead, with a plain-text reason.
+
+The endpoints that produce validation errors are flagged in their sections below with a "Validation" callout.
+
 ## System
 
 ### `GET /healthz`
@@ -486,6 +515,14 @@ Returns the same shape as a list entry. Values are never returned.
 
 **Response:** `201 Created`
 
+**Validation** (see [Validation errors](#validation-errors) for the response shape):
+
+| Field      | Rule                                                                            | Code                    |
+|------------|---------------------------------------------------------------------------------|-------------------------|
+| `username` | 2-50 characters                                                                 | `user.username.length`  |
+| `username` | starts with a letter or digit, then `[a-zA-Z0-9._-]`                            | `user.username.format`  |
+| `password` | 8-128 characters                                                                | `user.password.length`  |
+
 ### `GET /users/me`
 
 Returns the user attached to the bearer token.
@@ -503,7 +540,7 @@ Returns the user attached to the bearer token.
 
 ### `PUT /users/{id}`
 
-Update a user.
+Update a user. Both fields are optional — sending an empty body is a no-op that returns `200 OK`.
 
 ```json
 {
@@ -513,6 +550,8 @@ Update a user.
 ```
 
 **Response:** `200 OK`
+
+**Validation** (see [Validation errors](#validation-errors)): same rules as `POST /users` applied to whichever fields are present in the body. Omitted fields are skipped.
 
 ### `DELETE /users/{id}`
 
@@ -662,7 +701,9 @@ Returns information about the host running the Ring server.
 
 ## Error format
 
-Ring's error responses are not yet uniform across endpoints. Three shapes appear in the wild:
+Ring's error responses are migrating to [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807). Newly-rewritten endpoints serve that shape — see [Validation errors](#validation-errors) for the canonical example.
+
+The migration is in progress, so three legacy shapes still appear in older handlers:
 
 ```json
 // Most handlers (deployments, namespaces, secrets, configs)
@@ -675,7 +716,7 @@ Ring's error responses are not yet uniform across endpoints. Three shapes appear
 { "errors": ["Invalid credentials"] }
 ```
 
-There is currently no `code` field. Some endpoints attach contextual fields — for instance, `DELETE /secrets/{id}` returns the list of referencing deployments under `deployments` and a `hint` field. Plan to handle all three shapes when consuming the API; standardisation is on the roadmap.
+Plan to handle all four shapes when consuming the API. The endpoints that have moved to RFC 7807 are flagged with a "Validation" callout in their section above. Standardisation onto problem+json is on the roadmap.
 
 ## Examples
 

--- a/src/api/action/user/create.rs
+++ b/src/api/action/user/create.rs
@@ -1,8 +1,13 @@
+use crate::api::action::user::validation::{
+    PASSWORD_MAX, PASSWORD_MIN, USERNAME_MAX, USERNAME_MIN, USERNAME_PATTERN,
+};
 use crate::api::dto::user::UserOutput;
 use crate::api::server::Db;
+use crate::api::validation::ViolationList;
 use crate::config::config::Config;
 use crate::models::users as users_model;
 use crate::models::users::User;
+use axum::response::{IntoResponse, Response};
 use axum::{Json, extract::State, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -13,12 +18,10 @@ pub(crate) async fn create(
     State(configuration): State<Config>,
     _user: User,
     Json(input): Json<UserInput>,
-) -> Result<(StatusCode, Json<UserOutput>), (StatusCode, Json<serde_json::Value>)> {
-    if let Err(errors) = input.validate() {
-        return Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(json!({ "errors": errors })),
-        ));
+) -> Result<(StatusCode, Json<UserOutput>), Response> {
+    if let Err(errs) = input.validate() {
+        let violations: ViolationList = errs.into();
+        return Err(violations.into_response());
     }
 
     let password_hash = users_model::hash_password(&input.password, &configuration.user.salt)
@@ -27,6 +30,7 @@ pub(crate) async fn create(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "errors": ["Password hashing failed"] })),
             )
+                .into_response()
         })?;
 
     users_model::create(&pool, &input.username, &password_hash)
@@ -36,6 +40,7 @@ pub(crate) async fn create(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "errors": ["User creation failed"] })),
             )
+                .into_response()
         })?;
 
     let user = users_model::find_by_username(&pool, &input.username)
@@ -45,11 +50,15 @@ pub(crate) async fn create(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "errors": ["Failed to retrieve created user"] })),
             )
+                .into_response()
         })?
-        .ok_or((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "errors": ["Created user not found"] })),
-        ))?;
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "errors": ["Created user not found"] })),
+            )
+                .into_response()
+        })?;
 
     let output = UserOutput {
         id: user.id,
@@ -65,9 +74,26 @@ pub(crate) async fn create(
 
 #[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 pub(crate) struct UserInput {
-    #[validate(length(min = 2, max = 50))]
+    #[validate(
+        length(
+            min = "USERNAME_MIN",
+            max = "USERNAME_MAX",
+            code = "user.username.length",
+            message = "must be 2 to 50 characters"
+        ),
+        regex(
+            path = *USERNAME_PATTERN,
+            code = "user.username.format",
+            message = "must start with a letter or digit and contain only letters, digits, '.', '-', '_'"
+        )
+    )]
     username: String,
-    #[validate(length(min = 8, max = 128))]
+    #[validate(length(
+        min = "PASSWORD_MIN",
+        max = "PASSWORD_MAX",
+        code = "user.password.length",
+        message = "must be 8 to 128 characters"
+    ))]
     password: String,
 }
 
@@ -112,6 +138,13 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["status"], 422);
+        assert_eq!(body["title"], "Validation failed");
+        let v = &body["violations"];
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["property_path"], "username");
+        assert_eq!(v[0]["code"], "user.username.length");
     }
 
     #[tokio::test]
@@ -130,5 +163,138 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["property_path"], "password");
+        assert_eq!(v[0]["code"], "user.password.length");
+    }
+
+    #[tokio::test]
+    async fn create_accumulates_all_violations() {
+        // Both username and password invalid → the response must list both
+        // violations in one shot, not stop at the first.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/users")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "@",
+                "password": "x"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        // username "@" trips both length and format; password "x" trips length.
+        // That's three violations in total for a single request.
+        assert!(codes.contains(&"user.username.length".to_string()));
+        assert!(codes.contains(&"user.username.format".to_string()));
+        assert!(codes.contains(&"user.password.length".to_string()));
+    }
+
+    #[tokio::test]
+    async fn create_with_invalid_username_chars() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/users")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "john doe",
+                "password": "validpassword"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v[0]["code"], "user.username.format");
+    }
+
+    #[tokio::test]
+    async fn create_with_long_username() {
+        // 51 chars → exceeds max of 50. Trips length only, not format.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/users")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "a".repeat(51),
+                "password": "validpassword"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"user.username.length".to_string()));
+        assert!(!codes.contains(&"user.username.format".to_string()));
+    }
+
+    #[tokio::test]
+    async fn create_unauthenticated_does_not_validate() {
+        // Auth middleware must short-circuit before validation runs —
+        // protects against unauthenticated callers fingerprinting our
+        // field rules.
+        let app = new_test_app().await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/users")
+            .json(&json!({
+                "username": "@",
+                "password": "x"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn create_response_uses_problem_json_content_type() {
+        // The 422 must carry `application/problem+json` so clients that
+        // branch on Content-Type can parse the body as an RFC 7807
+        // payload without sniffing.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/users")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "username": "a", "password": "short" }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let content_type = response
+            .header("content-type")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            content_type.starts_with("application/problem+json"),
+            "got content-type: {}",
+            content_type
+        );
     }
 }

--- a/src/api/action/user/mod.rs
+++ b/src/api/action/user/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod delete;
 pub(crate) mod list;
 pub(crate) mod me;
 pub(crate) mod update;
+pub(crate) mod validation;

--- a/src/api/action/user/update.rs
+++ b/src/api/action/user/update.rs
@@ -1,4 +1,8 @@
+use crate::api::action::user::validation::{
+    PASSWORD_MAX, PASSWORD_MIN, USERNAME_MAX, USERNAME_MIN, USERNAME_PATTERN,
+};
 use crate::api::server::Db;
+use crate::api::validation::ViolationList;
 use crate::config::config::Config;
 use crate::models::users as users_model;
 use crate::models::users::User;
@@ -16,12 +20,13 @@ pub(crate) async fn update(
     _user: User,
     Json(input): Json<UserInput>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-    if let Err(errors) = input.validate() {
-        return Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(json!({ "errors": errors })),
-        )
-            .into_response());
+    // `Validate` skips fields that are `None`, so an empty body falls
+    // through cleanly. Whatever the user passes gets the same rules as
+    // create — the regex / length attributes are declared once and shared
+    // via constants in `validation.rs`.
+    if let Err(errs) = input.validate() {
+        let violations: ViolationList = errs.into();
+        return Err(violations.into_response());
     }
 
     let mut user = match users_model::find(&pool, &id).await.ok().flatten() {
@@ -59,9 +64,26 @@ pub(crate) async fn update(
 
 #[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 pub(crate) struct UserInput {
-    #[validate(length(min = 2, max = 50))]
+    #[validate(
+        length(
+            min = "USERNAME_MIN",
+            max = "USERNAME_MAX",
+            code = "user.username.length",
+            message = "must be 2 to 50 characters"
+        ),
+        regex(
+            path = *USERNAME_PATTERN,
+            code = "user.username.format",
+            message = "must start with a letter or digit and contain only letters, digits, '.', '-', '_'"
+        )
+    )]
     username: Option<String>,
-    #[validate(length(min = 8, max = 128))]
+    #[validate(length(
+        min = "PASSWORD_MIN",
+        max = "PASSWORD_MAX",
+        code = "user.password.length",
+        message = "must be 8 to 128 characters"
+    ))]
     password: Option<String>,
 }
 
@@ -129,5 +151,133 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn update_with_short_username_returns_violations() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "a"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["property_path"], "username");
+        assert_eq!(v[0]["code"], "user.username.length");
+    }
+
+    #[tokio::test]
+    async fn update_with_invalid_username_chars_returns_violations() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "john doe"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v[0]["code"], "user.username.format");
+    }
+
+    #[tokio::test]
+    async fn update_with_short_password_returns_violations() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "password": "short"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["property_path"], "password");
+        assert_eq!(v[0]["code"], "user.password.length");
+    }
+
+    #[tokio::test]
+    async fn update_accumulates_all_violations() {
+        // Both fields invalid → response must list everything in one shot.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "username": "@",
+                "password": "x"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"user.username.length".to_string()));
+        assert!(codes.contains(&"user.username.format".to_string()));
+        assert!(codes.contains(&"user.password.length".to_string()));
+    }
+
+    #[tokio::test]
+    async fn update_empty_body_is_a_noop_with_ok() {
+        // PUT with neither username nor password: no validation triggers,
+        // no field changes, and the existing user comes back unchanged.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({}))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn update_unauthenticated_does_not_validate() {
+        // No bearer token: the auth middleware must short-circuit with
+        // 401 before validation runs — we don't want validation behavior
+        // to leak field names to unauthenticated callers.
+        let app = new_test_app().await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .json(&json!({
+                "username": "@"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/src/api/action/user/validation.rs
+++ b/src/api/action/user/validation.rs
@@ -1,0 +1,26 @@
+//! Validation rules shared between `create` and `update` user endpoints.
+//!
+//! The rules themselves are declared via `#[validate(...)]` attributes on
+//! each handler's `UserInput` DTO. This module holds the shared building
+//! blocks: the regex used for the username pattern, and the constants for
+//! length bounds, so the two handlers stay in lockstep. A field that's OK
+//! at create time must also be OK at update time.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Username format: GitHub-style relaxed identifier. Starts with an
+/// alphanumeric character, followed by alphanumerics, dot, dash, or
+/// underscore. Matches the convention most user-facing platforms use —
+/// we deliberately don't go full RFC 1123 (which forbids `_` and `.`)
+/// because Ring users are humans, not container resources.
+pub(crate) static USERNAME_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$").unwrap());
+
+pub(crate) const USERNAME_MIN: u64 = 2;
+pub(crate) const USERNAME_MAX: u64 = 50;
+pub(crate) const PASSWORD_MIN: u64 = 8;
+/// 128 is a sanity bound, not a security boundary (the hash is
+/// fixed-size). NIST SP 800-63B §5.1.1.2 recommends no upper cap, but
+/// going unbounded invites trivial DoS via huge payloads, so we cap.
+pub(crate) const PASSWORD_MAX: u64 = 128;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod action;
 pub(crate) mod dto;
 pub(crate) mod server;
+pub(crate) mod validation;

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -1,0 +1,232 @@
+//! Shared validation primitives for Ring's HTTP API.
+//!
+//! Modeled after the API Platform / Symfony validator response shape, served
+//! as RFC 7807 `application/problem+json`. Each handler builds a
+//! `ViolationList`, returns it from a fallible code path, and the helper
+//! `into_response` turns the list into a 422 with the standard body:
+//!
+//! ```json
+//! {
+//!   "type": "about:blank",
+//!   "title": "Validation failed",
+//!   "status": 422,
+//!   "detail": "<concatenated messages>",
+//!   "violations": [
+//!     { "property_path": "<field>", "message": "<human>", "code": "<slug>" }
+//!   ]
+//! }
+//! ```
+//!
+//! Two design choices worth keeping:
+//!
+//! - **Accumulate, don't short-circuit.** A handler that only reports the
+//!   first invalid field forces the user to apply, fix, re-apply N times.
+//!   Build the full list and return it once.
+//! - **Stable `code` slugs.** `validator`'s default codes (`length`,
+//!   `regex`, …) are too generic to discriminate between fields. We use
+//!   slugs like `user.username.format` so a client (CLI, dashboard) can
+//!   key off `code` rather than parse the message.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use validator::{ValidationError, ValidationErrors, ValidationErrorsKind};
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Violation {
+    pub(crate) property_path: String,
+    pub(crate) message: String,
+    pub(crate) code: String,
+}
+
+impl Violation {
+    pub(crate) fn new(
+        property_path: impl Into<String>,
+        message: impl Into<String>,
+        code: impl Into<String>,
+    ) -> Self {
+        Self {
+            property_path: property_path.into(),
+            message: message.into(),
+            code: code.into(),
+        }
+    }
+}
+
+/// A collection of violations gathered by a single validation pass. Empty
+/// means the input is valid; non-empty turns into a 422 response.
+///
+/// Most handlers build one of these by calling `Validate::validate()` on
+/// the input DTO and feeding the result through `From<ValidationErrors>`.
+/// Handlers that need cross-field rules can keep pushing manual entries
+/// before returning.
+#[derive(Debug, Default, Serialize)]
+pub(crate) struct ViolationList {
+    pub(crate) violations: Vec<Violation>,
+}
+
+impl ViolationList {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn push(&mut self, v: Violation) {
+        self.violations.push(v);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.violations.is_empty()
+    }
+
+    /// Merge violations produced by `validator::Validate::validate()` into
+    /// this list. Lets a handler combine framework-driven field rules with
+    /// hand-written cross-field rules in a single response.
+    pub(crate) fn extend_from_validator(&mut self, errs: ValidationErrors) {
+        collect_field_errors(&mut self.violations, "", &errs);
+    }
+
+    /// Aggregate every message into the RFC 7807 `detail` field, one per
+    /// line, with the property path prefixed so a quick `grep` finds the
+    /// offending field. Mirrors what kubectl prints for invalid resources.
+    fn detail(&self) -> String {
+        self.violations
+            .iter()
+            .map(|v| format!("{}: {}", v.property_path, v.message))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+impl From<ValidationErrors> for ViolationList {
+    fn from(errs: ValidationErrors) -> Self {
+        let mut list = Self::new();
+        list.extend_from_validator(errs);
+        list
+    }
+}
+
+/// Walk a `ValidationErrors` tree and push every leaf into `out`. The
+/// `prefix` carries the dotted path of nested structs (`Validate` can be
+/// derived on nested types) so violations show up as `ports[0].published`,
+/// `resources.limits.cpu`, etc. Today none of our DTOs nest, but the
+/// recursion is cheap and saves us a refactor the day they do.
+fn collect_field_errors(out: &mut Vec<Violation>, prefix: &str, errs: &ValidationErrors) {
+    for (field, kind) in errs.errors() {
+        let path = if prefix.is_empty() {
+            field.to_string()
+        } else {
+            format!("{}.{}", prefix, field)
+        };
+        match kind {
+            ValidationErrorsKind::Field(field_errors) => {
+                for err in field_errors {
+                    out.push(violation_from_field_error(&path, err));
+                }
+            }
+            ValidationErrorsKind::Struct(nested) => {
+                collect_field_errors(out, &path, nested);
+            }
+            ValidationErrorsKind::List(indexed) => {
+                for (idx, nested) in indexed {
+                    let item_path = format!("{}[{}]", path, idx);
+                    collect_field_errors(out, &item_path, nested);
+                }
+            }
+        }
+    }
+}
+
+/// Translate one validator field error into a Ring violation. The
+/// `code` is whatever the `#[validate(..., code = "...")]` attribute
+/// declared on the DTO; the message uses the human string when present,
+/// otherwise falls back to the code so something always shows.
+fn violation_from_field_error(path: &str, err: &ValidationError) -> Violation {
+    let code = err.code.clone().into_owned();
+    let message = err
+        .message
+        .as_ref()
+        .map(|m| m.to_string())
+        .unwrap_or_else(|| code.clone());
+    Violation::new(path, message, code)
+}
+
+#[derive(Debug, Serialize)]
+struct ProblemJson<'a> {
+    #[serde(rename = "type")]
+    type_: &'static str,
+    title: &'static str,
+    status: u16,
+    detail: String,
+    violations: &'a [Violation],
+}
+
+impl IntoResponse for ViolationList {
+    fn into_response(self) -> Response {
+        let body = ProblemJson {
+            type_: "about:blank",
+            title: "Validation failed",
+            status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
+            detail: self.detail(),
+            violations: &self.violations,
+        };
+        let mut response = (StatusCode::UNPROCESSABLE_ENTITY, Json(body)).into_response();
+        // RFC 7807: problem+json content type so clients that key off the
+        // type can branch without sniffing the body.
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("application/problem+json"),
+        );
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn empty_list_is_empty() {
+        let list = ViolationList::new();
+        assert!(list.is_empty());
+    }
+
+    #[tokio::test]
+    async fn into_response_returns_422_problem_json() {
+        let mut list = ViolationList::new();
+        list.push(Violation::new(
+            "username",
+            "must be 2-50 chars",
+            "user.username.length",
+        ));
+        list.push(Violation::new(
+            "password",
+            "must be at least 8 chars",
+            "user.password.length",
+        ));
+
+        let response = list.into_response();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            "application/problem+json"
+        );
+
+        let bytes = to_bytes(response.into_body(), 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["status"], 422);
+        assert_eq!(body["title"], "Validation failed");
+        assert_eq!(body["violations"].as_array().unwrap().len(), 2);
+        assert_eq!(body["violations"][0]["property_path"], "username");
+        assert_eq!(body["violations"][0]["code"], "user.username.length");
+        // `detail` mirrors what the user reads in the terminal — both
+        // violations, one per line, with the property path prefixed.
+        let detail = body["detail"].as_str().unwrap();
+        assert!(detail.contains("username: must be 2-50 chars"));
+        assert!(detail.contains("password: must be at least 8 chars"));
+    }
+}

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::Config;
 use crate::exit_code;
 use clap::Arg;
@@ -55,8 +56,8 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Login failed: {}", status);
-                exit_code::from_http_status(status.as_u16()).exit();
+                let code = render_response_error("Login failed", response).await;
+                exit_code::from_http_status(code).exit();
             }
 
             let auth = match response.json::<AuthToken>().await {

--- a/src/commands/problem_json.rs
+++ b/src/commands/problem_json.rs
@@ -1,0 +1,140 @@
+//! Client-side rendering for the RFC 7807 `application/problem+json`
+//! responses Ring's API returns on validation failure.
+//!
+//! Most CLI commands only need to do two things when a request fails:
+//!
+//! 1. Print something useful to stderr.
+//! 2. Exit with the right code.
+//!
+//! Both come from the HTTP status alone for legacy endpoints (`Unable to
+//! create user: 422 Unprocessable Entity` — useless to the user), but the
+//! API now serves a structured body for validation failures. This module
+//! lets a command call `render_response_error(...)` and get the right
+//! behaviour regardless of which response format the API spoke.
+
+use reqwest::Response;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct Violation {
+    pub(crate) property_path: String,
+    pub(crate) message: String,
+    #[serde(default)]
+    #[allow(dead_code)] // Kept for callers that want to branch on the slug.
+    pub(crate) code: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ProblemDetails {
+    #[serde(default)]
+    pub(crate) title: String,
+    #[serde(default)]
+    pub(crate) detail: String,
+    #[serde(default)]
+    pub(crate) violations: Vec<Violation>,
+}
+
+/// Render the failure of a non-success response to stderr, choosing the
+/// best format available:
+///
+/// - **RFC 7807 problem+json** (`Content-Type: application/problem+json`):
+///   pretty-print every violation with its property path.
+/// - **Anything else**: fall back to a plain `<context>: <status>` line so
+///   pre-7807 endpoints still produce something readable.
+///
+/// `context` is a short human prefix (e.g. `"Unable to create user"`).
+/// The function returns the original status code so the caller can map it
+/// to an exit code with `exit_code::from_http_status`.
+pub(crate) async fn render_response_error(context: &str, response: Response) -> u16 {
+    let status = response.status();
+    let status_u16 = status.as_u16();
+    let is_problem = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.starts_with("application/problem+json"))
+        .unwrap_or(false);
+
+    // Consume the body — once. We get the bytes first because we need both
+    // the structured parse (when problem+json) and a fallback raw-text
+    // print (when the structured parse fails).
+    let body = response.bytes().await.unwrap_or_default();
+
+    if is_problem {
+        if let Ok(problem) = serde_json::from_slice::<ProblemDetails>(&body) {
+            // Title line: `<context>: <title> (<status>)`. e.g.
+            // `Unable to create user: Validation failed (422)`.
+            let title = if problem.title.is_empty() {
+                status.canonical_reason().unwrap_or("error").to_string()
+            } else {
+                problem.title
+            };
+            eprintln!("{}: {} ({})", context, title, status_u16);
+            if !problem.violations.is_empty() {
+                for v in &problem.violations {
+                    eprintln!("  * {}: {}", v.property_path, v.message);
+                }
+            } else if !problem.detail.is_empty() {
+                // No structured violations but a free-form detail string:
+                // surface it as-is. RFC 7807 servers may use this for
+                // non-validation errors (auth, business rules, …).
+                eprintln!("  {}", problem.detail);
+            }
+            return status_u16;
+        }
+        // problem+json header but body didn't parse — fall through to the
+        // legacy path so we still print *something*.
+    }
+
+    // Legacy / unknown shape: just print the status and dump the body if
+    // it's plausibly text. Avoids drowning the terminal in binary on a
+    // 502 from a misconfigured proxy.
+    eprintln!("{}: {}", context, status);
+    let text = String::from_utf8_lossy(&body);
+    let trimmed = text.trim();
+    if !trimmed.is_empty() && trimmed.len() <= 2_000 {
+        eprintln!("{}", trimmed);
+    }
+    status_u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn problem_details_round_trips_full_shape() {
+        let raw = r#"{
+            "type": "about:blank",
+            "title": "Validation failed",
+            "status": 422,
+            "detail": "username: too short",
+            "violations": [
+                { "property_path": "username", "message": "too short", "code": "user.username.length" }
+            ]
+        }"#;
+        let parsed: ProblemDetails = serde_json::from_str(raw).expect("parses");
+        assert_eq!(parsed.title, "Validation failed");
+        assert_eq!(parsed.detail, "username: too short");
+        assert_eq!(parsed.violations.len(), 1);
+        assert_eq!(parsed.violations[0].property_path, "username");
+        assert_eq!(parsed.violations[0].code, "user.username.length");
+    }
+
+    #[test]
+    fn problem_details_tolerates_missing_optional_fields() {
+        // Minimal body: just `title`. detail/violations default empty.
+        let raw = r#"{ "title": "Forbidden" }"#;
+        let parsed: ProblemDetails = serde_json::from_str(raw).expect("parses");
+        assert_eq!(parsed.title, "Forbidden");
+        assert!(parsed.detail.is_empty());
+        assert!(parsed.violations.is_empty());
+    }
+
+    #[test]
+    fn violation_without_code_defaults_to_empty() {
+        let raw = r#"{ "property_path": "x", "message": "y" }"#;
+        let parsed: Violation = serde_json::from_str(raw).expect("parses");
+        assert_eq!(parsed.code, "");
+    }
+}

--- a/src/commands/user/create.rs
+++ b/src/commands/user/create.rs
@@ -3,6 +3,7 @@ use clap::ArgMatches;
 use clap::Command;
 use serde_json::json;
 
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 
@@ -52,8 +53,8 @@ pub(crate) async fn execute(
             if status == 201 {
                 println!("user creates")
             } else {
-                eprintln!("Unable to create user: {}", status);
-                exit_code::from_http_status(status.as_u16()).exit();
+                let code = render_response_error("Unable to create user", response).await;
+                exit_code::from_http_status(code).exit();
             }
         }
         Err(err) => {

--- a/src/commands/user/update.rs
+++ b/src/commands/user/update.rs
@@ -1,3 +1,5 @@
+use crate::api::dto::user::UserOutput;
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -5,8 +7,6 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
 use serde_json::json;
-
-use crate::api::dto::user::UserOutput;
 
 pub(crate) fn command_config() -> Command {
     Command::new("update")
@@ -96,11 +96,14 @@ pub(crate) async fn execute(
     match request {
         Ok(response) => {
             let status = response.status();
-            if status == 201 {
+            // API returns 200 OK on update (was 201 by accident in the
+            // pre-validation code path). Accept any 2xx to stay
+            // forward-compatible with future shape changes.
+            if status.is_success() {
                 println!("user update")
             } else {
-                eprintln!("Unable to update user: {}", status);
-                exit_code::from_http_status(status.as_u16()).exit();
+                let code = render_response_error("Unable to update user", response).await;
+                exit_code::from_http_status(code).exit();
             }
         }
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod commands {
     pub(crate) mod deployment;
     pub(crate) mod doctor;
     pub(crate) mod init;
+    pub(crate) mod problem_json;
     pub(crate) mod server;
 
     pub(crate) mod config;


### PR DESCRIPTION
## Summary

Modernise validation on `POST /users` and `PUT /users/{id}` so the API returns structured, accumulated errors via [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807), and teach the CLI commands that consume them how to render the new format.

## What changed

### Server side (`src/api/`)

- **`api/validation.rs`** — shared primitives: `Violation { property_path, message, code }`, `ViolationList`, `IntoResponse` that turns the list into a 422 with the standard problem+json body. `From<validator::ValidationErrors>` adapter so any DTO annotated with `#[derive(Validate)]` flows straight into a violation list.
- **`api/action/user/validation.rs`** — shared constants and the username regex consumed by the `#[validate(...)]` attributes on the create/update DTOs. Keeps the two handlers in lockstep.
- **`api/action/user/create.rs` / `update.rs`** — `UserInput` now carries `#[validate]` attributes with explicit `code = "user.username.length"` / `"user.username.format"` / `"user.password.length"` slugs so clients can branch on `code` without parsing `message`.
- Username format is now `[a-zA-Z0-9][a-zA-Z0-9._-]*`, 2-50 chars. Password rules unchanged (8-128 chars).
- All rules accumulate: a single invalid request lists every failure in one shot.

### Client side (`src/commands/`)

- **`commands/problem_json.rs`** — `render_response_error(context, response)` helper that prints a problem+json body cleanly:
  ```
  Unable to create user: Validation failed (422)
    * username: must be 2 to 50 characters
    * password: must be 8 to 128 characters
  ```
  Falls back to the legacy `<context>: <status>` line when the response isn't problem+json, so it's safe to use on commands that talk to handlers not yet migrated.
- **`commands/user/create.rs`, `commands/user/update.rs`, `commands/login.rs`** — call the helper instead of the previous `eprintln!("Unable to ...: {status}")`.
- Side fix in `user update`: success code was incorrectly checked as `201` (the API returns `200 OK`). Now accepts any 2xx.

### Documentation

- **`documentation/reference/api.md`** — new "Validation errors" section explaining the problem+json shape, what the `code` slugs are for, and that all violations are reported per request. Per-endpoint tables on `POST /users` and `PUT /users/{id}` list the rules with their codes. The legacy "Error format" section flags the migration.
- **`CHANGELOG.md`** — Unreleased entry under "Changed (breaking)" with the response shape diff and the migration notes for external consumers.

## Test plan

- [x] `cargo test --bin ring` — **326 passed, 0 failed** (was 310 before, +16 new). New tests:
  - 2 on `api/validation.rs` (round-trip + 422 problem+json shape)
  - 3 on `problem_json.rs` (parse full body / tolerate missing fields / default code)
  - 11 across `user/create.rs` and `user/update.rs` covering the happy path, every individual failure mode, multi-violation accumulation, the new `application/problem+json` content type, and unauthenticated requests skipping validation.
- [x] `cargo fmt --check` clean.

## Why not extend further now

`apply.rs` and the other handlers (deployments, secrets, configs, namespaces) still serve the legacy `{"error": "..."}` shape, so the CLI parsing helper is wired only to commands that talk to migrated endpoints. Migrating them is the natural follow-up; the helper is built to handle both shapes so it can stay in place as those PRs land.