### PR TITLE
feat(deployment): RFC 7807 validation + cross-field & business rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Event `reason` strings (`ImagePullBackOff`, `InstanceCreationFailed`, …) stay PascalCase — those are event labels, not statuses.
 
+### Added
+- **`ring apply` now renders RFC 7807 problem details from `POST /deployments` and `POST /namespaces`**. On validation failure the CLI prints the title line plus every violation with its property path, e.g.
+
+  ```
+  Unable to apply deployment 'nginx': Validation failed (422)
+    * ports[0].published: must be between 1 and 65535
+    * replicas: replicas > 1 (3) is incompatible with `ports` — drop `ports` or reduce `replicas` to 1
+  ```
+
+  instead of the legacy `API returned status 422: <raw body>` one-liner. Non-7807 responses fall back to the previous behaviour.
+
 ## [0.8.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed (breaking)
+- **`POST /deployments` now uses RFC 7807** with the same shape as `POST /users` (`application/problem+json`, `violations[]` with `property_path`, `message`, `code`). Existing 400/422 responses with `{"message": "..."}` body are replaced. Codes for the rules already in place:
+  - `deployment.runtime.unsupported` — runtime must be one of: docker, cloud-hypervisor
+  - `deployment.command.cloud_hypervisor_unsupported`
+  - `deployment.image.cloud_hypervisor_requires_absolute_path`
+  - `deployment.network.host_runtime_unsupported`
+  - `deployment.ports.host_network_conflict`
+  - `deployment.replicas.host_network_conflict`
+
+  **New rules** (previously not validated, the manifest applied and broke at runtime):
+  - `deployment.ports.published.out_of_range` / `deployment.ports.target.out_of_range` — port 0 is reserved
+  - `deployment.ports.published.duplicate` — two entries publishing the same host port
+  - `deployment.ports.replicas_conflict` + `deployment.replicas.ports_conflict` — publishing host ports with `replicas > 1` causes inter-replica collisions
+  - `deployment.replicas.job_must_be_one` — `kind: job` is one-shot
+  - `deployment.health_checks.job_readiness_unsupported` — readiness checks only gate rolling updates
+  - `deployment.environment.key.invalid` — env var names must match `[A-Za-z_][A-Za-z0-9_]*`
+  - `deployment.resources.{limits,requests}.{cpu,memory}.invalid` — invalid quantity string
+  - `deployment.config.image_pull_policy.unsupported` — must be `Always`, `IfNotPresent` or `Never`
+
+  `property_path` follows JSONPath conventions for nested collections: `ports[0].published`, `volumes[2].source`, `resources.limits.cpu`.
+
 - **Validation errors on `POST /users` and `PUT /users/{id}` now use RFC 7807.** The 422 response shape changed from the bare `validator`-derived `{"errors": <map>}` to `application/problem+json`:
 
   ```json

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -208,6 +208,25 @@ Environment values support two forms:
 
 **Response:** `201 Created` with the full deployment object (same shape as `GET /deployments/{id}`).
 
+**Validation** (see [Validation errors](#validation-errors) for the response shape):
+
+| Rule                                                                         | Code                                                       |
+|------------------------------------------------------------------------------|------------------------------------------------------------|
+| `runtime` must be `docker` or `cloud-hypervisor`                             | `deployment.runtime.unsupported`                           |
+| Cloud Hypervisor refuses custom `command`                                    | `deployment.command.cloud_hypervisor_unsupported`          |
+| Cloud Hypervisor needs an absolute path image                                | `deployment.image.cloud_hypervisor_requires_absolute_path` |
+| `network.mode=host` is docker-only                                           | `deployment.network.host_runtime_unsupported`              |
+| `network.mode=host` forbids `ports`                                          | `deployment.ports.host_network_conflict`                   |
+| `network.mode=host` forbids `replicas > 1`                                   | `deployment.replicas.host_network_conflict`                |
+| `ports[i].published` / `target` must be 1-65535                              | `deployment.ports.published.out_of_range` / `target...`    |
+| `ports` must not declare the same `published` twice                          | `deployment.ports.published.duplicate`                     |
+| `ports` set with `replicas > 1` would race; surfaces on both fields          | `deployment.ports.replicas_conflict` + `deployment.replicas.ports_conflict` |
+| `kind: job` requires `replicas: 1`                                           | `deployment.replicas.job_must_be_one`                      |
+| `kind: job` doesn't take readiness checks                                    | `deployment.health_checks.job_readiness_unsupported`       |
+| Environment keys must match `[A-Za-z_][A-Za-z0-9_]*`                         | `deployment.environment.key.invalid`                       |
+| `resources.{limits,requests}.{cpu,memory}` must parse                        | `deployment.resources.{limits,requests}.{cpu,memory}.invalid` |
+| `config.image_pull_policy` must be `Always`, `IfNotPresent`, or `Never`      | `deployment.config.image_pull_policy.unsupported`          |
+
 ### `GET /deployments/{id}`
 
 Retrieve a deployment by UUID.

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -79,6 +79,61 @@ fn validate_network_constraints(input: &DeploymentInput, errors: &mut ViolationL
     }
 }
 
+/// Cross-field rules that catch configurations which are syntactically valid
+/// but semantically broken. Every rule pushes one violation per affected
+/// field — when a rule could be fixed by changing either of two fields, both
+/// get a violation so the user picks which one to change.
+fn validate_cross_field_constraints(input: &DeploymentInput, errors: &mut ViolationList) {
+    // `ports[] + replicas > 1`: every replica would race for the same
+    // host port. Either drop the ports or scale down to 1.
+    if !input.ports.is_empty() && input.replicas > 1 {
+        errors.push(Violation::new(
+            "ports",
+            format!(
+                "publishing host ports with replicas > 1 ({}) causes port conflicts between replicas — drop `ports` or reduce `replicas` to 1",
+                input.replicas
+            ),
+            "deployment.ports.replicas_conflict",
+        ));
+        errors.push(Violation::new(
+            "replicas",
+            format!(
+                "replicas > 1 ({}) is incompatible with `ports` — drop `ports` or reduce `replicas` to 1",
+                input.replicas
+            ),
+            "deployment.replicas.ports_conflict",
+        ));
+    }
+
+    // `kind: job + replicas > 1`: a job is one-shot. Multiple replicas
+    // would mean N parallel runs of the same task which is not what the
+    // job kind models.
+    if matches!(input.kind, DeploymentKind::Job) && input.replicas > 1 {
+        errors.push(Violation::new(
+            "replicas",
+            format!(
+                "kind=job runs once and exits; replicas must be 1, got {}",
+                input.replicas
+            ),
+            "deployment.replicas.job_must_be_one",
+        ));
+    }
+
+    // `kind: job + readiness check`: readiness gates a rolling update.
+    // Jobs don't roll — they run once. A readiness flag here is a config
+    // gap that would never trigger anything useful.
+    if matches!(input.kind, DeploymentKind::Job)
+        && let Some(hcs) = input.health_checks.as_ref()
+        && hcs.iter().any(|hc| hc.is_readiness())
+    {
+        errors.push(Violation::new(
+            "health_checks",
+            "kind=job is incompatible with readiness health checks (readiness gates rolling updates, which don't apply to one-shot jobs)",
+            "deployment.health_checks.job_readiness_unsupported",
+        ));
+    }
+}
+
 fn validate_runtime_constraints(input: &DeploymentInput, errors: &mut ViolationList) {
     if input.runtime == "cloud-hypervisor" {
         // `command` health checks are now supported via the in-guest
@@ -314,6 +369,7 @@ pub(crate) async fn create(
     }
     validate_runtime_constraints(&input, &mut violations);
     validate_network_constraints(&input, &mut violations);
+    validate_cross_field_constraints(&input, &mut violations);
     if !violations.is_empty() {
         return violations.into_response();
     }
@@ -2145,6 +2201,10 @@ mod tests {
 
     #[tokio::test]
     async fn create_with_bridge_network_mode_explicit() {
+        // bridge mode is the existing default — declaring it explicitly
+        // must not change anything. `ports` and `replicas: 1` remain
+        // a valid pair (replicas > 1 with ports is rejected separately,
+        // see `create_rejects_ports_with_replicas_above_one`).
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -2159,11 +2219,10 @@ mod tests {
                 "image": "nginx:latest",
                 "network": { "mode": "bridge" },
                 "ports": [{ "published": 8080, "target": 80 }],
-                "replicas": 2
+                "replicas": 1
             }))
             .await;
 
-        // bridge mode is the existing default — ports and replicas remain valid.
         assert_eq!(response.status_code(), StatusCode::CREATED);
     }
 
@@ -2188,5 +2247,134 @@ mod tests {
         let body: serde_json::Value = response.json();
         let ports = body["ports"].as_array().unwrap();
         assert!(ports.is_empty());
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Cross-field rules
+    // ────────────────────────────────────────────────────────────────────────
+    //
+    // These rules catch combinations that are syntactically valid but
+    // semantically broken — the apply would silently produce a non-working
+    // deployment. They surface BOTH affected fields so the user can pick
+    // which one to change, as per the convention agreed for cross-field
+    // violations.
+
+    #[tokio::test]
+    async fn create_rejects_ports_with_replicas_above_one() {
+        // Two replicas binding the same host port collide. Either reduce
+        // replicas or drop the ports — surface both options.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "replicas": 3,
+                "ports": [{ "published": 80, "target": 80 }]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|v| v["code"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.ports.replicas_conflict".to_string()),
+            "missing ports code, got {:?}",
+            codes
+        );
+        assert!(
+            codes.contains(&"deployment.replicas.ports_conflict".to_string()),
+            "missing replicas code, got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_job_with_replicas_above_one() {
+        // A job is one-shot by definition. replicas > 1 is meaningless.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "kind": "job",
+                "name": "batch",
+                "namespace": "ring",
+                "image": "busybox:latest",
+                "replicas": 4
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|v| v["code"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.replicas.job_must_be_one".to_string()),
+            "expected job/replicas violation, got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_job_with_readiness_check() {
+        // Readiness gates a rolling update — but jobs don't roll, they
+        // run once and exit. A readiness check on a job is a config gap.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "kind": "job",
+                "name": "batch",
+                "namespace": "ring",
+                "image": "busybox:latest",
+                "health_checks": [{
+                    "type": "tcp",
+                    "port": 8080,
+                    "interval": "5s",
+                    "timeout": "2s",
+                    "on_failure": "restart",
+                    "readiness": true
+                }]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|v| v["code"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.health_checks.job_readiness_unsupported".to_string()),
+            "expected job/readiness violation, got {:?}",
+            codes
+        );
     }
 }

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -79,6 +79,85 @@ fn validate_network_constraints(input: &DeploymentInput, errors: &mut ViolationL
     }
 }
 
+/// Validate environment variable names against POSIX/Docker rules:
+/// `[A-Za-z_][A-Za-z0-9_]*`. Names like `bad-name` or `1NOT_ALLOWED`
+/// silently become unusable variables in the container shell — surface
+/// them at API time so the user catches typos before deploy.
+fn validate_environment(input: &DeploymentInput, errors: &mut ViolationList) {
+    static ENV_VAR_PATTERN: once_cell::sync::Lazy<regex::Regex> =
+        once_cell::sync::Lazy::new(|| regex::Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").unwrap());
+
+    for key in input.environment.keys() {
+        if !ENV_VAR_PATTERN.is_match(key) {
+            errors.push(Violation::new(
+                format!("environment.{}", key),
+                format!(
+                    "'{}' is not a valid env var name (must match [A-Za-z_][A-Za-z0-9_]*)",
+                    key
+                ),
+                "deployment.environment.key.invalid",
+            ));
+        }
+    }
+}
+
+/// Validate `resources.limits.{cpu,memory}` and `resources.requests.{cpu,memory}`
+/// strings parse correctly. `parse_cpu_string` accepts forms like `"500m"` or
+/// `"2"`; `parse_memory_string` handles binary (`Ki`, `Mi`, …) and decimal
+/// (`K`, `M`, …) suffixes. Anything else used to be a silent runtime crash.
+fn validate_resources(input: &DeploymentInput, errors: &mut ViolationList) {
+    let Some(resources) = &input.resources else {
+        return;
+    };
+    let check = |spec: Option<&crate::models::deployments::ResourceSpec>,
+                 kind: &str,
+                 errors: &mut ViolationList| {
+        let Some(spec) = spec else { return };
+        if let Some(cpu) = &spec.cpu
+            && crate::models::deployments::parse_cpu_string(cpu).is_err()
+        {
+            errors.push(Violation::new(
+                format!("resources.{}.cpu", kind),
+                format!("'{}' is not a valid CPU spec (e.g. '500m' or '2')", cpu),
+                format!("deployment.resources.{}.cpu.invalid", kind),
+            ));
+        }
+        if let Some(memory) = &spec.memory
+            && crate::models::deployments::parse_memory_string(memory).is_err()
+        {
+            errors.push(Violation::new(
+                format!("resources.{}.memory", kind),
+                format!(
+                    "'{}' is not a valid memory spec (e.g. '512Mi' or '2Gi')",
+                    memory
+                ),
+                format!("deployment.resources.{}.memory.invalid", kind),
+            ));
+        }
+    };
+    check(resources.limits.as_ref(), "limits", errors);
+    check(resources.requests.as_ref(), "requests", errors);
+}
+
+/// Validate `config.image_pull_policy` is one of Docker's accepted values.
+/// Anything else is silently ignored at runtime; reject upfront.
+fn validate_config(input: &DeploymentInput, errors: &mut ViolationList) {
+    let Some(config) = &input.config else {
+        return;
+    };
+    let policy = config.image_pull_policy.as_str();
+    if !matches!(policy, "Always" | "IfNotPresent" | "Never") {
+        errors.push(Violation::new(
+            "config.image_pull_policy",
+            format!(
+                "'{}' is not a supported pull policy (must be one of: Always, IfNotPresent, Never)",
+                policy
+            ),
+            "deployment.config.image_pull_policy.unsupported",
+        ));
+    }
+}
+
 /// Per-port rules. The `DeploymentPort` struct already constrains
 /// `published`/`target` to `u16` so anything > 65535 is caught at deserialize
 /// time; we still need to reject `0` (reserved + "any port" semantics) and
@@ -414,6 +493,9 @@ pub(crate) async fn create(
     validate_runtime_constraints(&input, &mut violations);
     validate_network_constraints(&input, &mut violations);
     validate_ports(&input, &mut violations);
+    validate_environment(&input, &mut violations);
+    validate_resources(&input, &mut violations);
+    validate_config(&input, &mut violations);
     validate_cross_field_constraints(&input, &mut violations);
     if !violations.is_empty() {
         return violations.into_response();
@@ -2452,6 +2534,159 @@ mod tests {
             .collect();
         assert!(
             codes.contains(&"deployment.ports.published.duplicate".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Environment / Resources / Config rules
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_rejects_invalid_env_var_name() {
+        // POSIX/Docker env var names: [A-Za-z_][A-Za-z0-9_]*. Names with
+        // spaces, dots, or dashes silently become unusable variables in
+        // the container shell. Reject up front.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "environment": {
+                    "bad-name": "value",
+                    "1NOT_ALLOWED": "value",
+                    "GOOD_ONE": "ok"
+                }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes
+                .iter()
+                .filter(|c| *c == "deployment.environment.key.invalid")
+                .count()
+                >= 2,
+            "expected at least 2 invalid env keys, got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_invalid_cpu_string() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "resources": {
+                    "limits": { "cpu": "notanumber" }
+                }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.resources.limits.cpu.invalid".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_invalid_memory_string() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "resources": {
+                    "requests": { "memory": "lots" }
+                }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.resources.requests.memory.invalid".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_unknown_image_pull_policy() {
+        // Docker accepts: Always, IfNotPresent, Never. Anything else is
+        // silently ignored at runtime — fail at API time instead.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "config": { "image_pull_policy": "Maybe" }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.config.image_pull_policy.unsupported".to_string()),
             "got {:?}",
             codes
         );

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -79,6 +79,50 @@ fn validate_network_constraints(input: &DeploymentInput, errors: &mut ViolationL
     }
 }
 
+/// Per-port rules. The `DeploymentPort` struct already constrains
+/// `published`/`target` to `u16` so anything > 65535 is caught at deserialize
+/// time; we still need to reject `0` (reserved + "any port" semantics) and
+/// to surface duplicate `published` values that would race for the same host
+/// port. Paths use JSONPath form (`ports[idx].published`) so a client can
+/// point straight at the offending entry.
+fn validate_ports(input: &DeploymentInput, errors: &mut ViolationList) {
+    use std::collections::HashMap;
+
+    let mut published_seen: HashMap<u16, usize> = HashMap::new();
+
+    for (idx, port) in input.ports.iter().enumerate() {
+        if port.published == 0 {
+            errors.push(Violation::new(
+                format!("ports[{}].published", idx),
+                "must be between 1 and 65535",
+                "deployment.ports.published.out_of_range",
+            ));
+        }
+        if port.target == 0 {
+            errors.push(Violation::new(
+                format!("ports[{}].target", idx),
+                "must be between 1 and 65535",
+                "deployment.ports.target.out_of_range",
+            ));
+        }
+
+        if port.published != 0 {
+            if let Some(prev_idx) = published_seen.get(&port.published) {
+                errors.push(Violation::new(
+                    format!("ports[{}].published", idx),
+                    format!(
+                        "duplicates ports[{}].published = {}; each host port can only be bound once",
+                        prev_idx, port.published
+                    ),
+                    "deployment.ports.published.duplicate",
+                ));
+            } else {
+                published_seen.insert(port.published, idx);
+            }
+        }
+    }
+}
+
 /// Cross-field rules that catch configurations which are syntactically valid
 /// but semantically broken. Every rule pushes one violation per affected
 /// field — when a rule could be fixed by changing either of two fields, both
@@ -369,6 +413,7 @@ pub(crate) async fn create(
     }
     validate_runtime_constraints(&input, &mut violations);
     validate_network_constraints(&input, &mut violations);
+    validate_ports(&input, &mut violations);
     validate_cross_field_constraints(&input, &mut violations);
     if !violations.is_empty() {
         return violations.into_response();
@@ -2247,6 +2292,169 @@ mod tests {
         let body: serde_json::Value = response.json();
         let ports = body["ports"].as_array().unwrap();
         assert!(ports.is_empty());
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Property paths
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_violation_paths_use_jsonpath_for_lists() {
+        // A violation on volumes[N].source must surface that exact path so
+        // the operator can point at the right entry in their manifest. The
+        // path adapter in `api/validation.rs` is generic; this test pins
+        // the JSONPath convention for any nested-list validation.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "volumes": [
+                    {
+                        "type": "bind",
+                        "destination": "/var/run/docker.sock",
+                        "driver": "local",
+                        "permission": "ro"
+                    }
+                ]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let paths: Vec<&str> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["property_path"].as_str().unwrap())
+            .collect();
+        assert!(
+            paths.contains(&"volumes[0].source"),
+            "expected JSONPath `volumes[0].source`, got {:?}",
+            paths
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Port validation
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_rejects_port_zero() {
+        // 0 is reserved by the kernel — Docker uses it to mean "pick any
+        // free port", which is not what the user typed. Reject explicitly.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "ports": [{ "published": 0, "target": 80 }]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let v = body["violations"].as_array().unwrap();
+        let codes: Vec<&str> = v.iter().map(|x| x["code"].as_str().unwrap()).collect();
+        let paths: Vec<&str> = v
+            .iter()
+            .map(|x| x["property_path"].as_str().unwrap())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.ports.published.out_of_range"),
+            "got codes {:?}",
+            codes
+        );
+        assert!(
+            paths.contains(&"ports[0].published"),
+            "got paths {:?}",
+            paths
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_target_zero() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "ports": [{ "published": 8080, "target": 0 }]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let v = body["violations"].as_array().unwrap();
+        let codes: Vec<&str> = v.iter().map(|x| x["code"].as_str().unwrap()).collect();
+        let paths: Vec<&str> = v
+            .iter()
+            .map(|x| x["property_path"].as_str().unwrap())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.ports.target.out_of_range"),
+            "got codes {:?}",
+            codes
+        );
+        assert!(paths.contains(&"ports[0].target"), "got paths {:?}", paths);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_duplicate_published_ports() {
+        // Two entries publishing the same host port can't both bind.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "nginx:latest",
+                "ports": [
+                    { "published": 8080, "target": 80 },
+                    { "published": 8080, "target": 81 }
+                ]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.ports.published.duplicate".to_string()),
+            "got {:?}",
+            codes
+        );
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -15,6 +15,7 @@ use validator::{Validate, ValidationError};
 
 use crate::api::dto::deployment::DeploymentOutput;
 use crate::api::server::Db;
+use crate::api::validation::{Violation, ViolationList};
 use crate::models::deployment_event;
 use crate::models::deployments;
 use crate::models::deployments::{
@@ -31,45 +32,54 @@ fn default_replicas() -> u32 {
 fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
     match runtime {
         "docker" | "cloud-hypervisor" => Ok(()),
-        _ => Err(ValidationError::new(
-            "invalid runtime, supported: [docker, cloud-hypervisor]",
-        )),
+        _ => Err(
+            ValidationError::new("deployment.runtime.unsupported").with_message(Cow::Borrowed(
+                "runtime must be one of: docker, cloud-hypervisor",
+            )),
+        ),
     }
 }
 
-fn validate_network_constraints(input: &DeploymentInput) -> Result<(), String> {
+fn validate_network_constraints(input: &DeploymentInput, errors: &mut ViolationList) {
     let Some(network) = &input.network else {
-        return Ok(());
+        return;
     };
     if !matches!(network.mode, NetworkMode::Host) {
-        return Ok(());
+        return;
     }
 
     if input.runtime != "docker" {
-        return Err(format!(
-            "network.mode=host is only supported on the docker runtime, got '{}'",
-            input.runtime
+        errors.push(Violation::new(
+            "network.mode",
+            format!(
+                "host networking is only supported on the docker runtime, got '{}'",
+                input.runtime
+            ),
+            "deployment.network.host_runtime_unsupported",
         ));
     }
 
     if !input.ports.is_empty() {
-        return Err(
-            "network.mode=host is incompatible with port mappings: host networking bypasses Docker's port bindings, so `ports` would be silently ignored. Remove `ports` and let the container bind directly on the host."
-                .to_string(),
-        );
-    }
-
-    if input.replicas > 1 {
-        return Err(format!(
-            "network.mode=host is incompatible with replicas > 1 (got {}): all replicas would compete for the same host ports. Reduce replicas to 1.",
-            input.replicas
+        errors.push(Violation::new(
+            "ports",
+            "host networking bypasses Docker's port bindings; remove `ports` and let the container bind directly on the host",
+            "deployment.ports.host_network_conflict",
         ));
     }
 
-    Ok(())
+    if input.replicas > 1 {
+        errors.push(Violation::new(
+            "replicas",
+            format!(
+                "host networking is incompatible with replicas > 1 (got {}): all replicas would compete for the same host ports",
+                input.replicas
+            ),
+            "deployment.replicas.host_network_conflict",
+        ));
+    }
 }
 
-fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
+fn validate_runtime_constraints(input: &DeploymentInput, errors: &mut ViolationList) {
     if input.runtime == "cloud-hypervisor" {
         // `command` health checks are now supported via the in-guest
         // `ring-agent` daemon (vsock). The guest image must ship the agent
@@ -81,9 +91,11 @@ fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
         //  src/runtime/cloud_hypervisor/cloud_init.rs. Requires the guest
         //  image to ship cloud-init, which every standard cloud image does.)
         if !input.command.is_empty() {
-            return Err(
-                "custom commands are not supported on cloud-hypervisor runtime (alpha); the VM boots whatever its image is configured to run".to_string(),
-            );
+            errors.push(Violation::new(
+                "command",
+                "custom commands are not supported on cloud-hypervisor runtime (alpha); the VM boots whatever its image is configured to run",
+                "deployment.command.cloud_hypervisor_unsupported",
+            ));
         }
 
         // CH expects a raw disk image path on the host, not a Docker image
@@ -91,13 +103,16 @@ fn validate_runtime_constraints(input: &DeploymentInput) -> Result<(), String> {
         // a Docker reference (e.g. `nginx:latest`) — fail early instead of
         // letting it fail much later with a confusing "VM image not found".
         if !input.image.starts_with('/') {
-            return Err(format!(
-                "cloud-hypervisor runtime expects an absolute path to a raw disk image, got '{}' (Docker image references are not supported)",
-                input.image
+            errors.push(Violation::new(
+                "image",
+                format!(
+                    "cloud-hypervisor runtime expects an absolute path to a raw disk image, got '{}' (Docker image references are not supported)",
+                    input.image
+                ),
+                "deployment.image.cloud_hypervisor_requires_absolute_path",
             ));
         }
     }
-    Ok(())
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -286,246 +301,242 @@ pub(crate) async fn create(
     filters.push(input.namespace.clone());
     filters.push(input.name.clone());
 
-    match input.validate() {
-        Ok(()) => {
-            if let Err(msg) = validate_runtime_constraints(&input) {
-                let message = Message { message: msg };
-                return (StatusCode::BAD_REQUEST, Json(message)).into_response();
+    // Accumulate every validation error in one pass: a manifest that
+    // violates several rules surfaces the full list in one response so
+    // the user can fix everything in one apply cycle. Order:
+    //   1. `validator` field rules driven by #[validate(...)] attributes
+    //   2. Runtime-specific constraints (e.g. cloud-hypervisor expects an
+    //      absolute image path, no custom command, …)
+    //   3. Cross-field constraints (e.g. host networking + replicas > 1).
+    let mut violations = ViolationList::new();
+    if let Err(errs) = input.validate() {
+        violations.extend_from_validator(errs);
+    }
+    validate_runtime_constraints(&input, &mut violations);
+    validate_network_constraints(&input, &mut violations);
+    if !violations.is_empty() {
+        return violations.into_response();
+    }
+
+    // Auto-create namespace if it doesn't exist
+    match namespace::find_by_name(&pool, &input.namespace).await {
+        Ok(None) => {
+            let new_namespace = namespace::Namespace {
+                id: Uuid::new_v4().to_string(),
+                created_at: Utc::now().to_string(),
+                updated_at: None,
+                name: input.namespace.clone(),
+            };
+            if let Err(e) = namespace::create(&pool, new_namespace).await
+                && !e.to_string().contains("UNIQUE constraint failed")
+            {
+                log::error!("Failed to create namespace '{}': {}", input.namespace, e);
+                let message = Message {
+                    message: "Failed to create namespace".to_string(),
+                };
+                return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
             }
+            info!("Namespace '{}' created automatically", input.namespace);
+        }
+        Ok(Some(_)) => {}
+        Err(e) => {
+            log::error!("Failed to check namespace '{}': {}", input.namespace, e);
+            let message = Message {
+                message: "Internal server error".to_string(),
+            };
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
+        }
+    }
 
-            if let Err(msg) = validate_network_constraints(&input) {
-                let message = Message { message: msg };
-                return (StatusCode::BAD_REQUEST, Json(message)).into_response();
-            }
+    let active_deployments =
+        deployments::find_active_by_namespace_name(&pool, &input.namespace, &input.name).await;
 
-            // Auto-create namespace if it doesn't exist
-            match namespace::find_by_name(&pool, &input.namespace).await {
-                Ok(None) => {
-                    let new_namespace = namespace::Namespace {
-                        id: Uuid::new_v4().to_string(),
-                        created_at: Utc::now().to_string(),
-                        updated_at: None,
-                        name: input.namespace.clone(),
-                    };
-                    if let Err(e) = namespace::create(&pool, new_namespace).await
-                        && !e.to_string().contains("UNIQUE constraint failed")
-                    {
-                        log::error!("Failed to create namespace '{}': {}", input.namespace, e);
-                        let message = Message {
-                            message: "Failed to create namespace".to_string(),
-                        };
-                        return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
-                    }
-                    info!("Namespace '{}' created automatically", input.namespace);
-                }
-                Ok(Some(_)) => {}
-                Err(e) => {
-                    log::error!("Failed to check namespace '{}': {}", input.namespace, e);
-                    let message = Message {
-                        message: "Internal server error".to_string(),
-                    };
-                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
-                }
-            }
+    // Determine whether rolling update is possible:
+    // - only when there is exactly one active deployment (the current one)
+    // - it has health checks configured
+    // - --force flag is not set
+    let mut rolling_parent_id: Option<String> = None;
+    // Captured to log a `ForceReplace` event on the new deployment once
+    // it exists. We collect the reason here so the caller of the API
+    // gets a clear explanation for why rolling didn't happen, instead
+    // of having to compare timestamps across two deployments.
+    let mut replaced_deployment_ids: Vec<String> = Vec::new();
+    let mut replace_reason: Option<&'static str> = None;
 
-            let active_deployments =
-                deployments::find_active_by_namespace_name(&pool, &input.namespace, &input.name)
-                    .await;
+    match active_deployments {
+        Ok(deployments_list) => {
+            info!(
+                "Checking for existing deployments: namespace='{}', name='{}' - found: {}",
+                input.namespace,
+                input.name,
+                deployments_list.len()
+            );
 
-            // Determine whether rolling update is possible:
-            // - only when there is exactly one active deployment (the current one)
-            // - it has health checks configured
-            // - --force flag is not set
-            let mut rolling_parent_id: Option<String> = None;
-            // Captured to log a `ForceReplace` event on the new deployment once
-            // it exists. We collect the reason here so the caller of the API
-            // gets a clear explanation for why rolling didn't happen, instead
-            // of having to compare timestamps across two deployments.
-            let mut replaced_deployment_ids: Vec<String> = Vec::new();
-            let mut replace_reason: Option<&'static str> = None;
+            if !deployments_list.is_empty() {
+                info!(
+                    "Found {} active deployments with the same namespace and name",
+                    deployments_list.len()
+                );
 
-            match active_deployments {
-                Ok(deployments_list) => {
+                let has_health_checks = input
+                    .health_checks
+                    .as_ref()
+                    .map(|hc| !hc.is_empty())
+                    .unwrap_or(false);
+
+                // Rolling update: keep old deployment running if conditions are met
+                if !params.force && has_health_checks && deployments_list.len() == 1 {
+                    let existing = &deployments_list[0];
                     info!(
-                        "Checking for existing deployments: namespace='{}', name='{}' - found: {}",
-                        input.namespace,
-                        input.name,
-                        deployments_list.len()
+                        "Rolling update: keeping deployment {} running as parent",
+                        existing.id
                     );
-
-                    if !deployments_list.is_empty() {
-                        info!(
-                            "Found {} active deployments with the same namespace and name",
-                            deployments_list.len()
-                        );
-
-                        let has_health_checks = input
-                            .health_checks
-                            .as_ref()
-                            .map(|hc| !hc.is_empty())
-                            .unwrap_or(false);
-
-                        // Rolling update: keep old deployment running if conditions are met
-                        if !params.force && has_health_checks && deployments_list.len() == 1 {
-                            let existing = &deployments_list[0];
-                            info!(
-                                "Rolling update: keeping deployment {} running as parent",
-                                existing.id
+                    rolling_parent_id = Some(existing.id.clone());
+                } else {
+                    // Immediate replace. Pick the most specific reason so
+                    // operators can fix the root cause: `force=true` is a
+                    // deliberate caller choice, the others are config gaps.
+                    replace_reason = Some(if params.force {
+                        "force"
+                    } else if !has_health_checks {
+                        "no_health_checks"
+                    } else {
+                        "multiple_active_deployments"
+                    });
+                    for mut deployment in deployments_list {
+                        info!("Marking deployment {} as deleted", deployment.id);
+                        replaced_deployment_ids.push(deployment.id.clone());
+                        deployment.status = DeploymentStatus::Deleted;
+                        deployment.updated_at = Some(Utc::now().to_string());
+                        if let Err(e) = deployments::update(&pool, &deployment).await {
+                            log::error!(
+                                "Failed to mark deployment {} as deleted: {}",
+                                deployment.id,
+                                e
                             );
-                            rolling_parent_id = Some(existing.id.clone());
-                        } else {
-                            // Immediate replace. Pick the most specific reason so
-                            // operators can fix the root cause: `force=true` is a
-                            // deliberate caller choice, the others are config gaps.
-                            replace_reason = Some(if params.force {
-                                "force"
-                            } else if !has_health_checks {
-                                "no_health_checks"
-                            } else {
-                                "multiple_active_deployments"
-                            });
-                            for mut deployment in deployments_list {
-                                info!("Marking deployment {} as deleted", deployment.id);
-                                replaced_deployment_ids.push(deployment.id.clone());
-                                deployment.status = DeploymentStatus::Deleted;
-                                deployment.updated_at = Some(Utc::now().to_string());
-                                if let Err(e) = deployments::update(&pool, &deployment).await {
-                                    log::error!(
-                                        "Failed to mark deployment {} as deleted: {}",
-                                        deployment.id,
-                                        e
-                                    );
-                                }
-                            }
                         }
                     }
-                }
-                Err(e) => {
-                    log::error!("Database error while checking active deployments: {}", e);
-                    let message = Message {
-                        message: "Internal server error".to_string(),
-                    };
-                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
-                }
-            }
-
-            let utc: DateTime<Utc> = Utc::now();
-
-            let volumes = match serde_json::to_string(&input.volumes) {
-                Ok(json_str) => json_str,
-                Err(e) => {
-                    log::error!("Volume serialization error: {}", e);
-                    let message = Message {
-                        message: "Internal server error".to_string(),
-                    };
-                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
-                }
-            };
-
-            let deployment = deployments::Deployment {
-                id: Uuid::new_v4().to_string(),
-                name: input.name.clone(),
-                runtime: input.runtime.clone(),
-                namespace: input.namespace.clone(),
-                kind: match input.kind {
-                    DeploymentKind::Worker => "worker".to_string(),
-                    DeploymentKind::Job => "job".to_string(),
-                },
-                image: input.image.clone(),
-                config: input.config.clone(),
-                status: DeploymentStatus::Creating,
-                created_at: utc.to_string(),
-                updated_at: None,
-                labels: input.labels,
-                environment: input.environment,
-                replicas: input.replicas,
-                command: input.command,
-                instances: [].to_vec(),
-                restart_count: 0,
-                volumes,
-                health_checks: input.health_checks.unwrap_or_default(),
-                resources: input.resources,
-                image_digest: None,
-                ports: input.ports,
-                pending_events: vec![],
-                parent_id: rolling_parent_id,
-                network: input.network.clone(),
-            };
-
-            match deployments::create(&pool, &deployment).await {
-                Ok(deployment) => {
-                    let _ = deployment_event::log_event(
-                        &pool,
-                        deployment.id.clone(),
-                        "info",
-                        format!("Deployment '{}' created successfully", deployment.name),
-                        "api",
-                        Some("deployment_created"),
-                    )
-                    .await;
-
-                    // When a previous active deployment was wiped instead of
-                    // being kept as a rolling parent, surface the reason as a
-                    // dedicated event. Operators inspecting "why didn't my
-                    // rolling update happen?" find the answer in one place
-                    // (event level: warning so it shows up under
-                    // `--level warning` filters).
-                    if let Some(reason) = replace_reason {
-                        let replaced = if replaced_deployment_ids.len() == 1 {
-                            format!("deployment {}", replaced_deployment_ids[0])
-                        } else {
-                            format!(
-                                "{} deployments ({})",
-                                replaced_deployment_ids.len(),
-                                replaced_deployment_ids.join(", ")
-                            )
-                        };
-                        let message = match reason {
-                            "force" => format!(
-                                "Replaced {} immediately because force=true was set on the request — rolling update skipped",
-                                replaced
-                            ),
-                            "no_health_checks" => format!(
-                                "Replaced {} immediately because no health checks are declared — rolling update requires at least one health check",
-                                replaced
-                            ),
-                            "multiple_active_deployments" => format!(
-                                "Replaced {} immediately because more than one active deployment was found for {}/{} — rolling update only applies when exactly one parent exists",
-                                replaced, deployment.namespace, deployment.name
-                            ),
-                            other => format!("Replaced {} immediately ({})", replaced, other),
-                        };
-                        let _ = deployment_event::log_event(
-                            &pool,
-                            deployment.id.clone(),
-                            "warning",
-                            message,
-                            "api",
-                            Some("force_replace"),
-                        )
-                        .await;
-                    }
-
-                    let deployment_output = DeploymentOutput::from_to_model(deployment);
-                    (StatusCode::CREATED, Json(deployment_output)).into_response()
-                }
-                Err(e) => {
-                    error!("Failed to create deployment: {}", e);
-                    let message = Message {
-                        message: format!(
-                            "A deployment with name '{}' already exists in namespace '{}'",
-                            input.name, input.namespace
-                        ),
-                    };
-                    (StatusCode::CONFLICT, Json(message)).into_response()
                 }
             }
         }
         Err(e) => {
+            log::error!("Database error while checking active deployments: {}", e);
             let message = Message {
-                message: e.to_string(),
+                message: "Internal server error".to_string(),
             };
-            (StatusCode::BAD_REQUEST, Json(message)).into_response()
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
+        }
+    }
+
+    let utc: DateTime<Utc> = Utc::now();
+
+    let volumes = match serde_json::to_string(&input.volumes) {
+        Ok(json_str) => json_str,
+        Err(e) => {
+            log::error!("Volume serialization error: {}", e);
+            let message = Message {
+                message: "Internal server error".to_string(),
+            };
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(message)).into_response();
+        }
+    };
+
+    let deployment = deployments::Deployment {
+        id: Uuid::new_v4().to_string(),
+        name: input.name.clone(),
+        runtime: input.runtime.clone(),
+        namespace: input.namespace.clone(),
+        kind: match input.kind {
+            DeploymentKind::Worker => "worker".to_string(),
+            DeploymentKind::Job => "job".to_string(),
+        },
+        image: input.image.clone(),
+        config: input.config.clone(),
+        status: DeploymentStatus::Creating,
+        created_at: utc.to_string(),
+        updated_at: None,
+        labels: input.labels,
+        environment: input.environment,
+        replicas: input.replicas,
+        command: input.command,
+        instances: [].to_vec(),
+        restart_count: 0,
+        volumes,
+        health_checks: input.health_checks.unwrap_or_default(),
+        resources: input.resources,
+        image_digest: None,
+        ports: input.ports,
+        pending_events: vec![],
+        parent_id: rolling_parent_id,
+        network: input.network.clone(),
+    };
+
+    match deployments::create(&pool, &deployment).await {
+        Ok(deployment) => {
+            let _ = deployment_event::log_event(
+                &pool,
+                deployment.id.clone(),
+                "info",
+                format!("Deployment '{}' created successfully", deployment.name),
+                "api",
+                Some("deployment_created"),
+            )
+            .await;
+
+            // When a previous active deployment was wiped instead of
+            // being kept as a rolling parent, surface the reason as a
+            // dedicated event. Operators inspecting "why didn't my
+            // rolling update happen?" find the answer in one place
+            // (event level: warning so it shows up under
+            // `--level warning` filters).
+            if let Some(reason) = replace_reason {
+                let replaced = if replaced_deployment_ids.len() == 1 {
+                    format!("deployment {}", replaced_deployment_ids[0])
+                } else {
+                    format!(
+                        "{} deployments ({})",
+                        replaced_deployment_ids.len(),
+                        replaced_deployment_ids.join(", ")
+                    )
+                };
+                let message = match reason {
+                    "force" => format!(
+                        "Replaced {} immediately because force=true was set on the request — rolling update skipped",
+                        replaced
+                    ),
+                    "no_health_checks" => format!(
+                        "Replaced {} immediately because no health checks are declared — rolling update requires at least one health check",
+                        replaced
+                    ),
+                    "multiple_active_deployments" => format!(
+                        "Replaced {} immediately because more than one active deployment was found for {}/{} — rolling update only applies when exactly one parent exists",
+                        replaced, deployment.namespace, deployment.name
+                    ),
+                    other => format!("Replaced {} immediately ({})", replaced, other),
+                };
+                let _ = deployment_event::log_event(
+                    &pool,
+                    deployment.id.clone(),
+                    "warning",
+                    message,
+                    "api",
+                    Some("force_replace"),
+                )
+                .await;
+            }
+
+            let deployment_output = DeploymentOutput::from_to_model(deployment);
+            (StatusCode::CREATED, Json(deployment_output)).into_response()
+        }
+        Err(e) => {
+            error!("Failed to create deployment: {}", e);
+            let message = Message {
+                message: format!(
+                    "A deployment with name '{}' already exists in namespace '{}'",
+                    input.name, input.namespace
+                ),
+            };
+            (StatusCode::CONFLICT, Json(message)).into_response()
         }
     }
 }
@@ -554,7 +565,7 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]
@@ -659,12 +670,15 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
         assert!(
-            body.message.contains("custom commands are not supported"),
+            body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("custom commands are not supported"),
             "unexpected error: {}",
-            body.message
+            body["detail"]
         );
     }
 
@@ -685,12 +699,15 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
         assert!(
-            body.message.contains("absolute path to a raw disk image"),
+            body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("absolute path to a raw disk image"),
             "unexpected error: {}",
-            body.message
+            body["detail"]
         );
     }
 
@@ -858,11 +875,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("source is required for bind volumes")
         );
     }
@@ -925,9 +943,14 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        assert!(error_body.message.contains("source cannot be empty"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        assert!(
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("source cannot be empty")
+        );
     }
 
     #[tokio::test]
@@ -955,14 +978,16 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("source is required for config volumes")
-                || error_body
-                    .message
+                || error_body["detail"]
+                    .as_str()
+                    .unwrap()
                     .contains("key is required for config volumes")
         );
     }
@@ -994,11 +1019,17 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body.message.contains("source cannot be empty")
-                || error_body.message.contains("key cannot be empty")
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("source cannot be empty")
+                || error_body["detail"]
+                    .as_str()
+                    .unwrap()
+                    .contains("key cannot be empty")
         );
     }
 
@@ -1028,9 +1059,14 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        assert!(error_body.message.contains("destination cannot be empty"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        assert!(
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("destination cannot be empty")
+        );
     }
 
     #[tokio::test]
@@ -1222,10 +1258,10 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        let message = &error_body.message;
-        assert!(message.contains("source") || message.contains("destination"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        let detail = error_body["detail"].as_str().unwrap_or("");
+        assert!(detail.contains("source") || detail.contains("destination"));
     }
 
     #[tokio::test]
@@ -1254,11 +1290,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("source is required for config volumes")
         );
     }
@@ -1289,11 +1326,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("key is required for config volumes")
         );
     }
@@ -1325,9 +1363,14 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        assert!(error_body.message.contains("source cannot be empty"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        assert!(
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("source cannot be empty")
+        );
     }
 
     #[tokio::test]
@@ -1357,9 +1400,14 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        assert!(error_body.message.contains("key cannot be empty"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        assert!(
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("key cannot be empty")
+        );
     }
 
     #[tokio::test]
@@ -1387,11 +1435,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("source is required for named volumes")
         );
     }
@@ -1422,9 +1471,14 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
-        assert!(error_body.message.contains("source cannot be empty"));
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
+        assert!(
+            error_body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("source cannot be empty")
+        );
     }
 
     #[tokio::test]
@@ -1454,11 +1508,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let error_body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let error_body: serde_json::Value = response.json();
         assert!(
-            error_body
-                .message
+            error_body["detail"]
+                .as_str()
+                .unwrap()
                 .contains("config volumes must be read-only")
         );
     }
@@ -1696,7 +1751,7 @@ mod tests {
 
         assert!(
             response.status_code() == StatusCode::CREATED
-                || response.status_code() == StatusCode::BAD_REQUEST
+                || response.status_code() == StatusCode::UNPROCESSABLE_ENTITY
                 || response.status_code() == StatusCode::UNPROCESSABLE_ENTITY
         );
     }
@@ -2016,12 +2071,20 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        // Match on the stable `code` slug instead of human text — the
+        // wording of `message` may evolve without breaking clients.
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|v| v["code"].as_str().unwrap_or("").to_string())
+            .collect();
         assert!(
-            body.message.contains("network.mode=host") && body.message.contains("port"),
-            "unexpected message: {}",
-            body.message
+            codes.contains(&"deployment.ports.host_network_conflict".to_string()),
+            "expected deployment.ports.host_network_conflict, got {:?}",
+            codes
         );
     }
 
@@ -2044,12 +2107,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
         assert!(
-            body.message.contains("replicas"),
+            body["detail"].as_str().unwrap().contains("replicas"),
             "unexpected message: {}",
-            body.message
+            body["detail"]
         );
     }
 
@@ -2071,12 +2134,12 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        let body: Message = response.json();
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
         assert!(
-            body.message.contains("docker runtime"),
+            body["detail"].as_str().unwrap().contains("docker runtime"),
             "unexpected message: {}",
-            body.message
+            body["detail"]
         );
     }
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::{Config, get_config_dir, load_auth_config};
 use crate::exit_code;
 use crate::models::deployments::EnvValue;
@@ -20,6 +21,10 @@ enum ApplyError {
     Validation(String),
     Http(reqwest::Error),
     HttpStatus(u16, String),
+    // The failure has already been printed to stderr (typically by
+    // `render_response_error`). Carry only the status so `apply()` can map
+    // it to the right exit code without re-printing.
+    Reported(u16),
     Auth(String),
 }
 
@@ -33,6 +38,7 @@ impl fmt::Display for ApplyError {
             ApplyError::HttpStatus(status, msg) => {
                 write!(f, "HTTP {} error: {}", status, msg)
             }
+            ApplyError::Reported(status) => write!(f, "request failed with status {}", status),
             ApplyError::Auth(msg) => write!(f, "Auth error: {}", msg),
         }
     }
@@ -366,17 +372,9 @@ async fn create_namespace_on_server(
         println!("Namespace '{}' already exists, skipping", namespace.name);
         Ok(())
     } else {
-        let error_body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unknown error".to_string());
-        Err(ApplyError::HttpStatus(
-            status.as_u16(),
-            format!(
-                "Failed to create namespace '{}': {} {}",
-                namespace.name, status, error_body
-            ),
-        ))
+        let context = format!("Failed to create namespace '{}'", namespace.name);
+        let code = render_response_error(&context, response).await;
+        Err(ApplyError::Reported(code))
     }
 }
 
@@ -413,23 +411,24 @@ async fn deploy_to_server(
         println!("Deployment '{}' created", deployment.name);
         Ok(())
     } else {
-        let error_body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unknown error".to_string());
-        Err(ApplyError::HttpStatus(
-            status.as_u16(),
-            format!("API returned status {}: {}", status, error_body),
-        ))
+        let context = format!("Unable to apply deployment '{}'", deployment.name);
+        let code = render_response_error(&context, response).await;
+        Err(ApplyError::Reported(code))
     }
 }
 
 pub(crate) async fn apply(args: &ArgMatches, configuration: Config, client: &reqwest::Client) {
     if let Err(e) = apply_internal(args, configuration, client).await {
-        eprintln!("Error: {}", e);
+        // `Reported` means render_response_error has already written a
+        // structured error to stderr — re-printing would just duplicate the
+        // problem+json output.
+        if !matches!(e, ApplyError::Reported(_)) {
+            eprintln!("Error: {}", e);
+        }
         match e {
             ApplyError::Http(err) => exit_code::from_reqwest_error(&err).exit(),
             ApplyError::HttpStatus(status, _) => exit_code::from_http_status(status).exit(),
+            ApplyError::Reported(status) => exit_code::from_http_status(status).exit(),
             ApplyError::Auth(_) => exit_code::ExitCode::Auth.exit(),
             ApplyError::Validation(_) => exit_code::ExitCode::General.exit(),
             _ => exit_code::ExitCode::General.exit(),
@@ -470,7 +469,9 @@ async fn apply_internal(
         } else if let Err(e) =
             create_namespace_on_server(namespace, &api_url, &auth_config.token, client).await
         {
-            eprintln!("Failed to create namespace '{}': {}", key, e);
+            if !matches!(e, ApplyError::Reported(_)) {
+                eprintln!("Failed to create namespace '{}': {}", key, e);
+            }
             if first_error.is_none() {
                 first_error = Some(e);
             }
@@ -512,7 +513,12 @@ async fn apply_internal(
             {
                 Ok(()) => success_count += 1,
                 Err(e) => {
-                    eprintln!("Failed to deploy '{}': {}", deployment_name, e);
+                    // `Reported` means render_response_error already wrote a
+                    // structured RFC 7807 dump to stderr — duplicating the
+                    // legacy one-liner here just adds noise.
+                    if !matches!(e, ApplyError::Reported(_)) {
+                        eprintln!("Failed to deploy '{}': {}", deployment_name, e);
+                    }
                     error_count += 1;
                     if first_error.is_none() {
                         first_error = Some(e);

--- a/tests/e2e/docker/t25_apply_validation_problem_json.sh
+++ b/tests/e2e/docker/t25_apply_validation_problem_json.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# T25: apply a manifest with three independent validation problems and
+# assert that `ring apply` surfaces the API's RFC 7807 problem+json body
+# (title + every violation), not the legacy `API returned status N: …` line.
+#
+# Covers `src/commands/apply.rs` -> `render_response_error()` wiring for
+# `POST /deployments` introduced alongside the deployment validator.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T25: apply renders problem+json violations =="
+
+start_ring
+ring_login
+
+OUTPUT_FILE=$(mktemp -t ring-e2e-t25-XXXXXX)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+set +e
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/invalid-multi-violation.yaml" \
+  > "$OUTPUT_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+log "ring apply exit code: $EXIT_CODE"
+log "ring apply output:"
+sed 's/^/  | /' "$OUTPUT_FILE"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  fail "expected apply to fail on invalid manifest, got exit 0"
+fi
+
+# Title line: `Unable to apply deployment 'bad': <title> (422)`. The exact
+# title is "Validation failed" but match loosely to stay resilient to wording
+# changes.
+if ! grep -q "Unable to apply deployment 'bad'" "$OUTPUT_FILE"; then
+  fail "title line missing the deployment name context"
+fi
+if ! grep -q "(422)" "$OUTPUT_FILE"; then
+  fail "expected the 422 status code in the title line"
+fi
+
+# Every violation we put in the fixture must appear with its property path.
+expected_paths=(
+  "replicas"
+  "ports[0].published"
+  "environment.1BAD_NAME"
+)
+for path in "${expected_paths[@]}"; do
+  # The path appears as `  * <path>: <message>`; just check the prefix to
+  # avoid coupling to message wording. Use fixed-string grep to avoid
+  # interpreting `[`/`]` as regex character classes.
+  if ! grep -F -q "* ${path}:" "$OUTPUT_FILE"; then
+    fail "missing violation for property path '${path}'"
+  fi
+done
+
+# Sanity: the legacy fallback should NOT have fired. If it did we'd see the
+# pre-7807 wrapper.
+if grep -q "API returned status" "$OUTPUT_FILE"; then
+  fail "legacy 'API returned status' wrapper still present — render_response_error did not fire"
+fi
+
+log "== T25: PASS =="

--- a/tests/e2e/fixtures/invalid-multi-violation.yaml
+++ b/tests/e2e/fixtures/invalid-multi-violation.yaml
@@ -1,0 +1,12 @@
+deployments:
+  bad:
+    name: bad
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:alpine
+    replicas: 3
+    ports:
+      - published: 0
+        target: 80
+    environment:
+      "1BAD_NAME": "x"


### PR DESCRIPTION
## Summary

Brings `POST /deployments` up to the same validation standard as `POST /users` (PR #88): RFC 7807 `application/problem+json` responses, every rule evaluated in one pass, stable `code` slugs per rule, JSONPath `property_path` for nested collections.

On top of that, adds a layer of cross-field and per-list rules that previously made it through to the runtime and broke things silently.

## Commits

Each commit leaves the test suite green; reviewing one by one is straightforward.

| Commit | What it does |
|---|---|
| `3f5418a` | **Modernize** existing validators. `validate_runtime_constraints` and `validate_network_constraints` no longer return ad-hoc `Result<(), String>`; they push into a shared `ViolationList`. Handler returns 422 problem+json instead of 400 plain message. Existing tests updated. |
| `42e8318` | **Cross-field rules** in TDD: tests added first, then `validate_cross_field_constraints`. Rules: `ports + replicas > 1` (surfaces on both fields), `kind: job + replicas > 1`, `kind: job + readiness check`. |
| `7f6070d` | **Per-port** rules + JSONPath. Port 0 rejected (kernel-reserved, also Docker's "any port" semantic), duplicate published ports rejected, paths reach `ports[0].published`. JSONPath round-trip pinned by a dedicated test on volume violations (`volumes[0].source`). |
| `9d65979` | **environment / resources / config**. Env var names against POSIX regex; `resources.{limits,requests}.{cpu,memory}` parse with the existing model parsers; `config.image_pull_policy` ∈ {Always, IfNotPresent, Never}. |
| `32fe7a5` | **Docs + CHANGELOG**. New rules table on `POST /deployments`, breaking change note. |

## New rules in one place

| `property_path` | `code` |
|---|---|
| `runtime` | `deployment.runtime.unsupported` |
| `command` | `deployment.command.cloud_hypervisor_unsupported` |
| `image` | `deployment.image.cloud_hypervisor_requires_absolute_path` |
| `network.mode` | `deployment.network.host_runtime_unsupported` |
| `ports` | `deployment.ports.host_network_conflict` |
| `replicas` | `deployment.replicas.host_network_conflict` |
| `ports[i].published` | `deployment.ports.published.out_of_range` |
| `ports[i].target` | `deployment.ports.target.out_of_range` |
| `ports[i].published` | `deployment.ports.published.duplicate` |
| `ports` + `replicas` | `deployment.ports.replicas_conflict` + `deployment.replicas.ports_conflict` |
| `replicas` | `deployment.replicas.job_must_be_one` |
| `health_checks` | `deployment.health_checks.job_readiness_unsupported` |
| `environment.<KEY>` | `deployment.environment.key.invalid` |
| `resources.{limits,requests}.cpu` | `deployment.resources.{limits,requests}.cpu.invalid` |
| `resources.{limits,requests}.memory` | `deployment.resources.{limits,requests}.memory.invalid` |
| `config.image_pull_policy` | `deployment.config.image_pull_policy.unsupported` |

## Test plan

- [x] `cargo test --bin ring` — 337 passed, 0 failed (was 326 before; +11 new tests for the new rules and the JSONPath contract).
- [x] `cargo fmt --check` clean.
- [x] Full Docker e2e suite — 24/24 PASS, no regression.
- [x] Each commit's tests pass on its own (TDD — red → green per commit).

## Out of scope

- Custom extractor for malformed JSON — would touch every endpoint at once and shifts status semantics. Separate PR.
- `health_checks` body shape beyond what `validator` already enforces (URL parsing, retry windows) — own pass.
- `apply.rs` CLI rendering of the new deployment violations through `problem_json` helper from PR #88 — follow-up.