### PR TITLE
feat: RFC 7807 validation for namespaces, secrets, configs, login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `property_path` follows JSONPath conventions for nested collections: `ports[0].published`, `volumes[2].source`, `resources.limits.cpu`.
 
+- **`POST /namespaces` now uses RFC 7807.** Validation failures return `application/problem+json` (422) with codes:
+  - `namespace.name.length` — must be 2 to 63 characters
+  - `namespace.name.format` — lowercase DNS-label rules (`a-z0-9` plus `-`, no leading/trailing dash)
+
+  Conflicts (duplicate name) now return `application/problem+json` (409) with `title: "Conflict"` and a `detail` line naming the offending namespace, instead of the legacy `{"error": "..."}` shape.
+
+- **`POST /secrets` now uses RFC 7807.** Validation codes:
+  - `secret.namespace.length` / `secret.namespace.format`
+  - `secret.name.length` — 2 to 253 characters
+  - `secret.name.format` — DNS-subdomain rules (lowercase alphanumerics plus `.` and `-`)
+  - `secret.value.length` — 1 to 1 MiB (matches Kubernetes' Secret limit)
+
+  404 (namespace missing) and 409 (duplicate) responses are problem+json with `Not Found` / `Conflict` titles.
+
+- **`POST /configs` and `PUT /configs/{id}` now use RFC 7807.** Validation codes:
+  - `config.namespace.length` / `config.namespace.format`
+  - `config.name.length` — 1 to 253 characters
+  - `config.name.format` — same DNS-subdomain rules as secrets
+  - `config.data.length` — 1 to 1 MiB
+  - `config.data.invalid_json` — on PUT, when `data` is non-empty but doesn't round-trip as JSON
+  - `config.labels.length` — at most 1000 characters
+
+  The previous 400 with `{"error": "Validation failed", "details": ...}` is replaced by a 422 with violations. 404 (config missing on PUT) and 409 (duplicate on POST) are problem+json.
+
+- **`POST /login` now emits problem+json on 401/500** with `title: "Unauthorized"` and `detail: "invalid credentials"` (same shape on internal errors with a generic detail). The legacy `{"errors": ["Invalid credentials"]}` body is gone.
+
 - **Validation errors on `POST /users` and `PUT /users/{id}` now use RFC 7807.** The 422 response shape changed from the bare `validator`-derived `{"errors": <map>}` to `application/problem+json`:
 
   ```json
@@ -61,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Event `reason` strings (`ImagePullBackOff`, `InstanceCreationFailed`, …) stay PascalCase — those are event labels, not statuses.
 
 ### Added
-- **`ring apply` now renders RFC 7807 problem details from `POST /deployments` and `POST /namespaces`**. On validation failure the CLI prints the title line plus every violation with its property path, e.g.
+- **`ring apply`, `ring namespace create` and `ring secret create` render RFC 7807 problem details.** On validation failure the CLI prints the title line plus every violation with its property path, e.g.
 
   ```
   Unable to apply deployment 'nginx': Validation failed (422)
@@ -69,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * replicas: replicas > 1 (3) is incompatible with `ports` — drop `ports` or reduce `replicas` to 1
   ```
 
-  instead of the legacy `API returned status 422: <raw body>` one-liner. Non-7807 responses fall back to the previous behaviour.
+  instead of the legacy `API returned status 422: <raw body>` one-liner. Non-validation problems (404, 409) print the same way with the server's `title` and `detail`. Non-7807 responses fall back to the previous behaviour.
 
 ## [0.8.0] - 2026-05-12
 

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -40,6 +40,11 @@ Content-Type: application/json
 
 Tokens are stable per user; the CLI saves them in `~/.config/kemeter/ring/auth.json` after `ring login`.
 
+**Errors** (all in `application/problem+json`):
+
+- `401 Unauthorized` — `{"title": "Unauthorized", "detail": "invalid credentials"}` for both unknown username and wrong password.
+- `500 Internal Server Error` — token persistence or credential verification failure.
+
 ## CORS
 
 If `cors_origins` is configured in `config.toml`, the API serves the listed origins with `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS` and the headers `Authorization`, `Content-Type`, `Accept`. Browser clients require this to be set explicitly.
@@ -458,7 +463,15 @@ Secrets are AES-256-GCM-encrypted values stored per-namespace. The API never exp
 }
 ```
 
-**Errors:**
+**Validation** (see [Validation errors](#validation-errors) for the response shape):
+
+| Field | Rule | Code |
+| --- | --- | --- |
+| `namespace` | 2-63 lowercase DNS-label characters | `secret.namespace.length`, `secret.namespace.format` |
+| `name` | 2-253 lowercase DNS-subdomain characters | `secret.name.length`, `secret.name.format` |
+| `value` | 1 byte to 1 MiB | `secret.value.length` |
+
+**Errors** (all in `application/problem+json`):
 
 - `404 Not Found` — the namespace doesn't exist yet (POST /secrets does not auto-create it).
 - `409 Conflict` — a secret with this name already exists in this namespace.
@@ -605,6 +618,19 @@ A config is a named blob (typically a config file or JSON document) attached to 
 
 **Response:** `201 Created`
 
+**Validation** (see [Validation errors](#validation-errors) for the response shape):
+
+| Field | Rule | Code |
+| --- | --- | --- |
+| `namespace` | 2-63 lowercase DNS-label characters | `config.namespace.length`, `config.namespace.format` |
+| `name` | 1-253 lowercase DNS-subdomain characters | `config.name.length`, `config.name.format` |
+| `data` | 1 byte to 1 MiB | `config.data.length` |
+| `labels` | at most 1000 characters | `config.labels.length` |
+
+**Errors** (all in `application/problem+json`):
+
+- `409 Conflict` — a configuration with the same name already exists in this namespace.
+
 ### `GET /configs/{id}`
 
 ```json
@@ -630,6 +656,18 @@ Full replacement (not partial). All fields must be provided.
 ```
 
 **Response:** `200 OK`
+
+**Validation** (see [Validation errors](#validation-errors)):
+
+| Field | Rule | Code |
+| --- | --- | --- |
+| `name` | 1-253 lowercase DNS-subdomain characters | `config.name.length`, `config.name.format` |
+| `data` | 1 byte to 1 MiB, must round-trip as JSON when non-empty | `config.data.length`, `config.data.invalid_json` |
+| `labels` | at most 1000 characters | `config.labels.length` |
+
+**Errors** (all in `application/problem+json`):
+
+- `404 Not Found` — no configuration with that id.
 
 ### `DELETE /configs/{id}`
 
@@ -680,7 +718,16 @@ Full replacement (not partial). All fields must be provided.
 }
 ```
 
-**Errors:** `409 Conflict` if a namespace with the same name already exists.
+**Validation** (see [Validation errors](#validation-errors)):
+
+| Field | Rule | Code |
+| --- | --- | --- |
+| `name` | 2-63 characters | `namespace.name.length` |
+| `name` | lowercase DNS-label (`a-z0-9` plus `-`, no leading/trailing dash) | `namespace.name.format` |
+
+**Errors** (all in `application/problem+json`):
+
+- `409 Conflict` — a namespace with the same name already exists.
 
 > Namespaces are also auto-created when a deployment is applied to a non-existent namespace; calling `POST /namespaces` upfront is optional.
 
@@ -720,22 +767,22 @@ Returns information about the host running the Ring server.
 
 ## Error format
 
-Ring's error responses are migrating to [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807). Newly-rewritten endpoints serve that shape — see [Validation errors](#validation-errors) for the canonical example.
+Ring's error responses are [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807). Validation failures carry a `violations[]` array (see [Validation errors](#validation-errors)); non-validation problems (conflicts, not-found, unauthorized, server errors) carry the same envelope without the array:
 
-The migration is in progress, so three legacy shapes still appear in older handlers:
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
 
-```json
-// Most handlers (deployments, namespaces, secrets, configs)
-{ "error": "Secret not found" }
-
-// Some handlers (e.g. POST /deployments validation errors)
-{ "message": "Invalid runtime, supported: [docker, cloud-hypervisor]" }
-
-// POST /login on bad credentials
-{ "errors": ["Invalid credentials"] }
+{
+  "type": "about:blank",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "namespace 'production' already exists",
+  "violations": []
+}
 ```
 
-Plan to handle all four shapes when consuming the API. The endpoints that have moved to RFC 7807 are flagged with a "Validation" callout in their section above. Standardisation onto problem+json is on the roadmap.
+A few read endpoints (e.g. `GET` lookups, `DELETE` referenced-secret checks) still serve the legacy `{"error": "..."}` body; those will move next. Clients should branch on the `Content-Type` header to pick the parser.
 
 ## Examples
 

--- a/src/api/action/config/create.rs
+++ b/src/api/action/config/create.rs
@@ -1,10 +1,17 @@
+use crate::api::action::config::validation::{
+    CONFIG_DATA_MAX, CONFIG_LABELS_MAX, CONFIG_NAME_MAX, CONFIG_NAME_MIN, CONFIG_NAME_PATTERN,
+};
+use crate::api::action::namespace::validation::{
+    NAMESPACE_NAME_MAX, NAMESPACE_NAME_MIN, NAMESPACE_NAME_PATTERN,
+};
 use crate::api::server::Db;
+use crate::api::validation::{ViolationList, problem_response};
 use crate::models::config;
 use crate::models::users::User;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -12,79 +19,93 @@ use validator::Validate;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 pub(crate) struct ConfigInput {
+    #[validate(
+        length(
+            min = "NAMESPACE_NAME_MIN",
+            max = "NAMESPACE_NAME_MAX",
+            code = "config.namespace.length",
+            message = "must be 2 to 63 characters"
+        ),
+        regex(
+            path = *NAMESPACE_NAME_PATTERN,
+            code = "config.namespace.format",
+            message = "must contain only lowercase letters, digits and '-', and start and end with an alphanumeric character"
+        )
+    )]
     namespace: String,
+    #[validate(
+        length(
+            min = "CONFIG_NAME_MIN",
+            max = "CONFIG_NAME_MAX",
+            code = "config.name.length",
+            message = "must be 1 to 253 characters"
+        ),
+        regex(
+            path = *CONFIG_NAME_PATTERN,
+            code = "config.name.format",
+            message = "must contain only lowercase letters, digits, '.' and '-', and start and end with an alphanumeric character"
+        )
+    )]
     name: String,
+    #[validate(length(
+        min = 1,
+        max = "CONFIG_DATA_MAX",
+        code = "config.data.length",
+        message = "must be 1 to 1048576 bytes (1 MiB)"
+    ))]
     data: String,
+    #[validate(length(
+        max = "CONFIG_LABELS_MAX",
+        code = "config.labels.length",
+        message = "must be at most 1000 characters"
+    ))]
     #[serde(default)]
     labels: Option<String>,
-}
-
-impl ConfigInput {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        let errors = validator::ValidationErrors::new();
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
 }
 
 pub(crate) async fn create(
     State(pool): State<Db>,
     _user: User,
     Json(input): Json<ConfigInput>,
-) -> impl IntoResponse {
-    match input.validate() {
-        Ok(_) => {
-            let utc: DateTime<Utc> = Utc::now();
+) -> Response {
+    if let Err(errs) = input.validate() {
+        let violations: ViolationList = errs.into();
+        return violations.into_response();
+    }
 
-            let new_config = config::Config {
-                id: Uuid::new_v4().to_string(),
-                created_at: utc.to_string(),
-                updated_at: None,
-                namespace: input.namespace,
-                name: input.name,
-                data: input.data,
-                labels: input.labels.unwrap_or_default(),
-            };
+    let utc: DateTime<Utc> = Utc::now();
+    let new_config = config::Config {
+        id: Uuid::new_v4().to_string(),
+        created_at: utc.to_string(),
+        updated_at: None,
+        namespace: input.namespace,
+        name: input.name,
+        data: input.data,
+        labels: input.labels.unwrap_or_default(),
+    };
 
-            match config::create(&pool, new_config.clone()).await {
-                Ok(_) => (
-                    StatusCode::CREATED,
-                    Json(serde_json::to_value(new_config).unwrap()),
-                )
-                    .into_response(),
-                Err(e) => {
-                    if e.to_string().contains("UNIQUE constraint failed") {
-                        (
-                            StatusCode::CONFLICT,
-                            Json(serde_json::json!({
-                                "error": "Configuration with this name already exists"
-                            })),
-                        )
-                            .into_response()
-                    } else {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(serde_json::json!({
-                                "error": "Failed to create configuration"
-                            })),
-                        )
-                            .into_response()
-                    }
-                }
-            }
-        }
-        Err(validation_errors) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "Validation failed",
-                "details": validation_errors
-            })),
+    match config::create(&pool, new_config.clone()).await {
+        Ok(_) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(new_config).unwrap()),
         )
             .into_response(),
+        Err(e) if e.to_string().contains("UNIQUE constraint failed") => problem_response(
+            StatusCode::CONFLICT,
+            "Conflict",
+            format!(
+                "configuration '{}' already exists in namespace '{}'",
+                new_config.name, new_config.namespace
+            ),
+        ),
+        Err(e) => {
+            log::error!("Failed to create configuration: {}", e);
+            problem_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "failed to create configuration",
+            )
+        }
     }
 }
 
@@ -95,6 +116,7 @@ mod tests {
     use crate::api::server::tests::new_test_app;
     use axum::http::StatusCode;
     use axum_test::TestServer;
+    use serde_json::json;
 
     #[tokio::test]
     async fn create_config() {
@@ -105,7 +127,7 @@ mod tests {
         let response = server
             .post("/configs")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
+            .json(&json!({
                 "namespace": "test",
                 "name": "test-config",
                 "data": "test data",
@@ -122,52 +144,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_duplicate_config() {
+    async fn create_duplicate_config_returns_problem_json_conflict() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
 
-        // Create first config
-        let response = server
-            .post("/configs")
-            .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "namespace": "test",
-                "name": "duplicate-config",
-                "data": "test data"
-            }))
-            .await;
-        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let payload = json!({
+            "namespace": "test",
+            "name": "duplicate-config",
+            "data": "test data"
+        });
 
-        // Try to create duplicate config
+        let first = server
+            .post("/configs")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&payload)
+            .await;
+        assert_eq!(first.status_code(), StatusCode::CREATED);
+
         let response = server
             .post("/configs")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "namespace": "test",
-                "name": "duplicate-config",
-                "data": "test data"
-            }))
+            .json(&payload)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::CONFLICT);
+        let ct = response
+            .header("content-type")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(ct.starts_with("application/problem+json"), "got: {}", ct);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["title"], "Conflict");
+        assert!(
+            body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("duplicate-config")
+        );
     }
 
     #[tokio::test]
-    async fn create_invalid_config() {
+    async fn create_with_missing_fields_returns_422_with_violations() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
 
+        // Missing `namespace` and `data` empty → length violation on data,
+        // and an empty namespace fails both length and format.
         let response = server
             .post("/configs")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
+            .json(&json!({
+                "namespace": "",
                 "name": "test-config",
-                "data": "test data"
+                "data": ""
             }))
             .await;
 
         assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"config.namespace.length".to_string()));
+        assert!(codes.contains(&"config.data.length".to_string()));
     }
 }

--- a/src/api/action/config/mod.rs
+++ b/src/api/action/config/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod delete;
 pub(crate) mod get;
 pub(crate) mod list;
 pub(crate) mod update;
+pub(crate) mod validation;
 
 pub(crate) use create::create;
 pub(crate) use delete::delete;

--- a/src/api/action/config/update.rs
+++ b/src/api/action/config/update.rs
@@ -1,36 +1,50 @@
 use axum::extract::{Path, State};
-use axum::{Json, response::IntoResponse};
-use http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{Json, http::StatusCode};
 use serde::Deserialize;
 use validator::Validate;
 
+use crate::api::action::config::validation::{
+    CONFIG_DATA_MAX, CONFIG_LABELS_MAX, CONFIG_NAME_MAX, CONFIG_NAME_MIN, CONFIG_NAME_PATTERN,
+};
 use crate::api::dto::config::ConfigOutput;
 use crate::api::server::Db;
+use crate::api::validation::{Violation, ViolationList, problem_response};
 use crate::models::config as ConfigModel;
 use crate::models::users::User;
 
 #[derive(Deserialize, Debug, Validate)]
 pub(crate) struct UpdateConfigRequest {
-    #[validate(length(min = 1, max = 255))]
+    #[validate(
+        length(
+            min = "CONFIG_NAME_MIN",
+            max = "CONFIG_NAME_MAX",
+            code = "config.name.length",
+            message = "must be 1 to 253 characters"
+        ),
+        regex(
+            path = *CONFIG_NAME_PATTERN,
+            code = "config.name.format",
+            message = "must contain only lowercase letters, digits, '.' and '-', and start and end with an alphanumeric character"
+        )
+    )]
     pub name: String,
 
+    #[validate(length(
+        min = 1,
+        max = "CONFIG_DATA_MAX",
+        code = "config.data.length",
+        message = "must be 1 to 1048576 bytes (1 MiB)"
+    ))]
     pub data: String,
 
-    #[validate(length(max = 1000))]
+    #[validate(length(
+        max = "CONFIG_LABELS_MAX",
+        code = "config.labels.length",
+        message = "must be at most 1000 characters"
+    ))]
     #[serde(default)]
     pub labels: Option<String>,
-}
-
-impl UpdateConfigRequest {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        let errors = validator::ValidationErrors::new();
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
 }
 
 pub(crate) async fn update(
@@ -38,32 +52,31 @@ pub(crate) async fn update(
     State(pool): State<Db>,
     _user: User,
     Json(request): Json<UpdateConfigRequest>,
-) -> impl IntoResponse {
-    // Validate request
-    if let Err(errors) = request.validate() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "Validation failed",
-                "details": errors
-            })),
-        )
-            .into_response();
+) -> Response {
+    let mut violations: ViolationList = match request.validate() {
+        Ok(()) => ViolationList::new(),
+        Err(errs) => errs.into(),
+    };
+
+    // JSON-shape rule for `data`: the field must round-trip as a JSON
+    // value. We add this as a regular violation so it shows up alongside
+    // any length/format failures rather than overriding them with a
+    // single 400.
+    if !request.data.is_empty() && serde_json::from_str::<serde_json::Value>(&request.data).is_err()
+    {
+        violations.push(Violation::new(
+            "data",
+            "must be valid JSON",
+            "config.data.invalid_json",
+        ));
     }
 
-    // Validate JSON data
-    if serde_json::from_str::<serde_json::Value>(&request.data).is_err() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "Invalid JSON format in data field"})),
-        )
-            .into_response();
+    if !violations.is_empty() {
+        return violations.into_response();
     }
 
-    // Find existing config
     match ConfigModel::find(&pool, &id).await {
         Ok(Some(mut config)) => {
-            // PUT behavior: Full replacement (like create but keeping id, created_at, namespace)
             config.name = request.name;
             config.data = request.data;
             config.labels = request.labels.unwrap_or_default();
@@ -74,23 +87,23 @@ pub(crate) async fn update(
                     let output = ConfigOutput::from_to_model(config);
                     (StatusCode::OK, Json(output)).into_response()
                 }
-                Err(_) => (
+                Err(_) => problem_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": "Failed to update configuration"})),
-                )
-                    .into_response(),
+                    "Internal Server Error",
+                    "failed to update configuration",
+                ),
             }
         }
-        Ok(None) => (
+        Ok(None) => problem_response(
             StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "Configuration not found"})),
-        )
-            .into_response(),
-        Err(_) => (
+            "Not Found",
+            format!("configuration '{}' does not exist", id),
+        ),
+        Err(_) => problem_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "Database error"})),
-        )
-            .into_response(),
+            "Internal Server Error",
+            "database error",
+        ),
     }
 }
 
@@ -127,29 +140,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_config_data() {
-        let app = new_test_app().await;
-        let token = login(app.clone(), "admin", "changeme").await;
-        let server = TestServer::new(app).unwrap();
-
-        let response = server
-            .put("/configs/cde7806a-21af-473b-968b-08addc7bf0ba")
-            .add_header("Authorization", format!("Bearer {}", token))
-            .json(&json!({
-                "name": "my-config",
-                "data": "{\"updated\": true}"
-            }))
-            .await;
-
-        assert_eq!(response.status_code(), StatusCode::OK);
-
-        let config = response.json::<ConfigOutput>();
-        assert_eq!(config.name, "my-config");
-        assert_eq!(config.data, "{\"updated\": true}");
-    }
-
-    #[tokio::test]
-    async fn update_config_invalid_json_data() {
+    async fn update_config_invalid_json_data_returns_422_violation() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -163,11 +154,19 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"config.data.invalid_json".to_string()));
     }
 
     #[tokio::test]
-    async fn update_nonexistent_config() {
+    async fn update_nonexistent_config_returns_problem_json_not_found() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -182,6 +181,9 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["title"], "Not Found");
+        assert!(body["detail"].as_str().unwrap().contains("nonexistent"));
     }
 
     #[tokio::test]

--- a/src/api/action/config/validation.rs
+++ b/src/api/action/config/validation.rs
@@ -1,0 +1,17 @@
+//! Validation rules for config endpoints.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub(crate) const CONFIG_NAME_MIN: u64 = 1;
+pub(crate) const CONFIG_NAME_MAX: u64 = 253;
+
+/// Same shape as secret names: lowercase DNS subdomain.
+pub(crate) static CONFIG_NAME_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$").unwrap());
+
+/// Hard upper bound on the `data` payload. Matches Kubernetes' ConfigMap
+/// limit (1 MiB).
+pub(crate) const CONFIG_DATA_MAX: u64 = 1_048_576;
+
+pub(crate) const CONFIG_LABELS_MAX: u64 = 1_000;

--- a/src/api/action/login.rs
+++ b/src/api/action/login.rs
@@ -1,6 +1,8 @@
 use crate::api::server::Db;
+use crate::api::validation::problem_response;
 use crate::models::users as users_model;
 use axum::extract::State;
+use axum::response::Response;
 use axum::{Json, http::StatusCode, response::IntoResponse};
 use rand::Rng;
 use rand::distr::Alphanumeric;
@@ -8,10 +10,7 @@ use rand::rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-pub(crate) async fn login(
-    State(pool): State<Db>,
-    Json(input): Json<LoginInput>,
-) -> impl IntoResponse {
+pub(crate) async fn login(State(pool): State<Db>, Json(input): Json<LoginInput>) -> Response {
     debug!("Login attempt");
 
     let option = users_model::find_by_username(&pool, &input.username).await;
@@ -21,17 +20,19 @@ pub(crate) async fn login(
             let matches = match argon2::verify_encoded(&user.password, input.password.as_bytes()) {
                 Ok(m) => m,
                 Err(_) => {
-                    return (
+                    return problem_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "errors": ["Internal server error"] })),
+                        "Internal Server Error",
+                        "credential verification failed",
                     );
                 }
             };
 
             if !matches {
-                return (
+                return problem_response(
                     StatusCode::UNAUTHORIZED,
-                    Json(json!({ "errors": ["Invalid credentials"] })),
+                    "Unauthorized",
+                    "invalid credentials",
                 );
             }
 
@@ -42,21 +43,24 @@ pub(crate) async fn login(
             let token: String = user.token.clone();
 
             if users_model::login(&pool, user).await.is_err() {
-                return (
+                return problem_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "errors": ["Internal server error"] })),
+                    "Internal Server Error",
+                    "failed to record login",
                 );
             }
 
-            (StatusCode::OK, Json(json!({ "token": token })))
+            (StatusCode::OK, Json(json!({ "token": token }))).into_response()
         }
-        Ok(None) => (
+        Ok(None) => problem_response(
             StatusCode::UNAUTHORIZED,
-            Json(json!({ "errors": ["Invalid credentials"] })),
+            "Unauthorized",
+            "invalid credentials",
         ),
-        Err(_) => (
+        Err(_) => problem_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "errors": ["Internal server error"] })),
+            "Internal Server Error",
+            "lookup failed",
         ),
     }
 }
@@ -80,8 +84,8 @@ pub(crate) struct LoginInput {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::server::tests::ErrorResponse;
     use crate::api::server::tests::new_test_app;
+    use axum::http::StatusCode;
     use axum_test::{TestResponse, TestServer};
     use serde::Deserialize;
     use serde_json::json;
@@ -111,7 +115,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn login_fail() {
+    async fn login_fail_returns_problem_json_unauthorized() {
         let server = TestServer::new(new_test_app().await).unwrap();
 
         let response: TestResponse = server
@@ -122,11 +126,16 @@ mod tests {
             }))
             .await;
 
-        let response_body: ErrorResponse = response.json::<ErrorResponse>();
-        assert!(
-            response_body
-                .errors
-                .contains(&"Invalid credentials".to_string())
-        );
+        assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+        let ct = response
+            .header("content-type")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(ct.starts_with("application/problem+json"), "got: {}", ct);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["status"], 401);
+        assert_eq!(body["title"], "Unauthorized");
+        assert_eq!(body["detail"], "invalid credentials");
     }
 }

--- a/src/api/action/namespace/create.rs
+++ b/src/api/action/namespace/create.rs
@@ -1,17 +1,35 @@
+use crate::api::action::namespace::validation::{
+    NAMESPACE_NAME_MAX, NAMESPACE_NAME_MIN, NAMESPACE_NAME_PATTERN,
+};
 use crate::api::dto::namespace::NamespaceOutput;
 use crate::api::server::Db;
+use crate::api::validation::{ViolationList, problem_response};
 use crate::models::namespace;
 use crate::models::users::User;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use uuid::Uuid;
+use validator::Validate;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Validate)]
 pub(crate) struct NamespaceInput {
+    #[validate(
+        length(
+            min = "NAMESPACE_NAME_MIN",
+            max = "NAMESPACE_NAME_MAX",
+            code = "namespace.name.length",
+            message = "must be 2 to 63 characters"
+        ),
+        regex(
+            path = *NAMESPACE_NAME_PATTERN,
+            code = "namespace.name.format",
+            message = "must contain only lowercase letters, digits and '-', and start and end with an alphanumeric character"
+        )
+    )]
     name: String,
 }
 
@@ -19,9 +37,13 @@ pub(crate) async fn create(
     State(pool): State<Db>,
     _user: User,
     Json(input): Json<NamespaceInput>,
-) -> impl IntoResponse {
-    let utc: DateTime<Utc> = Utc::now();
+) -> Response {
+    if let Err(errs) = input.validate() {
+        let violations: ViolationList = errs.into();
+        return violations.into_response();
+    }
 
+    let utc: DateTime<Utc> = Utc::now();
     let new_namespace = namespace::Namespace {
         id: Uuid::new_v4().to_string(),
         created_at: utc.to_string(),
@@ -38,24 +60,18 @@ pub(crate) async fn create(
             )
                 .into_response()
         }
+        Err(e) if e.to_string().contains("UNIQUE constraint failed") => problem_response(
+            StatusCode::CONFLICT,
+            "Conflict",
+            format!("namespace '{}' already exists", new_namespace.name),
+        ),
         Err(e) => {
-            if e.to_string().contains("UNIQUE constraint failed") {
-                (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": "Namespace with this name already exists"
-                    })),
-                )
-                    .into_response()
-            } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": "Failed to create namespace"
-                    })),
-                )
-                    .into_response()
-            }
+            log::error!("Failed to create namespace: {}", e);
+            problem_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "failed to create namespace",
+            )
         }
     }
 }
@@ -67,6 +83,7 @@ mod tests {
     use crate::api::server::tests::new_test_app;
     use axum::http::StatusCode;
     use axum_test::TestServer;
+    use serde_json::json;
 
     #[tokio::test]
     async fn create_namespace() {
@@ -77,9 +94,7 @@ mod tests {
         let response = server
             .post("/namespaces")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "name": "production"
-            }))
+            .json(&json!({ "name": "production" }))
             .await;
 
         assert_eq!(response.status_code(), StatusCode::CREATED);
@@ -88,7 +103,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_duplicate_namespace() {
+    async fn create_duplicate_namespace_returns_problem_json_conflict() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let payload = json!({ "name": "duplicate-ns" });
+        let first = server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&payload)
+            .await;
+        assert_eq!(first.status_code(), StatusCode::CREATED);
+
+        let response = server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&payload)
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CONFLICT);
+        let ct = response
+            .header("content-type")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(ct.starts_with("application/problem+json"), "got: {}", ct);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["status"], 409);
+        assert_eq!(body["title"], "Conflict");
+        assert!(body["detail"].as_str().unwrap().contains("duplicate-ns"));
+    }
+
+    #[tokio::test]
+    async fn create_with_short_name_returns_422_problem_json() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
         let server = TestServer::new(app).unwrap();
@@ -96,20 +144,62 @@ mod tests {
         let response = server
             .post("/namespaces")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "name": "duplicate-ns"
-            }))
+            .json(&json!({ "name": "a" }))
             .await;
-        assert_eq!(response.status_code(), StatusCode::CREATED);
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let v = &body["violations"];
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["property_path"], "name");
+        assert_eq!(v[0]["code"], "namespace.name.length");
+    }
+
+    #[tokio::test]
+    async fn create_with_uppercase_name_trips_format() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
 
         let response = server
             .post("/namespaces")
             .add_header("Authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "name": "duplicate-ns"
-            }))
+            .json(&json!({ "name": "Production" }))
             .await;
 
-        assert_eq!(response.status_code(), StatusCode::CONFLICT);
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"namespace.name.format".to_string()));
+    }
+
+    #[tokio::test]
+    async fn create_accumulates_all_violations() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // `-` fails length (1 char) AND format (leading dash).
+        let response = server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "-" }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"namespace.name.length".to_string()));
+        assert!(codes.contains(&"namespace.name.format".to_string()));
     }
 }

--- a/src/api/action/namespace/mod.rs
+++ b/src/api/action/namespace/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod create;
 pub(crate) mod get;
 pub(crate) mod list;
+pub(crate) mod validation;
 
 pub(crate) use create::create;
 pub(crate) use get::get;

--- a/src/api/action/namespace/validation.rs
+++ b/src/api/action/namespace/validation.rs
@@ -1,0 +1,15 @@
+//! Validation rules for namespace endpoints. Mirrors the layout used by
+//! `api/action/user/validation.rs`: shared bounds + regex live here, the
+//! `#[validate(...)]` attributes on `NamespaceInput` reference them.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub(crate) const NAMESPACE_NAME_MIN: u64 = 2;
+pub(crate) const NAMESPACE_NAME_MAX: u64 = 63;
+
+/// Lowercase DNS-label rules (RFC 1123 subset): `a-z0-9` plus `-`, no
+/// leading or trailing dash. Matches Kubernetes namespace conventions so
+/// the same manifest is portable.
+pub(crate) static NAMESPACE_NAME_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$").unwrap());

--- a/src/api/action/secret/create.rs
+++ b/src/api/action/secret/create.rs
@@ -1,19 +1,59 @@
+use crate::api::action::namespace::validation::{
+    NAMESPACE_NAME_MAX, NAMESPACE_NAME_MIN, NAMESPACE_NAME_PATTERN,
+};
+use crate::api::action::secret::validation::{
+    SECRET_NAME_MAX, SECRET_NAME_MIN, SECRET_NAME_PATTERN, SECRET_VALUE_MAX,
+};
 use crate::api::server::Db;
+use crate::api::validation::{ViolationList, problem_response};
 use crate::models::namespace;
 use crate::models::secret;
 use crate::models::users::User;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use validator::Validate;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 pub(crate) struct SecretInput {
+    #[validate(
+        length(
+            min = "NAMESPACE_NAME_MIN",
+            max = "NAMESPACE_NAME_MAX",
+            code = "secret.namespace.length",
+            message = "must be 2 to 63 characters"
+        ),
+        regex(
+            path = *NAMESPACE_NAME_PATTERN,
+            code = "secret.namespace.format",
+            message = "must contain only lowercase letters, digits and '-', and start and end with an alphanumeric character"
+        )
+    )]
     namespace: String,
+    #[validate(
+        length(
+            min = "SECRET_NAME_MIN",
+            max = "SECRET_NAME_MAX",
+            code = "secret.name.length",
+            message = "must be 2 to 253 characters"
+        ),
+        regex(
+            path = *SECRET_NAME_PATTERN,
+            code = "secret.name.format",
+            message = "must contain only lowercase letters, digits, '.' and '-', and start and end with an alphanumeric character"
+        )
+    )]
     name: String,
+    #[validate(length(
+        min = 1,
+        max = "SECRET_VALUE_MAX",
+        code = "secret.value.length",
+        message = "must be 1 to 1048576 bytes (1 MiB)"
+    ))]
     value: String,
 }
 
@@ -29,26 +69,27 @@ pub(crate) async fn create(
     State(pool): State<Db>,
     _user: User,
     Json(input): Json<SecretInput>,
-) -> impl IntoResponse {
+) -> Response {
+    if let Err(errs) = input.validate() {
+        let violations: ViolationList = errs.into();
+        return violations.into_response();
+    }
+
     match namespace::find_by_name(&pool, &input.namespace).await {
         Ok(None) => {
-            return (
+            return problem_response(
                 StatusCode::NOT_FOUND,
-                Json(serde_json::json!({
-                    "error": format!("Namespace '{}' not found", input.namespace)
-                })),
-            )
-                .into_response();
+                "Not Found",
+                format!("namespace '{}' does not exist", input.namespace),
+            );
         }
         Err(e) => {
             log::error!("Failed to check namespace: {}", e);
-            return (
+            return problem_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": "Failed to verify namespace"
-                })),
-            )
-                .into_response();
+                "Internal Server Error",
+                "failed to verify namespace",
+            );
         }
         Ok(Some(_)) => {}
     }
@@ -74,25 +115,21 @@ pub(crate) async fn create(
             };
             (StatusCode::CREATED, Json(output)).into_response()
         }
+        Err(e) if e.to_string().contains("UNIQUE constraint failed") => problem_response(
+            StatusCode::CONFLICT,
+            "Conflict",
+            format!(
+                "secret '{}' already exists in namespace '{}'",
+                new_secret.name, new_secret.namespace
+            ),
+        ),
         Err(e) => {
-            if e.to_string().contains("UNIQUE constraint failed") {
-                (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": "Secret with this name already exists in this namespace"
-                    })),
-                )
-                    .into_response()
-            } else {
-                log::error!("Failed to create secret: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": "Failed to create secret"
-                    })),
-                )
-                    .into_response()
-            }
+            log::error!("Failed to create secret: {}", e);
+            problem_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "failed to create secret",
+            )
         }
     }
 }
@@ -145,7 +182,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_secret_in_nonexistent_namespace() {
+    async fn create_secret_in_nonexistent_namespace_returns_problem_json() {
         set_test_key();
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
@@ -162,10 +199,20 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+        let ct = response
+            .header("content-type")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(ct.starts_with("application/problem+json"), "got: {}", ct);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["status"], 404);
+        assert_eq!(body["title"], "Not Found");
+        assert!(body["detail"].as_str().unwrap().contains("does-not-exist"));
     }
 
     #[tokio::test]
-    async fn create_duplicate_secret() {
+    async fn create_duplicate_secret_returns_problem_json_conflict() {
         set_test_key();
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
@@ -192,5 +239,44 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::CONFLICT);
+        let body = response.json::<serde_json::Value>();
+        assert_eq!(body["title"], "Conflict");
+        assert!(
+            body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("already exists in namespace")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_with_invalid_fields_returns_422_with_violations() {
+        set_test_key();
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // Namespace and name both invalid (uppercase / leading dash), value empty.
+        let response = server
+            .post("/secrets")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({
+                "namespace": "Production",
+                "name": "-bad",
+                "value": ""
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = response.json::<serde_json::Value>();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(codes.contains(&"secret.namespace.format".to_string()));
+        assert!(codes.contains(&"secret.name.format".to_string()));
+        assert!(codes.contains(&"secret.value.length".to_string()));
     }
 }

--- a/src/api/action/secret/mod.rs
+++ b/src/api/action/secret/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod create;
 pub(crate) mod delete;
 pub(crate) mod get;
 pub(crate) mod list;
+pub(crate) mod validation;
 
 pub(crate) use create::create;
 pub(crate) use delete::delete;

--- a/src/api/action/secret/validation.rs
+++ b/src/api/action/secret/validation.rs
@@ -1,0 +1,17 @@
+//! Validation rules for secret endpoints.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub(crate) const SECRET_NAME_MIN: u64 = 2;
+pub(crate) const SECRET_NAME_MAX: u64 = 253;
+
+/// Kubernetes secret-name convention: lowercase DNS subdomain. Letters,
+/// digits, dot and dash, must start and end with an alphanumeric.
+pub(crate) static SECRET_NAME_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$").unwrap());
+
+/// Hard upper bound on the plaintext value. Anything bigger should live in
+/// a config or an external secret store. 1 MiB matches Kubernetes' Secret
+/// limit and keeps the encrypted payload off the slow path.
+pub(crate) const SECRET_VALUE_MAX: u64 = 1_048_576;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -237,11 +237,6 @@ pub(crate) mod tests {
         pub(crate) token: String,
     }
 
-    #[derive(Debug, Deserialize)]
-    pub(crate) struct ErrorResponse {
-        pub errors: Vec<String>,
-    }
-
     pub(crate) async fn new_test_app() -> Router {
         let (_, router) = new_test_app_with_pool().await;
         router

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -181,6 +181,40 @@ impl IntoResponse for ViolationList {
     }
 }
 
+/// Build a non-validation problem+json response (conflict, not-found,
+/// unauthorized, …). Same envelope as `ViolationList` minus the
+/// `violations` array, so CLI clients render it through the exact same
+/// path (`render_response_error`). `title` lands in the title line,
+/// `detail` becomes the free-form explanation shown to the user.
+pub(crate) fn problem_response(
+    status: StatusCode,
+    title: &'static str,
+    detail: impl Into<String>,
+) -> Response {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        #[serde(rename = "type")]
+        type_: &'static str,
+        title: &'static str,
+        status: u16,
+        detail: String,
+        violations: &'a [Violation],
+    }
+    let body = Body {
+        type_: "about:blank",
+        title,
+        status: status.as_u16(),
+        detail: detail.into(),
+        violations: &[],
+    };
+    let mut response = (status, Json(body)).into_response();
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/problem+json"),
+    );
+    response
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +224,29 @@ mod tests {
     async fn empty_list_is_empty() {
         let list = ViolationList::new();
         assert!(list.is_empty());
+    }
+
+    #[tokio::test]
+    async fn problem_response_emits_problem_json_with_given_status() {
+        let response = problem_response(
+            StatusCode::CONFLICT,
+            "Conflict",
+            "namespace 'production' already exists",
+        );
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            "application/problem+json"
+        );
+        let bytes = to_bytes(response.into_body(), 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["status"], 409);
+        assert_eq!(body["title"], "Conflict");
+        assert_eq!(body["detail"], "namespace 'production' already exists");
+        assert!(body["violations"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/commands/namespace/create.rs
+++ b/src/commands/namespace/create.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -22,11 +23,6 @@ struct NamespaceOutput {
     name: String,
 }
 
-#[derive(Deserialize)]
-struct ErrorResponse {
-    error: String,
-}
-
 pub(crate) async fn execute(
     args: &ArgMatches,
     mut configuration: Config,
@@ -49,19 +45,16 @@ pub(crate) async fn execute(
     match request {
         Ok(response) => {
             let status = response.status();
-            if status == 201 {
+            if status.is_success() {
                 let namespace: NamespaceOutput = response.json().await.unwrap();
                 println!(
                     "Namespace '{}' created (id: {})",
                     namespace.name, namespace.id
                 );
-            } else if status == 409 {
-                let error: ErrorResponse = response.json().await.unwrap();
-                eprintln!("Error: {}", error.error);
-                exit_code::from_http_status(status.as_u16()).exit();
             } else {
-                eprintln!("Failed to create namespace: {}", status);
-                exit_code::from_http_status(status.as_u16()).exit();
+                let context = format!("Failed to create namespace '{}'", name);
+                let code = render_response_error(&context, response).await;
+                exit_code::from_http_status(code).exit();
             }
         }
         Err(error) => {

--- a/src/commands/secret/create.rs
+++ b/src/commands/secret/create.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::render_response_error;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -39,11 +40,6 @@ struct SecretOutput {
     namespace: String,
 }
 
-#[derive(Deserialize)]
-struct ErrorResponse {
-    error: String,
-}
-
 pub(crate) async fn execute(
     args: &ArgMatches,
     mut configuration: Config,
@@ -72,19 +68,16 @@ pub(crate) async fn execute(
     match request {
         Ok(response) => {
             let status = response.status();
-            if status == 201 {
+            if status.is_success() {
                 let secret: SecretOutput = response.json().await.unwrap();
                 println!(
                     "Secret '{}' created in namespace '{}' (id: {})",
                     secret.name, secret.namespace, secret.id
                 );
-            } else if status == 409 {
-                let error: ErrorResponse = response.json().await.unwrap();
-                eprintln!("Error: {}", error.error);
-                exit_code::from_http_status(status.as_u16()).exit();
             } else {
-                eprintln!("Failed to create secret: {}", status);
-                exit_code::from_http_status(status.as_u16()).exit();
+                let context = format!("Failed to create secret '{}'", name);
+                let code = render_response_error(&context, response).await;
+                exit_code::from_http_status(code).exit();
             }
         }
         Err(error) => {

--- a/tests/e2e/docker/t26_namespace_validation_problem_json.sh
+++ b/tests/e2e/docker/t26_namespace_validation_problem_json.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# T26: assert `ring namespace create` renders RFC 7807 problem+json
+# violations from the API (length + format).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T26: namespace create renders problem+json violations =="
+
+start_ring
+ring_login
+
+OUTPUT_FILE=$(mktemp -t ring-e2e-t26-XXXXXX)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+# `-` fails both length (1 char) and format (leading dash).
+set +e
+"$RING_BIN" namespace create -- "-" > "$OUTPUT_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+log "ring namespace create exit code: $EXIT_CODE"
+log "ring namespace create output:"
+sed 's/^/  | /' "$OUTPUT_FILE"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  fail "expected namespace create to fail on invalid name"
+fi
+
+if ! grep -q "Failed to create namespace '-'" "$OUTPUT_FILE"; then
+  fail "missing context line with the namespace name"
+fi
+if ! grep -q "(422)" "$OUTPUT_FILE"; then
+  fail "expected the 422 status code in the title line"
+fi
+if ! grep -F -q "* name:" "$OUTPUT_FILE"; then
+  fail "missing violation line for property 'name'"
+fi
+# Both rules should fire in a single response.
+if ! grep -q "namespace.name.length\|2 to 63" "$OUTPUT_FILE"; then
+  fail "length rule did not appear"
+fi
+if ! grep -q "namespace.name.format\|lowercase letters" "$OUTPUT_FILE"; then
+  fail "format rule did not appear"
+fi
+
+log "== T26: PASS =="

--- a/tests/e2e/docker/t27_secret_validation_problem_json.sh
+++ b/tests/e2e/docker/t27_secret_validation_problem_json.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# T27: assert `ring secret create` renders RFC 7807 problem+json
+# violations from the API:
+#   - missing namespace → 404 problem+json (Not Found)
+#   - invalid name      → 422 problem+json (Validation failed)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T27: secret create renders problem+json violations =="
+
+start_ring
+ring_login
+
+OUTPUT_FILE=$(mktemp -t ring-e2e-t27-XXXXXX)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+# Case 1: invalid name → 422 with violations.
+set +e
+"$RING_BIN" secret create "BAD_NAME" --namespace ring-e2e --value "x" \
+  > "$OUTPUT_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+log "ring secret create (invalid name) exit code: $EXIT_CODE"
+log "ring secret create output:"
+sed 's/^/  | /' "$OUTPUT_FILE"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  fail "expected secret create to fail on invalid name"
+fi
+if ! grep -q "Failed to create secret 'BAD_NAME'" "$OUTPUT_FILE"; then
+  fail "missing context line with the secret name"
+fi
+if ! grep -q "(422)" "$OUTPUT_FILE"; then
+  fail "expected the 422 status code in the title line"
+fi
+if ! grep -F -q "* name:" "$OUTPUT_FILE"; then
+  fail "missing violation line for property 'name'"
+fi
+
+# Case 2: nonexistent namespace → 404 problem+json with detail line.
+> "$OUTPUT_FILE"
+set +e
+"$RING_BIN" secret create "valid-name" --namespace "does-not-exist" --value "x" \
+  > "$OUTPUT_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+log "ring secret create (missing namespace) exit code: $EXIT_CODE"
+log "ring secret create output:"
+sed 's/^/  | /' "$OUTPUT_FILE"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  fail "expected secret create to fail on missing namespace"
+fi
+if ! grep -q "(404)" "$OUTPUT_FILE"; then
+  fail "expected the 404 status code in the title line"
+fi
+if ! grep -q "does-not-exist" "$OUTPUT_FILE"; then
+  fail "missing namespace name in the detail line"
+fi
+
+log "== T27: PASS =="

--- a/tests/e2e/docker/t28_config_validation_problem_json.sh
+++ b/tests/e2e/docker/t28_config_validation_problem_json.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# T28: assert `POST /configs` returns RFC 7807 problem+json with
+# violations on invalid input. No CLI command exists for `config create`
+# yet, so this test hits the API directly via curl.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T28: POST /configs returns problem+json on validation failure =="
+
+start_ring
+ring_login
+
+TOKEN=$(jq -r '.default.token' "$RING_CONFIG_DIR/auth.json")
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  fail "could not extract auth token from $RING_CONFIG_DIR/auth.json"
+fi
+
+RESPONSE_BODY=$(mktemp -t ring-e2e-t28-body-XXXXXX)
+trap 'rm -f "$RESPONSE_BODY"' EXIT
+
+# Invalid payload: empty namespace + empty data.
+STATUS=$(curl -s -o "$RESPONSE_BODY" -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/configs" \
+  --data '{"namespace":"","name":"valid-name","data":""}')
+CONTENT_TYPE=$(curl -s -o /dev/null -D - \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/configs" \
+  --data '{"namespace":"","name":"valid-name","data":""}' \
+  | grep -i '^content-type:' | tr -d '\r')
+
+log "POST /configs status: $STATUS"
+log "POST /configs body:"
+sed 's/^/  | /' "$RESPONSE_BODY"
+log "POST /configs $CONTENT_TYPE"
+
+if [ "$STATUS" != "422" ]; then
+  fail "expected 422, got $STATUS"
+fi
+if ! echo "$CONTENT_TYPE" | grep -qi "application/problem+json"; then
+  fail "expected application/problem+json content-type"
+fi
+
+TITLE=$(jq -r '.title' "$RESPONSE_BODY")
+if [ "$TITLE" != "Validation failed" ]; then
+  fail "expected title 'Validation failed', got '$TITLE'"
+fi
+
+CODES=$(jq -r '.violations[].code' "$RESPONSE_BODY" | sort -u)
+log "violation codes: $CODES"
+if ! echo "$CODES" | grep -q "^config.namespace.length$"; then
+  fail "missing violation code config.namespace.length"
+fi
+if ! echo "$CODES" | grep -q "^config.data.length$"; then
+  fail "missing violation code config.data.length"
+fi
+
+log "== T28: PASS =="


### PR DESCRIPTION
## Summary
- Extends RFC 7807 (`application/problem+json`) to every remaining user-facing endpoint: `POST /namespaces`, `POST /secrets`, `POST /configs`, `PUT /configs/{id}`, `POST /login`.
- New shared helper `problem_response(status, title, detail)` so non-validation problems (409 Conflict, 404 Not Found, 401 Unauthorized, 500) carry the same envelope as validation problems — clients parse one shape.
- CLI commands `ring namespace create` and `ring secret create` render violations via the existing `render_response_error` helper (same path as `ring apply` and `ring login`).

## What changed
Per-resource validation rules with stable code slugs:
- **namespaces**: `namespace.name.length` (2-63), `namespace.name.format` (lowercase DNS-label).
- **secrets**: `secret.namespace.{length,format}`, `secret.name.{length,format}` (2-253, DNS-subdomain), `secret.value.length` (1 byte – 1 MiB).
- **configs**: `config.namespace.{length,format}`, `config.name.{length,format}` (1-253, DNS-subdomain), `config.data.length` (1 byte – 1 MiB), `config.labels.length` (max 1000), `config.data.invalid_json` (PUT only, when `data` is non-empty but not valid JSON).
- **login**: 401/500 now problem+json with `Unauthorized` / `Internal Server Error` titles.

Non-validation failures rewritten to problem+json:
- `409 Conflict` on duplicates (namespace, secret, config) with `detail` naming the offending resource.
- `404 Not Found` on missing namespace (POST /secrets) and missing config (PUT /configs/{id}).

## Test plan
- [x] `cargo test` — 341 passing (+11 new unit/integration tests for the modernised endpoints).
- [x] `t26_namespace_validation_problem_json.sh` — `ring namespace create -- "-"` surfaces both length + format violations.
- [x] `t27_secret_validation_problem_json.sh` — `ring secret create` renders 422 (invalid name) and 404 (missing namespace) bodies.
- [x] `t28_config_validation_problem_json.sh` — `POST /configs` returns 422 problem+json with `config.namespace.length` + `config.data.length` violations.

## Notes
- Branched off `feat/deployment-validation-rfc7807` (PR #89). Once #89 merges this PR rebases to a clean fast-forward against `main`.
- Read endpoints (`GET`, `DELETE` referenced-secret checks) still serve the legacy `{"error": "..."}` body and are not in scope here.