### PR TITLE
feat(dashboard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+      - uses: oven-sh/setup-bun@v1
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: rustup component add clippy
       - run: cargo clippy --all-targets
 
@@ -48,6 +51,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - uses: oven-sh/setup-bun@v1
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: docker pull nginx:alpine
       - run: cargo test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,16 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-release-gnu-${{ hashFiles('**/Cargo.lock') }}
 
+      # The dashboard's static build is baked into the Rust binary via
+      # rust-embed, so it must exist before `cargo build` runs. Skipping
+      # this step would silently ship a binary without any UI assets.
+      - uses: oven-sh/setup-bun@v1
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Build release binary
         run: cargo build --release --bin ring
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,6 +20,9 @@ jobs:
         override: true
     - name: Pull test images
       run: docker pull nginx:alpine
+    - uses: oven-sh/setup-bun@v1
+    - name: Build dashboard
+      run: cd dashboard && bun install --frozen-lockfile && bun run build
     - name: Build
       uses: actions-rs/cargo@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 ring.db
+ring.db-shm
+ring.db-wal
 .config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2310,7 @@ name = "ring-server"
 version = "0.8.0"
 dependencies = [
  "aes-gcm",
+ "anyhow",
  "async-trait",
  "axum",
  "axum-extra",
@@ -2319,11 +2330,13 @@ dependencies = [
  "hyperlocal",
  "local-ip-address",
  "log",
+ "mime_guess",
  "once_cell",
  "rand 0.9.4",
  "regex",
  "reqwest",
  "rust-argon2",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2372,6 +2385,40 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd",
  "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -2446,6 +2493,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3347,6 +3403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3560,16 @@ checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
  "nix",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,9 @@ thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 tokio-vsock = "0.7"
+rust-embed = "8"
+mime_guess = "2"
+anyhow = "1"
+
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.svelte-kit
+build
+bun.lock

--- a/dashboard/biome.json
+++ b/dashboard/biome.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**/*.ts",
+      "**/*.js",
+      "**/*.json",
+      "!**/.svelte-kit",
+      "!**/build",
+      "!**/node_modules"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "none"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ring-dashboard",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
+    "@sveltejs/adapter-static": "^3.0.6",
+    "@sveltejs/kit": "^2.58.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "svelte": "^5.55.5",
+    "svelte-check": "^4.4.7",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -1,0 +1,162 @@
+@import url('https://rsms.me/inter/inter.css');
+
+:root {
+  --bg-0: #0a0c10;
+  --bg-1: #0f1216;
+  --bg-2: #151a21;
+  --bg-3: #1c222b;
+  --bg-hover: #1f2631;
+  --border: #242b36;
+  --border-strong: #2f3847;
+
+  --fg-0: #e8ecf1;
+  --fg-1: #b6bdc9;
+  --fg-2: #7a8594;
+  --fg-3: #4d5663;
+
+  --accent: #6ee7b7;
+  --accent-hover: #34d399;
+  --accent-bg: rgba(110, 231, 183, 0.1);
+
+  --success: #3fb950;
+  --success-bg: rgba(63, 185, 80, 0.12);
+  --warning: #f0b429;
+  --warning-bg: rgba(240, 180, 41, 0.12);
+  --danger: #f85149;
+  --danger-bg: rgba(248, 81, 73, 0.12);
+
+  --radius-sm: 4px;
+  --radius: 6px;
+  --radius-lg: 10px;
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+
+  font-family: var(--font-sans);
+  font-feature-settings: 'cv11', 'ss01', 'ss03';
+  color-scheme: dark;
+}
+
+@supports (font-variation-settings: normal) {
+  :root {
+    font-family: 'Inter var', var(--font-sans);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-0);
+  color: var(--fg-0);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+input,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+code,
+.mono {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--accent-hover);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--bg-3);
+  border-radius: 5px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+th {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-2);
+  background: var(--bg-2);
+}
+
+tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.status {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius);
+  font-size: 0.72rem;
+  font-weight: 500;
+  background: var(--bg-3);
+  color: var(--fg-1);
+}
+
+.status-running {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.status-failed,
+.status-crashloopbackoff,
+.status-error {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+.status-pending,
+.status-booting,
+.status-created {
+  background: var(--warning-bg);
+  color: var(--warning);
+}

--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -160,3 +160,121 @@ tbody tr:hover {
   background: var(--warning-bg);
   color: var(--warning);
 }
+
+/*
+ * Shared page chrome. Every list/detail page below uses the same header,
+ * card, table, filter-bar, button and alert primitives — keep them here so
+ * a new page is a single import away.
+ */
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 1.75rem;
+}
+.page-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.page-header .subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--fg-2);
+  font-size: 0.85rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.refresh-meta {
+  color: var(--fg-3);
+  font-size: 0.75rem;
+}
+
+.btn-secondary {
+  background: var(--bg-2);
+  color: var(--fg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+.btn-secondary:hover {
+  background: var(--bg-hover);
+  color: var(--fg-0);
+}
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.85rem;
+  font-size: 0.8rem;
+  color: var(--fg-2);
+}
+.filter-bar select {
+  background: var(--bg-1);
+  color: var(--fg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  overflow: hidden;
+}
+
+.alert {
+  background: var(--danger-bg);
+  border: 1px solid var(--danger);
+  color: var(--fg-0);
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius);
+  margin-bottom: 1.25rem;
+  font-size: 0.825rem;
+}
+.alert strong {
+  color: var(--danger);
+  margin-right: 0.5rem;
+}
+
+.empty {
+  background: var(--bg-1);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 3rem 1rem;
+  text-align: center;
+}
+.empty p {
+  margin: 0.35rem 0;
+}
+.empty .muted {
+  color: var(--fg-2);
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--fg-2);
+}
+
+p code,
+.empty code {
+  background: var(--bg-2);
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+}

--- a/dashboard/src/app.d.ts
+++ b/dashboard/src/app.d.ts
@@ -1,0 +1,11 @@
+// See https://kit.svelte.dev/docs/types#app
+declare global {
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface Platform {}
+  }
+}
+
+export {};

--- a/dashboard/src/app.html
+++ b/dashboard/src/app.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ring dashboard</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -21,6 +21,101 @@ export interface CurrentUser {
   status: string;
 }
 
+export interface Namespace {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface DeploymentPort {
+  published: number;
+  target: number;
+  protocol?: string;
+}
+
+export interface DeploymentVolume {
+  type: string;
+  source?: string | null;
+  key?: string | null;
+  destination: string;
+  driver: string;
+  permission: string;
+}
+
+/** Discriminated union mirroring `enum HealthCheck` on the server. */
+export type HealthCheck =
+  | {
+      type: 'tcp';
+      port: number;
+      interval: string;
+      timeout: string;
+      threshold: number;
+      on_failure: string;
+      readiness?: boolean;
+      min_healthy_time?: string | null;
+    }
+  | {
+      type: 'http';
+      url: string;
+      interval: string;
+      timeout: string;
+      threshold: number;
+      on_failure: string;
+      readiness?: boolean;
+      min_healthy_time?: string | null;
+    }
+  | {
+      type: 'command';
+      command: string;
+      interval: string;
+      timeout: string;
+      threshold: number;
+      on_failure: string;
+      readiness?: boolean;
+      min_healthy_time?: string | null;
+    };
+
+export interface ResourceLimits {
+  cpu?: string;
+  memory?: string;
+}
+
+export interface DeploymentResources {
+  limits?: ResourceLimits;
+  requests?: ResourceLimits;
+}
+
+/** Either a literal string or a `{ secretRef: "name" }` reference. */
+export type EnvValue = string | { secretRef: string };
+
+export interface DeploymentDetail extends Deployment {
+  created_at: string;
+  updated_at: string;
+  kind: string;
+  restart_count: number;
+  command: string[];
+  ports: DeploymentPort[];
+  labels: Record<string, string>;
+  instances: string[];
+  environment: Record<string, EnvValue>;
+  volumes: DeploymentVolume[];
+  health_checks: HealthCheck[];
+  resources?: DeploymentResources | null;
+  image_digest?: string | null;
+  parent_id?: string | null;
+  network?: unknown;
+}
+
+export interface DeploymentEvent {
+  id?: string;
+  deployment_id?: string;
+  level?: string;
+  message?: string;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   const token = getToken();
   const headers = new Headers(init.headers);
@@ -71,4 +166,16 @@ export function listDeployments(): Promise<Deployment[]> {
 
 export function getCurrentUser(): Promise<CurrentUser> {
   return request<CurrentUser>('/users/me');
+}
+
+export function listNamespaces(): Promise<Namespace[]> {
+  return request<Namespace[]>('/namespaces');
+}
+
+export function getDeployment(id: string): Promise<DeploymentDetail> {
+  return request<DeploymentDetail>(`/deployments/${encodeURIComponent(id)}`);
+}
+
+export function listDeploymentEvents(id: string): Promise<DeploymentEvent[]> {
+  return request<DeploymentEvent[]>(`/deployments/${encodeURIComponent(id)}/events`);
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,74 @@
+// All API calls go through `/api/*`. In dev that's proxied by Vite to the
+// local ring-server; in production (whether served by `ring dashboard` or
+// the embedded mode), the Rust side proxies the same prefix to the real
+// API. The dashboard JS therefore never needs to know the API URL.
+
+import { clearToken, getToken } from './auth';
+
+export interface Deployment {
+  id: string;
+  name: string;
+  namespace: string;
+  runtime: string;
+  status: string;
+  replicas: number;
+  image: string;
+}
+
+export interface CurrentUser {
+  id: string;
+  username: string;
+  status: string;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = getToken();
+  const headers = new Headers(init.headers);
+  headers.set('Accept', 'application/json');
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const res = await fetch(`/api${path}`, { ...init, headers });
+
+  if (res.status === 401) {
+    clearToken();
+    if (typeof window !== 'undefined' && !window.location.pathname.endsWith('/')) {
+      window.location.assign('./');
+    }
+    throw new Error('401 Unauthorized');
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}${text ? `: ${text}` : ''}`);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function login(username: string, password: string): Promise<string> {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { token: string };
+  return data.token;
+}
+
+export function listDeployments(): Promise<Deployment[]> {
+  return request<Deployment[]>('/deployments');
+}
+
+export function getCurrentUser(): Promise<CurrentUser> {
+  return request<CurrentUser>('/users/me');
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -107,6 +107,30 @@ export interface DeploymentDetail extends Deployment {
   network?: unknown;
 }
 
+export interface Secret {
+  id: string;
+  created_at: string;
+  updated_at: string | null;
+  namespace: string;
+  name: string;
+}
+
+export interface Config {
+  id: string;
+  /** Server returns a SQL-style timestamp like `2026-05-13 19:26:27.93 UTC`,
+   *  not RFC3339. Parse with `Date(s)` may not work on all browsers; pages
+   *  fall back to the raw string when parsing fails. */
+  created_at: string;
+  /** Empty string when never updated; some endpoints return `null` instead. */
+  updated_at: string | null;
+  namespace: string;
+  name: string;
+  data: string;
+  /** Free-form string set by the client (often `key=value,key=value`). The
+   *  API stores it as-is and does not parse it. Empty string means no labels. */
+  labels: string;
+}
+
 export interface DeploymentEvent {
   id?: string;
   deployment_id?: string;
@@ -183,4 +207,12 @@ export function getDeployment(id: string): Promise<DeploymentDetail> {
 
 export function listDeploymentEvents(id: string): Promise<DeploymentEvent[]> {
   return request<DeploymentEvent[]>(`/deployments/${encodeURIComponent(id)}/events`);
+}
+
+export function listSecrets(): Promise<Secret[]> {
+  return request<Secret[]>('/secrets');
+}
+
+export function listConfigs(): Promise<Config[]> {
+  return request<Config[]>('/configs');
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -112,7 +112,12 @@ export interface DeploymentEvent {
   deployment_id?: string;
   level?: string;
   message?: string;
+  /** Server returns `timestamp` (RFC3339). `created_at` kept as a fallback
+   *  for older API versions. */
+  timestamp?: string;
   created_at?: string;
+  component?: string;
+  reason?: string;
   [key: string]: unknown;
 }
 

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -1,0 +1,26 @@
+// Auth is the same Bearer JWT the CLI uses. We store it in localStorage so
+// the SPA stays decoupled from any server-rendered session — same approach
+// as the Sozune dashboard.
+
+const TOKEN_KEY = 'ring.token';
+
+export function getToken(): string | null {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  localStorage.removeItem(TOKEN_KEY);
+}

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -1,0 +1,51 @@
+// Pure formatting helpers shared by every list/detail page.
+
+/** Relative time string for a refresh-meta line. `null` → empty so callers
+ *  can bind it directly without guarding. */
+export function timeAgo(d: Date | null): string {
+  if (!d) {
+    return '';
+  }
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (s < 5) {
+    return 'just now';
+  }
+  if (s < 60) {
+    return `${s}s ago`;
+  }
+  return `${Math.floor(s / 60)}m ago`;
+}
+
+/** Render a server-side timestamp to the user's locale. The Ring API returns
+ *  several formats depending on the endpoint:
+ *   - RFC3339 (`2026-04-15T10:30:00Z`)
+ *   - SQL-style with nanoseconds and a `UTC` suffix
+ *     (`2026-05-13 19:26:27.931985780 UTC`) — produced by `chrono::Utc::now().to_string()`
+ *  Browsers' `Date` parser accepts the first but rejects the second, so we
+ *  normalise the second to ISO before parsing. Anything we can't parse is
+ *  returned verbatim. */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) {
+    return '—';
+  }
+  const normalised = normaliseTimestamp(iso);
+  const d = new Date(normalised);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  return d.toLocaleString();
+}
+
+function normaliseTimestamp(input: string): string {
+  // SQL-style: `YYYY-MM-DD HH:MM:SS[.nnn...] UTC` → `YYYY-MM-DDTHH:MM:SS[.nnn]Z`.
+  // We keep at most 3 fractional digits because `Date` ignores anything beyond
+  // milliseconds and some browsers complain about longer precision.
+  const m = input.match(
+    /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(\.\d+)? UTC$/
+  );
+  if (m) {
+    const frac = m[3] ? m[3].slice(0, 4) : '';
+    return `${m[1]}T${m[2]}${frac}Z`;
+  }
+  return input;
+}

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -11,7 +11,9 @@
 
   const nav = [
     { href: '/deployments', label: 'Deployments', icon: 'grid' },
-    { href: '/namespaces', label: 'Namespaces', icon: 'folder' }
+    { href: '/namespaces', label: 'Namespaces', icon: 'folder' },
+    { href: '/secrets', label: 'Secrets', icon: 'key' },
+    { href: '/configs', label: 'Configs', icon: 'file' }
   ];
 
   function isActive(href: string): boolean {
@@ -20,7 +22,7 @@
     return current === target || current.startsWith(`${target}/`);
   }
 
-  let onLoginPage = $derived($page.url.pathname === '/' || $page.url.pathname === '');
+  let onLoginPage = $derived($page.url.pathname === '/');
 
   onMount(async () => {
     if (onLoginPage) {
@@ -80,6 +82,30 @@
                   stroke-linejoin="round"
                 >
                   <path d="M1.5 4.5a1 1 0 0 1 1-1H6l1.5 1.5h6a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1h-11a1 1 0 0 1-1-1V4.5z" />
+                </svg>
+              {:else if item.icon === 'key'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <circle cx="6" cy="10" r="3" />
+                  <path d="M8.1 8.1L14 2.2M11 5l1.5 1.5" />
+                </svg>
+              {:else if item.icon === 'file'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M3 1.5h6L13 5.5V14a.5.5 0 0 1-.5.5h-9A.5.5 0 0 1 3 14V1.5z" />
+                  <path d="M9 1.5V5.5h4" />
                 </svg>
               {/if}
             </span>

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+  import '../app.css';
+  import { page } from '$app/stores';
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getCurrentUser, type CurrentUser } from '$lib/api';
+  import { clearToken, getToken } from '$lib/auth';
+
+  let { children } = $props();
+  let currentUser = $state<CurrentUser | null>(null);
+
+  const nav = [
+    { href: './deployments', label: 'Deployments', icon: 'grid' }
+  ];
+
+  function isActive(href: string): boolean {
+    const current = $page.url.pathname.replace(/\/$/, '');
+    const target = href.replace(/^\.\//, '/').replace(/\/$/, '');
+    if (target === '') {
+      return current === '';
+    }
+    return current === target || current.startsWith(`${target}/`);
+  }
+
+  let onLoginPage = $derived($page.url.pathname === '/' || $page.url.pathname === '');
+
+  onMount(async () => {
+    if (onLoginPage) {
+      return;
+    }
+    if (!getToken()) {
+      goto('./');
+      return;
+    }
+    try {
+      currentUser = await getCurrentUser();
+    } catch {
+      // Auth interceptor in api.ts handles 401 → redirect. For other
+      // errors we just keep the user identity blank — the rest of the
+      // dashboard still loads.
+      currentUser = null;
+    }
+  });
+
+  function logout() {
+    clearToken();
+    goto('./');
+  }
+</script>
+
+{#if onLoginPage}
+  {@render children()}
+{:else}
+  <div class="shell">
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="logo">r</div>
+        <div class="brand-text">
+          <div class="brand-name">ring</div>
+          <div class="brand-sub">dashboard</div>
+        </div>
+      </div>
+
+      <nav>
+        {#each nav as item}
+          <a href={item.href} class="nav-item" class:active={isActive(item.href)}>
+            <span class="nav-icon">
+              {#if item.icon === 'grid'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <rect x="2" y="2" width="5" height="5" rx="1" />
+                  <rect x="9" y="2" width="5" height="5" rx="1" />
+                  <rect x="2" y="9" width="5" height="5" rx="1" />
+                  <rect x="9" y="9" width="5" height="5" rx="1" />
+                </svg>
+              {/if}
+            </span>
+            <span>{item.label}</span>
+          </a>
+        {/each}
+      </nav>
+
+      <div class="sidebar-footer">
+        {#if currentUser}
+          <div class="user">
+            <div class="user-name">{currentUser.username}</div>
+            <div class="user-status">{currentUser.status}</div>
+          </div>
+        {/if}
+        <button class="logout" onclick={logout}>Sign out</button>
+        <a
+          class="doc-link"
+          href="https://ring.kemeter.io/documentation"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M2 3h4a2 2 0 0 1 2 2v9a2 2 0 0 0-2-2H2zM14 3h-4a2 2 0 0 0-2 2v9a2 2 0 0 1 2-2h4z" />
+          </svg>
+          <span>Documentation</span>
+        </a>
+      </div>
+    </aside>
+
+    <main class="main">
+      {@render children()}
+    </main>
+  </div>
+{/if}
+
+<style>
+  .shell {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 100vh;
+  }
+
+  .sidebar {
+    background: var(--bg-1);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 0.75rem;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.25rem 0.5rem 1.25rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .logo {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--accent), #0f766e);
+    color: #042f25;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 1.05rem;
+    box-shadow: 0 2px 8px rgba(110, 231, 183, 0.25);
+  }
+
+  .brand-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: -0.01em;
+  }
+
+  .brand-sub {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 0.5rem;
+  }
+
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: var(--radius);
+    color: var(--fg-1);
+    font-size: 0.825rem;
+    font-weight: 500;
+    transition:
+      background 0.1s,
+      color 0.1s;
+  }
+  .nav-item:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .nav-item.active {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+
+  .nav-icon {
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+  }
+  .nav-icon :global(svg) {
+    width: 16px;
+    height: 16px;
+  }
+
+  .sidebar-footer {
+    margin-top: auto;
+    padding: 0.75rem 0.625rem 0.25rem;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .user {
+    display: flex;
+    flex-direction: column;
+  }
+  .user-name {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--fg-0);
+  }
+  .user-status {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .logout {
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-1);
+    font-size: 0.75rem;
+    padding: 0.4rem 0.625rem;
+    text-align: left;
+  }
+  .logout:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+
+  .doc-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.625rem;
+    border-radius: var(--radius);
+    color: var(--fg-2);
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+  .doc-link:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .doc-link :global(svg) {
+    width: 14px;
+    height: 14px;
+  }
+
+  .main {
+    padding: 2rem 2.5rem;
+    max-width: 1400px;
+    width: 100%;
+  }
+</style>

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -10,15 +10,13 @@
   let currentUser = $state<CurrentUser | null>(null);
 
   const nav = [
-    { href: './deployments', label: 'Deployments', icon: 'grid' }
+    { href: '/deployments', label: 'Deployments', icon: 'grid' },
+    { href: '/namespaces', label: 'Namespaces', icon: 'folder' }
   ];
 
   function isActive(href: string): boolean {
     const current = $page.url.pathname.replace(/\/$/, '');
-    const target = href.replace(/^\.\//, '/').replace(/\/$/, '');
-    if (target === '') {
-      return current === '';
-    }
+    const target = href.replace(/\/$/, '');
     return current === target || current.startsWith(`${target}/`);
   }
 
@@ -29,7 +27,7 @@
       return;
     }
     if (!getToken()) {
-      goto('./');
+      goto('/');
       return;
     }
     try {
@@ -44,7 +42,7 @@
 
   function logout() {
     clearToken();
-    goto('./');
+    goto('/');
   }
 </script>
 
@@ -71,6 +69,17 @@
                   <rect x="9" y="2" width="5" height="5" rx="1" />
                   <rect x="2" y="9" width="5" height="5" rx="1" />
                   <rect x="9" y="9" width="5" height="5" rx="1" />
+                </svg>
+              {:else if item.icon === 'folder'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M1.5 4.5a1 1 0 0 1 1-1H6l1.5 1.5h6a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1h-11a1 1 0 0 1-1-1V4.5z" />
                 </svg>
               {/if}
             </span>

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { login } from '$lib/api';
+  import { getToken, setToken } from '$lib/auth';
+
+  let username = $state('admin');
+  let password = $state('');
+  let error = $state('');
+  let pending = $state(false);
+
+  onMount(() => {
+    if (getToken()) {
+      goto('./deployments');
+    }
+  });
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    error = '';
+    pending = true;
+    try {
+      const token = await login(username, password);
+      setToken(token);
+      goto('./deployments');
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<div class="login-shell">
+  <form class="card" onsubmit={submit}>
+    <div class="brand">
+      <div class="logo">r</div>
+      <div class="brand-text">
+        <div class="brand-name">ring</div>
+        <div class="brand-sub">dashboard</div>
+      </div>
+    </div>
+
+    <h1>Sign in</h1>
+
+    <div class="field">
+      <label for="name">Username</label>
+      <input id="name" type="text" autocomplete="username" bind:value={username} required />
+    </div>
+
+    <div class="field">
+      <label for="password">Password</label>
+      <input
+        id="password"
+        type="password"
+        autocomplete="current-password"
+        bind:value={password}
+        required
+      />
+    </div>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <button class="btn-primary" type="submit" disabled={pending}>
+      {pending ? 'Signing in…' : 'Sign in'}
+    </button>
+  </form>
+</div>
+
+<style>
+  .login-shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--bg-0);
+    padding: 1rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 2rem 2.25rem;
+    width: 100%;
+    max-width: 380px;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .logo {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--accent), #0f766e);
+    color: white;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+    box-shadow: 0 2px 8px rgba(110, 231, 183, 0.25);
+  }
+
+  .brand-name {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+  }
+
+  .brand-sub {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  h1 {
+    margin: 0 0 1.25rem;
+    font-size: 1.15rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .field {
+    margin-bottom: 1rem;
+  }
+
+  label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--fg-1);
+    margin-bottom: 0.4rem;
+    font-weight: 500;
+  }
+
+  input {
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-0);
+    outline: none;
+    transition: border-color 0.1s;
+  }
+
+  input:focus {
+    border-color: var(--accent);
+  }
+
+  input::placeholder {
+    color: var(--fg-3);
+  }
+
+  .error {
+    margin: 0 0 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--danger-bg);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    border-radius: var(--radius);
+    color: var(--danger);
+    font-size: 0.78rem;
+  }
+
+  .btn-primary {
+    width: 100%;
+    border: none;
+    border-radius: var(--radius);
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    background: var(--accent);
+    color: #042f25;
+    margin-top: 0.5rem;
+    transition: background 0.1s;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+</style>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 
   onMount(() => {
     if (getToken()) {
-      goto('./deployments');
+      goto('/deployments');
     }
   });
 
@@ -22,7 +22,7 @@
     try {
       const token = await login(username, password);
       setToken(token);
-      goto('./deployments');
+      goto('/deployments');
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {

--- a/dashboard/src/routes/configs/+page.svelte
+++ b/dashboard/src/routes/configs/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { listConfigs, type Config } from '$lib/api';
+  import { getToken } from '$lib/auth';
+  import { formatDate, timeAgo } from '$lib/utils';
+
+  let configs = $state<Config[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+  let nsFilter = $state<string>('');
+  let expanded = $state<Set<string>>(new Set());
+
+  async function refresh() {
+    try {
+      configs = await listConfigs();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  function syncUrl(): void {
+    const params = new URLSearchParams();
+    if (nsFilter) {
+      params.set('namespace', nsFilter);
+    }
+    const qs = params.toString();
+    history.replaceState(null, '', `${$page.url.pathname}${qs ? `?${qs}` : ''}`);
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    nsFilter = $page.url.searchParams.get('namespace') ?? '';
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function toggle(id: string) {
+    // Clone before mutating: Svelte 5 reactivity tracks the reference, not the
+    // contents of the Set, so an in-place add()/delete() wouldn't re-render.
+    const next = new Set(expanded);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    expanded = next;
+  }
+
+  function byteSize(s: string): string {
+    const bytes = new TextEncoder().encode(s).length;
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KiB`;
+    }
+    return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+  }
+
+  let namespaces = $derived(
+    Array.from(new Set(configs.map((c) => c.namespace))).sort((a, b) => a.localeCompare(b))
+  );
+  let filtered = $derived(nsFilter ? configs.filter((c) => c.namespace === nsFilter) : configs);
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Configs</h1>
+    <p class="subtitle">Free-form configuration blobs mounted into deployments</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && configs.length > 0}
+  {#if namespaces.length > 1}
+    <div class="filter-bar">
+      <label for="ns-filter">Namespace</label>
+      <select id="ns-filter" bind:value={nsFilter} onchange={syncUrl}>
+        <option value="">All ({configs.length})</option>
+        {#each namespaces as ns}
+          <option value={ns}>{ns} ({configs.filter((c) => c.namespace === ns).length})</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Name</th>
+          <th>Namespace</th>
+          <th class="num">Size</th>
+          <th>Labels</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each filtered as c (c.id)}
+          {@const open = expanded.has(c.id)}
+          <tr>
+            <td class="caret-cell">
+              <button
+                type="button"
+                class="caret"
+                aria-expanded={open}
+                aria-controls={`config-${c.id}-data`}
+                aria-label={open ? 'Collapse config data' : 'Expand config data'}
+                onclick={() => toggle(c.id)}
+              >
+                {open ? '▾' : '▸'}
+              </button>
+            </td>
+            <td class="mono">{c.name}</td>
+            <td>
+              <a class="ns-link" href="/configs?namespace={c.namespace}">{c.namespace}</a>
+            </td>
+            <td class="num mono">{byteSize(c.data)}</td>
+            <td class="mono small">{c.labels || '—'}</td>
+            <td class="muted">{formatDate(c.created_at)}</td>
+          </tr>
+          {#if open}
+            <tr class="data-row" id={`config-${c.id}-data`}>
+              <td></td>
+              <td colspan="5">
+                <pre class="data">{c.data}</pre>
+              </td>
+            </tr>
+          {/if}
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && configs.length === 0 && !errorMsg}
+  <div class="empty">
+    <p>No configs yet.</p>
+    <p class="muted">
+      Configs are created over the API (<code>POST /configs</code>) and mounted into deployments via
+      the <code>config:</code> field in your manifest.
+    </p>
+  </div>
+{/if}
+
+<style>
+  td.num,
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  td.small {
+    font-size: 0.78rem;
+  }
+  .ns-link {
+    color: var(--fg-0);
+    font-weight: 500;
+  }
+  .ns-link:hover {
+    color: var(--accent);
+  }
+
+  .caret-cell {
+    width: 2rem;
+    padding-right: 0;
+  }
+  .caret {
+    background: transparent;
+    border: none;
+    color: var(--fg-3);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.35rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .caret:hover {
+    background: var(--bg-hover);
+    color: var(--fg-1);
+  }
+  .caret:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .data-row td {
+    background: var(--bg-0);
+    padding: 0;
+  }
+  .data {
+    margin: 0;
+    padding: 0.85rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--fg-1);
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 24rem;
+    overflow-y: auto;
+  }
+</style>

--- a/dashboard/src/routes/deployments/+page.svelte
+++ b/dashboard/src/routes/deployments/+page.svelte
@@ -133,7 +133,13 @@
     if (k === 'running') {
       return 'success';
     }
-    if (k === 'failed' || k === 'crashloopbackoff' || k === 'error') {
+    if (
+      k === 'failed' ||
+      k === 'crashloopbackoff' ||
+      k === 'error' ||
+      k === 'createcontainererror' ||
+      k === 'imagepullbackoff'
+    ) {
       return 'danger';
     }
     if (k === 'pending' || k === 'booting' || k === 'created') {

--- a/dashboard/src/routes/deployments/+page.svelte
+++ b/dashboard/src/routes/deployments/+page.svelte
@@ -1,0 +1,362 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { listDeployments, type Deployment } from '$lib/api';
+  import { getToken } from '$lib/auth';
+
+  let items = $state<Deployment[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function refresh() {
+    try {
+      items = await listDeployments();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('../');
+      return;
+    }
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) {
+      return '';
+    }
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) {
+      return 'just now';
+    }
+    if (s < 60) {
+      return `${s}s ago`;
+    }
+    return `${Math.floor(s / 60)}m ago`;
+  }
+
+  function statusKind(s: string): 'success' | 'warn' | 'danger' | 'neutral' {
+    const k = s.toLowerCase();
+    if (k === 'running') {
+      return 'success';
+    }
+    if (k === 'failed' || k === 'crashloopbackoff' || k === 'error') {
+      return 'danger';
+    }
+    if (k === 'pending' || k === 'booting' || k === 'created') {
+      return 'warn';
+    }
+    return 'neutral';
+  }
+
+  let runningCount = $derived(items.filter((d) => d.status.toLowerCase() === 'running').length);
+  let totalReplicas = $derived(items.reduce((acc, d) => acc + (d.replicas ?? 0), 0));
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Deployments</h1>
+    <p class="subtitle">All workloads scheduled by this Ring instance</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Running</div>
+    <div class="stat-value">{runningCount}<span class="unit">/ {items.length}</span></div>
+    <div class="stat-sub">deployments currently healthy</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Replicas</div>
+    <div class="stat-value">{totalReplicas}</div>
+    <div class="stat-sub">across every deployment</div>
+  </div>
+</section>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && items.length > 0}
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>Namespace</th>
+          <th>Name</th>
+          <th>Runtime</th>
+          <th>Status</th>
+          <th class="num">Replicas</th>
+          <th>Image</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each items as d (d.id)}
+          {@const kind = statusKind(d.status)}
+          <tr>
+            <td>{d.namespace}</td>
+            <td><span class="deployment-name">{d.name}</span></td>
+            <td>{d.runtime}</td>
+            <td>
+              <span
+                class="status-pill"
+                class:success={kind === 'success'}
+                class:warn={kind === 'warn'}
+                class:danger={kind === 'danger'}
+              >
+                <span
+                  class="dot"
+                  class:success={kind === 'success'}
+                  class:warn={kind === 'warn'}
+                  class:danger={kind === 'danger'}
+                ></span>
+                {d.status}
+              </span>
+            </td>
+            <td class="num mono">{d.replicas}</td>
+            <td class="mono">{d.image}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && items.length === 0 && !errorMsg}
+  <div class="empty">
+    <p>No deployments yet.</p>
+    <p class="muted">Use <code>ring apply -f deployment.yaml</code> to create one.</p>
+  </div>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .unit {
+    font-size: 0.85rem;
+    color: var(--fg-2);
+    font-weight: 500;
+    margin-left: 4px;
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    overflow: hidden;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.7rem 1rem;
+    font-size: 0.85rem;
+    border-bottom: 1px solid var(--border);
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  th {
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  td.num,
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.mono {
+    font-family: var(--font-mono);
+    color: var(--fg-1);
+  }
+  .deployment-name {
+    font-weight: 500;
+    color: var(--fg-0);
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.18rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--fg-2);
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+  }
+  .status-pill.success {
+    color: var(--success);
+    background: var(--success-bg);
+    border-color: transparent;
+  }
+  .status-pill.warn {
+    color: var(--warning);
+    background: var(--warning-bg);
+    border-color: transparent;
+  }
+  .status-pill.danger {
+    color: var(--danger);
+    background: var(--danger-bg);
+    border-color: transparent;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--fg-3);
+  }
+  .dot.success {
+    background: var(--success);
+  }
+  .dot.warn {
+    background: var(--warning);
+  }
+  .dot.danger {
+    background: var(--danger);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+  }
+
+  .empty {
+    background: var(--bg-1);
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-lg);
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+  .empty p {
+    margin: 0.25rem 0;
+  }
+  .empty .muted {
+    color: var(--fg-2);
+    font-size: 0.85rem;
+  }
+  code {
+    background: var(--bg-2);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+  }
+</style>

--- a/dashboard/src/routes/deployments/+page.svelte
+++ b/dashboard/src/routes/deployments/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { listDeployments, type Deployment } from '$lib/api';
   import { getToken } from '$lib/auth';
 
@@ -9,6 +10,81 @@
   let errorMsg = $state<string | null>(null);
   let lastFetch = $state<Date | null>(null);
   let poll: ReturnType<typeof setInterval> | null = null;
+
+  // Filters are mirrored to the URL so a filtered view is shareable and
+  // a back-button restores the state. Empty string means "no filter".
+  let namespaceFilter = $state('');
+  let runtimeFilter = $state('');
+  let statusFilter = $state('');
+  let searchQuery = $state('');
+
+  // One-shot read of the URL on mount; subsequent changes are pushed back
+  // by `syncUrl()` below.
+  function loadFiltersFromUrl(url: URL): void {
+    namespaceFilter = url.searchParams.get('namespace') ?? '';
+    runtimeFilter = url.searchParams.get('runtime') ?? '';
+    statusFilter = url.searchParams.get('status') ?? '';
+    searchQuery = url.searchParams.get('q') ?? '';
+  }
+
+  function syncUrl(): void {
+    const params = new URLSearchParams();
+    if (namespaceFilter) {
+      params.set('namespace', namespaceFilter);
+    }
+    if (runtimeFilter) {
+      params.set('runtime', runtimeFilter);
+    }
+    if (statusFilter) {
+      params.set('status', statusFilter);
+    }
+    if (searchQuery) {
+      params.set('q', searchQuery);
+    }
+    const qs = params.toString();
+    const next = qs ? `?${qs}` : '';
+    // Replace the URL silently — no navigation, no re-mount.
+    history.replaceState(null, '', `${$page.url.pathname}${next}`);
+  }
+
+  function clearFilters() {
+    namespaceFilter = '';
+    runtimeFilter = '';
+    statusFilter = '';
+    searchQuery = '';
+    syncUrl();
+  }
+
+  // Distinct values, derived from the current dataset, used to populate
+  // the dropdowns. Sorted alphabetically so the order is stable.
+  let allNamespaces = $derived(
+    Array.from(new Set(items.map((d) => d.namespace))).sort()
+  );
+  let allRuntimes = $derived(Array.from(new Set(items.map((d) => d.runtime))).sort());
+  let allStatuses = $derived(Array.from(new Set(items.map((d) => d.status))).sort());
+
+  let visible = $derived(
+    items.filter((d) => {
+      if (namespaceFilter && d.namespace !== namespaceFilter) {
+        return false;
+      }
+      if (runtimeFilter && d.runtime !== runtimeFilter) {
+        return false;
+      }
+      if (statusFilter && d.status !== statusFilter) {
+        return false;
+      }
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        return d.name.toLowerCase().includes(q) || d.image.toLowerCase().includes(q);
+      }
+      return true;
+    })
+  );
+
+  let hasActiveFilter = $derived(
+    Boolean(namespaceFilter || runtimeFilter || statusFilter || searchQuery)
+  );
 
   async function refresh() {
     try {
@@ -24,9 +100,10 @@
 
   onMount(() => {
     if (!getToken()) {
-      goto('../');
+      goto('/');
       return;
     }
+    loadFiltersFromUrl($page.url);
     void refresh();
     poll = setInterval(() => void refresh(), 5000);
   });
@@ -65,14 +142,27 @@
     return 'neutral';
   }
 
-  let runningCount = $derived(items.filter((d) => d.status.toLowerCase() === 'running').length);
-  let totalReplicas = $derived(items.reduce((acc, d) => acc + (d.replicas ?? 0), 0));
+  let runningCount = $derived(visible.filter((d) => d.status.toLowerCase() === 'running').length);
+  let totalReplicas = $derived(visible.reduce((acc, d) => acc + (d.replicas ?? 0), 0));
 </script>
 
 <header class="page-header">
   <div>
     <h1>Deployments</h1>
-    <p class="subtitle">All workloads scheduled by this Ring instance</p>
+    <p class="subtitle">
+      {#if hasActiveFilter}
+        Showing {visible.length} of {items.length}
+        — <a
+          href="/deployments"
+          onclick={(e) => {
+            e.preventDefault();
+            clearFilters();
+          }}>clear filters</a
+        >
+      {:else}
+        All workloads scheduled by this Ring instance
+      {/if}
+    </p>
   </div>
   <div class="header-actions">
     {#if lastFetch}
@@ -87,7 +177,7 @@
 <section class="stats">
   <div class="stat-card">
     <div class="stat-label">Running</div>
-    <div class="stat-value">{runningCount}<span class="unit">/ {items.length}</span></div>
+    <div class="stat-value">{runningCount}<span class="unit">/ {visible.length}</span></div>
     <div class="stat-sub">deployments currently healthy</div>
   </div>
   <div class="stat-card">
@@ -97,13 +187,51 @@
   </div>
 </section>
 
+<section class="filters">
+  <div class="filter search">
+    <input
+      type="search"
+      placeholder="Search name or image…"
+      bind:value={searchQuery}
+      oninput={syncUrl}
+    />
+  </div>
+  <div class="filter">
+    <select bind:value={namespaceFilter} onchange={syncUrl}>
+      <option value="">All namespaces</option>
+      {#each allNamespaces as ns}
+        <option value={ns}>{ns}</option>
+      {/each}
+    </select>
+  </div>
+  <div class="filter">
+    <select bind:value={runtimeFilter} onchange={syncUrl}>
+      <option value="">All runtimes</option>
+      {#each allRuntimes as rt}
+        <option value={rt}>{rt}</option>
+      {/each}
+    </select>
+  </div>
+  <div class="filter">
+    <select bind:value={statusFilter} onchange={syncUrl}>
+      <option value="">All statuses</option>
+      {#each allStatuses as st}
+        <option value={st}>{st}</option>
+      {/each}
+    </select>
+  </div>
+  {#if hasActiveFilter}
+    <button class="btn-clear" onclick={clearFilters}>Clear</button>
+  {/if}
+</section>
+
 {#if errorMsg}
   <div class="alert">
     <strong>error</strong> {errorMsg}
   </div>
 {/if}
 
-{#if !loading && items.length > 0}
+{#if !loading && visible.length > 0}
   <section class="card">
     <table>
       <thead>
@@ -117,11 +245,11 @@
         </tr>
       </thead>
       <tbody>
-        {#each items as d (d.id)}
+        {#each visible as d (d.id)}
           {@const kind = statusKind(d.status)}
           <tr>
             <td>{d.namespace}</td>
-            <td><span class="deployment-name">{d.name}</span></td>
+            <td><a class="deployment-name" href="/deployments/{d.id}">{d.name}</a></td>
             <td>{d.runtime}</td>
             <td>
               <span
@@ -148,10 +276,24 @@
   </section>
 {/if}
 
-{#if !loading && items.length === 0 && !errorMsg}
+{#if !loading && visible.length === 0 && !errorMsg}
   <div class="empty">
-    <p>No deployments yet.</p>
-    <p class="muted">Use <code>ring apply -f deployment.yaml</code> to create one.</p>
+    {#if hasActiveFilter}
+      <p>No deployments match the current filters.</p>
+      <p class="muted">
+        <a
+          href="/deployments"
+          onclick={(e) => {
+            e.preventDefault();
+            clearFilters();
+          }}>Clear filters</a
+        >
+        or adjust them.
+      </p>
+    {:else}
+      <p>No deployments yet.</p>
+      <p class="muted">Use <code>ring apply -f deployment.yaml</code> to create one.</p>
+    {/if}
   </div>
 {/if}
 
@@ -198,6 +340,66 @@
   .btn-secondary:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    align-items: center;
+  }
+  .filter {
+    min-width: 160px;
+  }
+  .filter.search {
+    flex: 1 1 220px;
+    min-width: 220px;
+  }
+  .filter input,
+  .filter select {
+    width: 100%;
+    background: var(--bg-1);
+    color: var(--fg-0);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.45rem 0.7rem;
+    font-size: 0.82rem;
+    outline: none;
+    transition: border-color 0.1s;
+  }
+  .filter input:focus,
+  .filter select:focus {
+    border-color: var(--accent);
+  }
+  .filter input::placeholder {
+    color: var(--fg-3);
+  }
+  .filter select {
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, var(--fg-2) 50%),
+      linear-gradient(135deg, var(--fg-2) 50%, transparent 50%);
+    background-position:
+      calc(100% - 14px) center,
+      calc(100% - 9px) center;
+    background-size:
+      5px 5px,
+      5px 5px;
+    background-repeat: no-repeat;
+    padding-right: 1.75rem;
+  }
+  .btn-clear {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.45rem 0.8rem;
+    font-size: 0.78rem;
+  }
+  .btn-clear:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
   }
 
   .stats {
@@ -280,6 +482,9 @@
   .deployment-name {
     font-weight: 500;
     color: var(--fg-0);
+  }
+  .deployment-name:hover {
+    color: var(--accent);
   }
 
   .status-pill {

--- a/dashboard/src/routes/deployments/+page.svelte
+++ b/dashboard/src/routes/deployments/+page.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import { listDeployments, type Deployment } from '$lib/api';
   import { getToken } from '$lib/auth';
+  import { timeAgo } from '$lib/utils';
 
   let items = $state<Deployment[]>([]);
   let loading = $state(true);
@@ -113,20 +114,6 @@
       clearInterval(poll);
     }
   });
-
-  function timeAgo(d: Date | null): string {
-    if (!d) {
-      return '';
-    }
-    const s = Math.floor((Date.now() - d.getTime()) / 1000);
-    if (s < 5) {
-      return 'just now';
-    }
-    if (s < 60) {
-      return `${s}s ago`;
-    }
-    return `${Math.floor(s / 60)}m ago`;
-  }
 
   function statusKind(s: string): 'success' | 'warn' | 'danger' | 'neutral' {
     const k = s.toLowerCase();
@@ -304,50 +291,6 @@
 {/if}
 
 <style>
-  .page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    margin-bottom: 1.75rem;
-  }
-  h1 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-  }
-  .subtitle {
-    margin: 0.25rem 0 0;
-    color: var(--fg-2);
-    font-size: 0.825rem;
-  }
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .refresh-meta {
-    color: var(--fg-3);
-    font-size: 0.75rem;
-  }
-  .btn-secondary {
-    background: var(--bg-2);
-    color: var(--fg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8rem;
-    font-weight: 500;
-  }
-  .btn-secondary:hover {
-    background: var(--bg-hover);
-    color: var(--fg-0);
-  }
-  .btn-secondary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .filters {
     display: flex;
     flex-wrap: wrap;
@@ -446,36 +389,6 @@
     margin-top: 0.25rem;
   }
 
-  .card {
-    background: var(--bg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: 0;
-    overflow: hidden;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  th,
-  td {
-    text-align: left;
-    padding: 0.7rem 1rem;
-    font-size: 0.85rem;
-    border-bottom: 1px solid var(--border);
-  }
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-  th {
-    font-weight: 500;
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--fg-2);
-    background: var(--bg-0);
-  }
   td.num,
   th.num {
     text-align: right;
@@ -536,38 +449,4 @@
     background: var(--danger);
   }
 
-  .alert {
-    background: var(--danger-bg);
-    border: 1px solid var(--danger);
-    color: var(--fg-0);
-    padding: 0.85rem 1rem;
-    border-radius: var(--radius);
-    margin-bottom: 1.25rem;
-    font-size: 0.825rem;
-  }
-  .alert strong {
-    color: var(--danger);
-    margin-right: 0.5rem;
-  }
-
-  .empty {
-    background: var(--bg-1);
-    border: 1px dashed var(--border);
-    border-radius: var(--radius-lg);
-    padding: 3rem 1rem;
-    text-align: center;
-  }
-  .empty p {
-    margin: 0.25rem 0;
-  }
-  .empty .muted {
-    color: var(--fg-2);
-    font-size: 0.85rem;
-  }
-  code {
-    background: var(--bg-2);
-    padding: 0.1rem 0.4rem;
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-  }
 </style>

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -1,0 +1,698 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import {
+    getDeployment,
+    listDeploymentEvents,
+    type DeploymentDetail,
+    type DeploymentEvent,
+    type EnvValue,
+    type HealthCheck
+  } from '$lib/api';
+  import { getToken } from '$lib/auth';
+
+  let detail = $state<DeploymentDetail | null>(null);
+  let events = $state<DeploymentEvent[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  let id = $derived($page.params.id ?? '');
+
+  async function refresh() {
+    if (!id) {
+      return;
+    }
+    try {
+      // Events can fail (e.g. older versions of the API) without invalidating
+      // the rest of the page — degrade gracefully.
+      const [d, ev] = await Promise.all([
+        getDeployment(id),
+        listDeploymentEvents(id).catch(() => [] as DeploymentEvent[])
+      ]);
+      // The API omits empty collections in some shapes (e.g. health_checks
+      // is missing entirely when none are configured). Normalize so the
+      // template can safely read `.length`, `Object.keys`, etc.
+      detail = {
+        ...d,
+        command: d.command ?? [],
+        ports: d.ports ?? [],
+        volumes: d.volumes ?? [],
+        instances: d.instances ?? [],
+        labels: d.labels ?? {},
+        environment: d.environment ?? {},
+        health_checks: d.health_checks ?? []
+      };
+      events = ev;
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function statusKind(s: string): 'success' | 'warn' | 'danger' | 'neutral' {
+    const k = s.toLowerCase();
+    if (k === 'running') {
+      return 'success';
+    }
+    if (k === 'failed' || k === 'crashloopbackoff' || k === 'error') {
+      return 'danger';
+    }
+    if (k === 'pending' || k === 'booting' || k === 'created') {
+      return 'warn';
+    }
+    return 'neutral';
+  }
+
+  function envDisplay(value: EnvValue): { kind: 'literal' | 'secret'; text: string } {
+    if (typeof value === 'string') {
+      return { kind: 'literal', text: value };
+    }
+    return { kind: 'secret', text: `secretRef: ${value.secretRef}` };
+  }
+
+  function hcSummary(hc: HealthCheck): string {
+    switch (hc.type) {
+      case 'tcp':
+        return `port ${hc.port}`;
+      case 'http':
+        return hc.url;
+      case 'command':
+        return hc.command;
+    }
+  }
+
+  function timeAgo(d: Date | null): string {
+    if (!d) {
+      return '';
+    }
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) {
+      return 'just now';
+    }
+    if (s < 60) {
+      return `${s}s ago`;
+    }
+    return `${Math.floor(s / 60)}m ago`;
+  }
+
+  function formatDate(iso: string | undefined | null): string {
+    if (!iso) {
+      return '—';
+    }
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  }
+</script>
+
+{#if loading && !detail}
+  <p class="muted">Loading…</p>
+{:else if errorMsg && !detail}
+  <div class="alert"><strong>error</strong> {errorMsg}</div>
+  <p><a href="/deployments">← Back to deployments</a></p>
+{:else if detail}
+  {@const kind = statusKind(detail.status)}
+  <nav class="breadcrumbs">
+    <a href="/deployments">Deployments</a>
+    <span class="sep">/</span>
+    <a href="/deployments?namespace={detail.namespace}">{detail.namespace}</a>
+    <span class="sep">/</span>
+    <span>{detail.name}</span>
+  </nav>
+
+  <header class="page-header">
+    <div>
+      <div class="title-row">
+        <h1>{detail.name}</h1>
+        <span
+          class="status-pill"
+          class:success={kind === 'success'}
+          class:warn={kind === 'warn'}
+          class:danger={kind === 'danger'}
+        >
+          <span
+            class="dot"
+            class:success={kind === 'success'}
+            class:warn={kind === 'warn'}
+            class:danger={kind === 'danger'}
+          ></span>
+          {detail.status}
+        </span>
+      </div>
+      <p class="subtitle">
+        <span class="mono">{detail.id}</span>
+      </p>
+    </div>
+    <div class="header-actions">
+      {#if lastFetch}
+        <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+      {/if}
+      <button class="btn-secondary" onclick={refresh} disabled={loading}>
+        {loading ? 'loading…' : 'Refresh'}
+      </button>
+    </div>
+  </header>
+
+  <section class="grid">
+    <div class="card pad">
+      <h2>Overview</h2>
+      <dl>
+        <dt>Runtime</dt>
+        <dd>{detail.runtime}</dd>
+        <dt>Kind</dt>
+        <dd>{detail.kind}</dd>
+        <dt>Namespace</dt>
+        <dd>{detail.namespace}</dd>
+        <dt>Replicas</dt>
+        <dd>{detail.replicas}</dd>
+        <dt>Restart count</dt>
+        <dd>{detail.restart_count}</dd>
+        <dt>Image</dt>
+        <dd class="mono">{detail.image}</dd>
+        {#if detail.image_digest}
+          <dt>Digest</dt>
+          <dd class="mono small">{detail.image_digest}</dd>
+        {/if}
+        {#if detail.command.length > 0}
+          <dt>Command</dt>
+          <dd class="mono">{detail.command.join(' ')}</dd>
+        {/if}
+        {#if detail.parent_id}
+          <dt>Parent</dt>
+          <dd>
+            <a class="mono" href="/deployments/{detail.parent_id}">{detail.parent_id}</a>
+          </dd>
+        {/if}
+        <dt>Created</dt>
+        <dd>{formatDate(detail.created_at)}</dd>
+        <dt>Updated</dt>
+        <dd>{formatDate(detail.updated_at)}</dd>
+      </dl>
+    </div>
+
+    <div class="card pad">
+      <h2>Resources</h2>
+      {#if detail.resources?.limits || detail.resources?.requests}
+        <dl>
+          {#if detail.resources.limits?.cpu}
+            <dt>CPU limit</dt>
+            <dd class="mono">{detail.resources.limits.cpu}</dd>
+          {/if}
+          {#if detail.resources.limits?.memory}
+            <dt>Memory limit</dt>
+            <dd class="mono">{detail.resources.limits.memory}</dd>
+          {/if}
+          {#if detail.resources.requests?.cpu}
+            <dt>CPU request</dt>
+            <dd class="mono">{detail.resources.requests.cpu}</dd>
+          {/if}
+          {#if detail.resources.requests?.memory}
+            <dt>Memory request</dt>
+            <dd class="mono">{detail.resources.requests.memory}</dd>
+          {/if}
+        </dl>
+      {:else}
+        <p class="muted">No resource limits set.</p>
+      {/if}
+    </div>
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Instances</h2>
+      <span class="count">{detail.instances.length}</span>
+    </header>
+    {#if detail.instances.length === 0}
+      <p class="muted pad">No running instances.</p>
+    {:else}
+      <ul class="instance-list">
+        {#each detail.instances as inst (inst)}
+          <li class="mono">{inst}</li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Ports</h2>
+      <span class="count">{detail.ports.length}</span>
+    </header>
+    {#if detail.ports.length === 0}
+      <p class="muted pad">No ports published.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th class="num">Published</th>
+            <th class="num">Target</th>
+            <th>Protocol</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each detail.ports as p}
+            <tr>
+              <td class="num mono">{p.published}</td>
+              <td class="num mono">{p.target}</td>
+              <td>{p.protocol ?? 'tcp'}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Volumes</h2>
+      <span class="count">{detail.volumes.length}</span>
+    </header>
+    {#if detail.volumes.length === 0}
+      <p class="muted pad">No volumes mounted.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Source</th>
+            <th>Destination</th>
+            <th>Mode</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each detail.volumes as v}
+            <tr>
+              <td>{v.type}</td>
+              <td class="mono">{v.source ?? v.key ?? '—'}</td>
+              <td class="mono">{v.destination}</td>
+              <td>{v.permission}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Environment</h2>
+      <span class="count">{Object.keys(detail.environment).length}</span>
+    </header>
+    {#if Object.keys(detail.environment).length === 0}
+      <p class="muted pad">No environment variables.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each Object.entries(detail.environment) as [k, v]}
+            {@const disp = envDisplay(v)}
+            <tr>
+              <td class="mono">{k}</td>
+              <td class="mono">
+                {#if disp.kind === 'secret'}
+                  <span class="secret-tag">{disp.text}</span>
+                {:else}
+                  {disp.text}
+                {/if}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Health checks</h2>
+      <span class="count">{detail.health_checks.length}</span>
+    </header>
+    {#if detail.health_checks.length === 0}
+      <p class="muted pad">No health checks configured.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Target</th>
+            <th>Interval</th>
+            <th>Timeout</th>
+            <th class="num">Threshold</th>
+            <th>On failure</th>
+            <th>Readiness</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each detail.health_checks as hc}
+            <tr>
+              <td>{hc.type}</td>
+              <td class="mono">{hcSummary(hc)}</td>
+              <td>{hc.interval}</td>
+              <td>{hc.timeout}</td>
+              <td class="num mono">{hc.threshold}</td>
+              <td>{hc.on_failure}</td>
+              <td>{hc.readiness ? 'yes' : 'no'}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  {#if events.length > 0}
+    <section class="card">
+      <header class="section-head">
+        <h2>Recent events</h2>
+        <span class="count">{events.length}</span>
+      </header>
+      <ul class="events">
+        {#each events.slice(0, 50) as ev, i (ev.id ?? i)}
+          <li>
+            <span class="event-time mono">{formatDate(ev.created_at)}</span>
+            {#if ev.level}
+              <span class="event-level event-level-{ev.level.toLowerCase()}">{ev.level}</span>
+            {/if}
+            <span class="event-msg">{ev.message ?? JSON.stringify(ev)}</span>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+{/if}
+
+<style>
+  .breadcrumbs {
+    margin-bottom: 1rem;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .breadcrumbs a {
+    color: var(--fg-1);
+  }
+  .breadcrumbs a:hover {
+    color: var(--accent);
+  }
+  .breadcrumbs .sep {
+    margin: 0 0.4rem;
+    color: var(--fg-3);
+  }
+
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1.75rem;
+  }
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.35rem 0 0;
+    color: var(--fg-3);
+    font-size: 0.78rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    margin-bottom: 1rem;
+    overflow: hidden;
+  }
+  .card.pad {
+    padding: 1.125rem 1.25rem;
+  }
+  .section-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.85rem 1.125rem;
+    border-bottom: 1px solid var(--border);
+  }
+  h2 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .pad h2 {
+    margin-bottom: 0.9rem;
+  }
+  .count {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .muted {
+    color: var(--fg-2);
+  }
+  .muted.pad {
+    padding: 1.25rem;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 1.5rem;
+    row-gap: 0.55rem;
+    margin: 0;
+  }
+  dt {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  dd {
+    margin: 0;
+    color: var(--fg-0);
+    font-size: 0.85rem;
+    word-break: break-word;
+  }
+  dd.small {
+    font-size: 0.78rem;
+    color: var(--fg-1);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.65rem 1rem;
+    font-size: 0.82rem;
+    border-bottom: 1px solid var(--border);
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  th {
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  td.num,
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .mono {
+    font-family: var(--font-mono);
+  }
+
+  .instance-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .instance-list li {
+    padding: 0.55rem 1.125rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--fg-1);
+  }
+  .instance-list li:last-child {
+    border-bottom: none;
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.18rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--fg-2);
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+  }
+  .status-pill.success {
+    color: var(--success);
+    background: var(--success-bg);
+    border-color: transparent;
+  }
+  .status-pill.warn {
+    color: var(--warning);
+    background: var(--warning-bg);
+    border-color: transparent;
+  }
+  .status-pill.danger {
+    color: var(--danger);
+    background: var(--danger-bg);
+    border-color: transparent;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--fg-3);
+  }
+  .dot.success {
+    background: var(--success);
+  }
+  .dot.warn {
+    background: var(--warning);
+  }
+  .dot.danger {
+    background: var(--danger);
+  }
+
+  .secret-tag {
+    background: var(--accent-bg);
+    color: var(--accent);
+    padding: 0.1rem 0.45rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+  }
+
+  .events {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .events li {
+    display: grid;
+    grid-template-columns: 11rem auto 1fr;
+    gap: 0.75rem;
+    align-items: baseline;
+    padding: 0.55rem 1.125rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+  }
+  .events li:last-child {
+    border-bottom: none;
+  }
+  .event-time {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .event-level {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    color: var(--fg-2);
+  }
+  .event-level-error {
+    color: var(--danger);
+  }
+  .event-level-warning,
+  .event-level-warn {
+    color: var(--warning);
+  }
+  .event-level-info {
+    color: var(--success);
+  }
+  .event-msg {
+    color: var(--fg-0);
+    word-break: break-word;
+  }
+</style>

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -11,6 +11,7 @@
     type HealthCheck
   } from '$lib/api';
   import { getToken } from '$lib/auth';
+  import { formatDate, timeAgo } from '$lib/utils';
 
   let detail = $state<DeploymentDetail | null>(null);
   let events = $state<DeploymentEvent[]>([]);
@@ -105,31 +106,6 @@
         return hc.url;
       case 'command':
         return hc.command;
-    }
-  }
-
-  function timeAgo(d: Date | null): string {
-    if (!d) {
-      return '';
-    }
-    const s = Math.floor((Date.now() - d.getTime()) / 1000);
-    if (s < 5) {
-      return 'just now';
-    }
-    if (s < 60) {
-      return `${s}s ago`;
-    }
-    return `${Math.floor(s / 60)}m ago`;
-  }
-
-  function formatDate(iso: string | undefined | null): string {
-    if (!iso) {
-      return '—';
-    }
-    try {
-      return new Date(iso).toLocaleString();
-    } catch {
-      return iso;
     }
   }
 
@@ -468,53 +444,22 @@
     color: var(--fg-3);
   }
 
+  /* Override the shared .page-header on this page: the detail layout uses
+   * top-aligned columns because the title block stacks pill + id below the
+   * h1, and we want the action buttons to sit next to the title (not the
+   * bottom of the meta column). */
   .page-header {
-    display: flex;
-    justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 1.75rem;
   }
   .title-row {
     display: flex;
     align-items: center;
     gap: 0.75rem;
   }
-  h1 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-  }
-  .subtitle {
-    margin: 0.35rem 0 0;
+  .page-header .subtitle {
+    margin-top: 0.35rem;
     color: var(--fg-3);
     font-size: 0.78rem;
-  }
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .refresh-meta {
-    color: var(--fg-3);
-    font-size: 0.75rem;
-  }
-  .btn-secondary {
-    background: var(--bg-2);
-    color: var(--fg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8rem;
-    font-weight: 500;
-  }
-  .btn-secondary:hover {
-    background: var(--bg-hover);
-    color: var(--fg-0);
-  }
-  .btn-secondary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .grid {
@@ -524,12 +469,10 @@
     margin-bottom: 1rem;
   }
 
+  /* Detail page stacks multiple cards vertically — the shared .card has no
+   * vertical rhythm baked in. */
   .card {
-    background: var(--bg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
     margin-bottom: 1rem;
-    overflow: hidden;
   }
   .card.pad {
     padding: 1.125rem 1.25rem;
@@ -554,9 +497,6 @@
     color: var(--fg-3);
     font-size: 0.75rem;
     font-variant-numeric: tabular-nums;
-  }
-  .muted {
-    color: var(--fg-2);
   }
   .muted.pad {
     padding: 1.25rem;
@@ -681,20 +621,6 @@
     padding: 0.1rem 0.45rem;
     border-radius: var(--radius-sm);
     font-size: 0.75rem;
-  }
-
-  .alert {
-    background: var(--danger-bg);
-    border: 1px solid var(--danger);
-    color: var(--fg-0);
-    padding: 0.85rem 1rem;
-    border-radius: var(--radius);
-    margin-bottom: 1.25rem;
-    font-size: 0.825rem;
-  }
-  .alert strong {
-    color: var(--danger);
-    margin-right: 0.5rem;
   }
 
   .events {

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -75,7 +75,13 @@
     if (k === 'running') {
       return 'success';
     }
-    if (k === 'failed' || k === 'crashloopbackoff' || k === 'error') {
+    if (
+      k === 'failed' ||
+      k === 'crashloopbackoff' ||
+      k === 'error' ||
+      k === 'createcontainererror' ||
+      k === 'imagepullbackoff'
+    ) {
       return 'danger';
     }
     if (k === 'pending' || k === 'booting' || k === 'created') {
@@ -126,6 +132,32 @@
       return iso;
     }
   }
+
+  /** Collapse runs of consecutive events sharing the same level + message
+   *  into a single row with a count. The scheduler emits e.g. "Scaled up"
+   *  on every reconciliation tick, which floods the timeline with no
+   *  added signal — we keep the first occurrence's timestamp and tally
+   *  the rest. */
+  interface GroupedEvent {
+    key: string;
+    first: DeploymentEvent;
+    count: number;
+  }
+  function groupConsecutive(list: DeploymentEvent[]): GroupedEvent[] {
+    const out: GroupedEvent[] = [];
+    for (const ev of list) {
+      const key = `${ev.level ?? ''}|${ev.message ?? ''}|${ev.reason ?? ''}`;
+      const last = out[out.length - 1];
+      if (last && last.key === key) {
+        last.count += 1;
+      } else {
+        out.push({ key, first: ev, count: 1 });
+      }
+    }
+    return out;
+  }
+
+  let groupedEvents = $derived(groupConsecutive(events));
 </script>
 
 {#if loading && !detail}
@@ -332,7 +364,7 @@
           </tr>
         </thead>
         <tbody>
-          {#each Object.entries(detail.environment) as [k, v]}
+          {#each Object.entries(detail.environment).sort(([a], [b]) => a.localeCompare(b)) as [k, v] (k)}
             {@const disp = envDisplay(v)}
             <tr>
               <td class="mono">{k}</td>
@@ -394,13 +426,24 @@
         <span class="count">{events.length}</span>
       </header>
       <ul class="events">
-        {#each events.slice(0, 50) as ev, i (ev.id ?? i)}
+        {#each groupedEvents as g, i (g.first.id ?? i)}
+          {@const ts = g.first.timestamp ?? g.first.created_at}
           <li>
-            <span class="event-time mono">{formatDate(ev.created_at)}</span>
-            {#if ev.level}
-              <span class="event-level event-level-{ev.level.toLowerCase()}">{ev.level}</span>
+            <span class="event-time mono">{formatDate(ts)}</span>
+            {#if g.first.level}
+              <span class="event-level event-level-{g.first.level.toLowerCase()}"
+                >{g.first.level}</span
+              >
             {/if}
-            <span class="event-msg">{ev.message ?? JSON.stringify(ev)}</span>
+            <span class="event-msg">
+              {g.first.message ?? JSON.stringify(g.first)}
+              {#if g.count > 1}
+                <span class="event-multiplier">×{g.count}</span>
+              {/if}
+              {#if g.first.reason}
+                <span class="event-reason">{g.first.reason}</span>
+              {/if}
+            </span>
           </li>
         {/each}
       </ul>
@@ -694,5 +737,24 @@
   .event-msg {
     color: var(--fg-0);
     word-break: break-word;
+  }
+  .event-multiplier {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: var(--radius-sm);
+    background: var(--bg-2);
+    color: var(--fg-2);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .event-reason {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: var(--radius-sm);
+    background: var(--accent-bg);
+    color: var(--accent);
+    font-size: 0.7rem;
   }
 </style>

--- a/dashboard/src/routes/deployments/[id]/+page.ts
+++ b/dashboard/src/routes/deployments/[id]/+page.ts
@@ -1,0 +1,5 @@
+// Dynamic deployment-ID page: skip prerendering (no fixed ids to enumerate
+// at build time). The SPA fallback served by adapter-static will route the
+// request to this page at runtime.
+export const prerender = false;
+export const ssr = false;

--- a/dashboard/src/routes/namespaces/+page.svelte
+++ b/dashboard/src/routes/namespaces/+page.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { listDeployments, listNamespaces, type Deployment, type Namespace } from '$lib/api';
+  import { getToken } from '$lib/auth';
+
+  let namespaces = $state<Namespace[]>([]);
+  let deployments = $state<Deployment[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function refresh() {
+    try {
+      // Fetch both in parallel so the deployment counts are consistent with
+      // the namespace list. Order matters less than the joint snapshot.
+      const [ns, dep] = await Promise.all([listNamespaces(), listDeployments()]);
+      namespaces = ns;
+      deployments = dep;
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) {
+      return '';
+    }
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) {
+      return 'just now';
+    }
+    if (s < 60) {
+      return `${s}s ago`;
+    }
+    return `${Math.floor(s / 60)}m ago`;
+  }
+
+  function deploymentCount(name: string): number {
+    return deployments.filter((d) => d.namespace === name).length;
+  }
+
+  function runningCount(name: string): number {
+    return deployments.filter(
+      (d) => d.namespace === name && d.status.toLowerCase() === 'running'
+    ).length;
+  }
+
+  function formatDate(iso: string): string {
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  }
+
+  let totalDeployments = $derived(deployments.length);
+  let usedNamespaces = $derived(
+    new Set(deployments.map((d) => d.namespace)).size
+  );
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Namespaces</h1>
+    <p class="subtitle">Logical groupings for deployments</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Namespaces</div>
+    <div class="stat-value">{namespaces.length}</div>
+    <div class="stat-sub">{usedNamespaces} currently hosting workloads</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Deployments</div>
+    <div class="stat-value">{totalDeployments}</div>
+    <div class="stat-sub">across every namespace</div>
+  </div>
+</section>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && namespaces.length > 0}
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th class="num">Deployments</th>
+          <th class="num">Running</th>
+          <th>Created</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each namespaces as ns (ns.id)}
+          {@const total = deploymentCount(ns.name)}
+          {@const running = runningCount(ns.name)}
+          <tr>
+            <td>
+              <a class="ns-link" href="/deployments?namespace={ns.name}">{ns.name}</a>
+            </td>
+            <td class="num mono">{total}</td>
+            <td class="num mono">
+              {#if total === 0}
+                <span class="muted">0</span>
+              {:else if running === total}
+                <span class="dot-inline success"></span>{running}
+              {:else}
+                <span class="dot-inline warn"></span>{running}
+              {/if}
+            </td>
+            <td class="muted">{formatDate(ns.created_at)}</td>
+            <td class="muted">{ns.updated_at ? formatDate(ns.updated_at) : '—'}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && namespaces.length === 0 && !errorMsg}
+  <div class="empty">
+    <p>No namespaces yet.</p>
+    <p class="muted">
+      Namespaces are created automatically when you <code>ring apply</code> a deployment with a new
+      namespace, or explicitly with <code>ring namespace create &lt;name&gt;</code>.
+    </p>
+  </div>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.7rem 1rem;
+    font-size: 0.85rem;
+    border-bottom: 1px solid var(--border);
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  th {
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  td.num,
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  .muted {
+    color: var(--fg-2);
+  }
+  .ns-link {
+    color: var(--fg-0);
+    font-weight: 500;
+  }
+  .ns-link:hover {
+    color: var(--accent);
+  }
+  .dot-inline {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-right: 0.4rem;
+    vertical-align: middle;
+  }
+  .dot-inline.success {
+    background: var(--success);
+  }
+  .dot-inline.warn {
+    background: var(--warning);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+  }
+
+  .empty {
+    background: var(--bg-1);
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-lg);
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+  .empty p {
+    margin: 0.35rem 0;
+  }
+  .empty .muted {
+    color: var(--fg-2);
+    font-size: 0.85rem;
+  }
+  code {
+    background: var(--bg-2);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+  }
+</style>

--- a/dashboard/src/routes/namespaces/+page.svelte
+++ b/dashboard/src/routes/namespaces/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { listDeployments, listNamespaces, type Deployment, type Namespace } from '$lib/api';
   import { getToken } from '$lib/auth';
+  import { formatDate, timeAgo } from '$lib/utils';
 
   let namespaces = $state<Namespace[]>([]);
   let deployments = $state<Deployment[]>([]);
@@ -42,20 +43,6 @@
     }
   });
 
-  function timeAgo(d: Date | null): string {
-    if (!d) {
-      return '';
-    }
-    const s = Math.floor((Date.now() - d.getTime()) / 1000);
-    if (s < 5) {
-      return 'just now';
-    }
-    if (s < 60) {
-      return `${s}s ago`;
-    }
-    return `${Math.floor(s / 60)}m ago`;
-  }
-
   function deploymentCount(name: string): number {
     return deployments.filter((d) => d.namespace === name).length;
   }
@@ -64,14 +51,6 @@
     return deployments.filter(
       (d) => d.namespace === name && d.status.toLowerCase() === 'running'
     ).length;
-  }
-
-  function formatDate(iso: string): string {
-    try {
-      return new Date(iso).toLocaleString();
-    } catch {
-      return iso;
-    }
   }
 
   let totalDeployments = $derived(deployments.length);
@@ -164,50 +143,6 @@
 {/if}
 
 <style>
-  .page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    margin-bottom: 1.75rem;
-  }
-  h1 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-  }
-  .subtitle {
-    margin: 0.25rem 0 0;
-    color: var(--fg-2);
-    font-size: 0.825rem;
-  }
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .refresh-meta {
-    color: var(--fg-3);
-    font-size: 0.75rem;
-  }
-  .btn-secondary {
-    background: var(--bg-2);
-    color: var(--fg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8rem;
-    font-weight: 500;
-  }
-  .btn-secondary:hover {
-    background: var(--bg-hover);
-    color: var(--fg-0);
-  }
-  .btn-secondary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .stats {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
@@ -240,35 +175,6 @@
     margin-top: 0.25rem;
   }
 
-  .card {
-    background: var(--bg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: 0;
-    overflow: hidden;
-  }
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  th,
-  td {
-    text-align: left;
-    padding: 0.7rem 1rem;
-    font-size: 0.85rem;
-    border-bottom: 1px solid var(--border);
-  }
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-  th {
-    font-weight: 500;
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--fg-2);
-    background: var(--bg-0);
-  }
   td.num,
   th.num {
     text-align: right;
@@ -276,9 +182,6 @@
   }
   td.mono {
     font-family: var(--font-mono);
-  }
-  .muted {
-    color: var(--fg-2);
   }
   .ns-link {
     color: var(--fg-0);
@@ -300,40 +203,5 @@
   }
   .dot-inline.warn {
     background: var(--warning);
-  }
-
-  .alert {
-    background: var(--danger-bg);
-    border: 1px solid var(--danger);
-    color: var(--fg-0);
-    padding: 0.85rem 1rem;
-    border-radius: var(--radius);
-    margin-bottom: 1.25rem;
-    font-size: 0.825rem;
-  }
-  .alert strong {
-    color: var(--danger);
-    margin-right: 0.5rem;
-  }
-
-  .empty {
-    background: var(--bg-1);
-    border: 1px dashed var(--border);
-    border-radius: var(--radius-lg);
-    padding: 3rem 1rem;
-    text-align: center;
-  }
-  .empty p {
-    margin: 0.35rem 0;
-  }
-  .empty .muted {
-    color: var(--fg-2);
-    font-size: 0.85rem;
-  }
-  code {
-    background: var(--bg-2);
-    padding: 0.1rem 0.4rem;
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
   }
 </style>

--- a/dashboard/src/routes/secrets/+page.svelte
+++ b/dashboard/src/routes/secrets/+page.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { listSecrets, type Secret } from '$lib/api';
+  import { getToken } from '$lib/auth';
+  import { formatDate, timeAgo } from '$lib/utils';
+
+  let secrets = $state<Secret[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+  let nsFilter = $state<string>('');
+
+  async function refresh() {
+    try {
+      secrets = await listSecrets();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  function syncUrl(): void {
+    const params = new URLSearchParams();
+    if (nsFilter) {
+      params.set('namespace', nsFilter);
+    }
+    const qs = params.toString();
+    history.replaceState(null, '', `${$page.url.pathname}${qs ? `?${qs}` : ''}`);
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    nsFilter = $page.url.searchParams.get('namespace') ?? '';
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  let namespaces = $derived(
+    Array.from(new Set(secrets.map((s) => s.namespace))).sort((a, b) => a.localeCompare(b))
+  );
+  let filtered = $derived(nsFilter ? secrets.filter((s) => s.namespace === nsFilter) : secrets);
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Secrets</h1>
+    <p class="subtitle">AES-256-GCM encrypted values, scoped per namespace</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && secrets.length > 0}
+  {#if namespaces.length > 1}
+    <div class="filter-bar">
+      <label for="ns-filter">Namespace</label>
+      <select id="ns-filter" bind:value={nsFilter} onchange={syncUrl}>
+        <option value="">All ({secrets.length})</option>
+        {#each namespaces as ns}
+          <option value={ns}>{ns} ({secrets.filter((s) => s.namespace === ns).length})</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Namespace</th>
+          <th>Created</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each filtered as s (s.id)}
+          <tr>
+            <td class="mono">{s.name}</td>
+            <td>
+              <a class="ns-link" href="/secrets?namespace={s.namespace}">{s.namespace}</a>
+            </td>
+            <td class="muted">{formatDate(s.created_at)}</td>
+            <td class="muted">{s.updated_at ? formatDate(s.updated_at) : '—'}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && secrets.length === 0 && !errorMsg}
+  <div class="empty">
+    <p>No secrets yet.</p>
+    <p class="muted">
+      Create one with <code>ring secret create &lt;name&gt; --namespace &lt;ns&gt; --value
+      &lt;value&gt;</code>. The value is encrypted before being stored and is never returned by the
+      API.
+    </p>
+  </div>
+{/if}
+
+<style>
+  .ns-link {
+    color: var(--fg-0);
+    font-weight: 500;
+  }
+  .ns-link:hover {
+    color: var(--accent);
+  }
+  td.mono {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/dashboard/static/favicon.svg
+++ b/dashboard/static/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="12" fill="none" stroke="#6ee7b7" stroke-width="3"/>
+</svg>

--- a/dashboard/svelte.config.js
+++ b/dashboard/svelte.config.js
@@ -1,0 +1,21 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter({
+      pages: 'build',
+      assets: 'build',
+      fallback: 'index.html',
+      precompress: false,
+      strict: true
+    }),
+    paths: {
+      relative: true
+    }
+  }
+};
+
+export default config;

--- a/dashboard/svelte.config.js
+++ b/dashboard/svelte.config.js
@@ -11,10 +11,12 @@ const config = {
       fallback: 'index.html',
       precompress: false,
       strict: true
-    }),
-    paths: {
-      relative: true
-    }
+    })
+    // No `paths: { relative: true }` — adapter-static rewrites our absolute
+    // `/foo` URLs to `./foo` relative to the current page, which breaks
+    // dynamic routes (`./deployments/abc` from `/deployments` resolves to
+    // `/deployments/deployments/abc`). Keep paths absolute, served from
+    // root by the Rust backend.
   }
 };
 

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,19 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  server: {
+    port: 5173,
+    // In dev, requests to /api/* hit the Rust backend rather than the
+    // Vite dev server. Matches the production routing where `ring dashboard`
+    // (or the embedded mode) proxies the same prefix to the real API.
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:3030',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    }
+  }
+});

--- a/documentation/how-to/use-the-dashboard.md
+++ b/documentation/how-to/use-the-dashboard.md
@@ -1,0 +1,87 @@
+# Use the web dashboard
+
+Ring ships with a read-only web dashboard. It lists deployments across all namespaces, with status, runtime, replicas, and image. Authentication uses the same Bearer JWT as the CLI.
+
+There are **two ways to run it**, both serving the same bundled UI:
+
+| Mode | Command | Where the dashboard runs | Where the API runs |
+|---|---|---|---|
+| Local (proxy) | `ring dashboard` | On your laptop | Anywhere reachable via your `config.toml` context |
+| Embedded | `ring server start` with `[dashboard] enabled = true` | On the server itself | Same server |
+
+Pick local when you want to monitor a remote cluster from your workstation. Pick embedded when you want a persistent dashboard URL for the whole team.
+
+## Local mode (`ring dashboard`)
+
+Boots a tiny web server on your machine that serves the static UI and reverse-proxies `/api/*` to the API URL of your current context. Your bearer token (from `auth.json` or `RING_TOKEN`) is injected on the way out — the browser never sees it.
+
+```bash
+ring dashboard
+# Dashboard:  http://127.0.0.1:3031
+# Upstream:   http://prod-ring.internal:3030
+```
+
+The browser opens automatically (pass `--no-open` to skip). The dashboard reads the context the rest of the CLI uses, so to switch clusters you change context first:
+
+```bash
+ring -c staging dashboard
+```
+
+You can override the listen address if 3031 is taken:
+
+```bash
+ring dashboard --listen 127.0.0.1:9999
+```
+
+**Prerequisites**:
+
+- `ring login` must have been run for the current context (or `RING_TOKEN` must be set in your environment).
+- The remote API must be reachable from your machine (port 3030 open, or an SSH tunnel / VPN in front).
+
+## Embedded mode (server-side dashboard)
+
+There are three ways to enable the embedded dashboard, in order of precedence:
+
+**1. CLI flag** — quickest, no config change:
+
+```bash
+ring server start --dashboard
+# Dashboard listening on http://127.0.0.1:3031
+```
+
+**2. Environment variable** — works with systemd, Docker, CI:
+
+```bash
+RING_DASHBOARD=true ring server start
+# Optional: override the bind address (useful in containers)
+RING_DASHBOARD=true RING_DASHBOARD_LISTEN=0.0.0.0:3031 ring server start
+```
+
+Accepted truthy values: `true`, `1`, `yes`, `on`.
+
+**3. `config.toml`** — persistent setup:
+
+```toml
+[contexts.default.dashboard]
+enabled = true
+listen_address = "0.0.0.0:3031"
+```
+
+After restarting `ring server start`, the dashboard is served on the configured port alongside the API. The UI uses the same `/api/*` prefix; the server proxies it to its own API over loopback, so users authenticate with their normal credentials.
+
+> The default `listen_address` binds to `127.0.0.1:3031`. Set it to `0.0.0.0:3031` only if you intend to expose the dashboard beyond the host — and put HTTPS in front of it (Sozune, Caddy, etc.).
+
+## Disabling the dashboard
+
+Embedded mode is **off by default**. If you've enabled it and want to roll back, set `enabled = false` (or remove the `[dashboard]` block) and restart the server.
+
+Local mode is always available — there's nothing to disable, it only runs when you type `ring dashboard`.
+
+## What the dashboard currently shows
+
+This is the v0.9 MVP — intentionally minimal:
+
+- A login screen
+- A list of all deployments visible to your account, with namespace / name / runtime / status / replicas / image
+
+Future cycles will add drill-down (instances, events, live logs) and actions (restart, scale, delete). Until then, the CLI remains the source of truth for anything mutating.

--- a/src/commands/dashboard.rs
+++ b/src/commands/dashboard.rs
@@ -1,0 +1,93 @@
+//! `ring dashboard` — local dashboard with a reverse proxy to a remote API.
+//!
+//! Reads the current context from `config.toml` to figure out which Ring API
+//! to talk to, pulls the bearer token from `auth.json` (or `RING_TOKEN` env),
+//! then boots an axum server on the user's machine that:
+//!
+//! - serves the embedded SvelteKit build,
+//! - proxies `/api/*` to the remote API, injecting the bearer token.
+//!
+//! Lets one operator monitor *any* Ring cluster from their laptop without
+//! exposing the dashboard from the server side.
+
+use crate::config::config::{Config, load_auth_config};
+use crate::dashboard::{Mode, UpstreamApi};
+use clap::{Arg, ArgMatches, Command};
+
+pub(crate) fn command_config() -> Command {
+    Command::new("dashboard")
+        .about("Open a local web dashboard that points at the current context's API")
+        .arg(
+            Arg::new("listen")
+                .long("listen")
+                .help("Address to bind the local dashboard to")
+                .default_value("127.0.0.1:3031"),
+        )
+        .arg(
+            Arg::new("no-open")
+                .long("no-open")
+                .help("Do not open the browser automatically")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+pub(crate) async fn execute(args: &ArgMatches, mut config: Config, context: String) {
+    let listen = args
+        .get_one::<String>("listen")
+        .cloned()
+        .unwrap_or_else(|| "127.0.0.1:3031".to_string());
+    let no_open = args.get_flag("no-open");
+
+    let api_url = config.get_api_url();
+    let auth = load_auth_config(context);
+    if auth.token.is_empty() {
+        eprintln!("No auth token available. Run `ring login` first, or set RING_TOKEN.");
+        std::process::exit(1);
+    }
+
+    let upstream = UpstreamApi {
+        url: api_url.clone(),
+        bearer_token: Some(auth.token),
+    };
+    let mode = Mode::Local { upstream };
+
+    let url = format!("http://{}", listen);
+    println!("Dashboard:  {}", url);
+    println!("Upstream:   {}", api_url);
+
+    // Open the browser before serving — Vite-style. We do it on a separate
+    // task so a flaky `xdg-open` doesn't keep the server from starting.
+    if !no_open {
+        let url_to_open = url.clone();
+        tokio::spawn(async move {
+            // Tiny grace period so the listener is up before the browser hits it.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let _ = open_browser(&url_to_open);
+        });
+    }
+
+    if let Err(e) = crate::dashboard::server::serve(mode, &listen).await {
+        eprintln!("Dashboard failed: {}", e);
+        std::process::exit(1);
+    }
+}
+
+/// Best-effort browser opener — silently does nothing if the platform tool
+/// is missing. We avoid pulling the `open`/`webbrowser` crate just for this.
+fn open_browser(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open").arg(url).spawn()?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open").arg(url).spawn()?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", url])
+            .spawn()?;
+    }
+    Ok(())
+}

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -4,7 +4,7 @@ use crate::runtime::docker;
 use crate::runtime::docker::docker_lifecycle::DockerLifecycle;
 use crate::runtime::lifecycle_trait::RuntimeLifecycle;
 use clap::ArgMatches;
-use clap::Command;
+use clap::{Arg, ArgAction, Command};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -17,10 +17,39 @@ use crate::scheduler::intentional_shutdowns::IntentionalShutdowns;
 use crate::scheduler::scheduler::schedule;
 
 pub(crate) fn command_config() -> Command {
-    Command::new("start")
+    Command::new("start").arg(
+        Arg::new("dashboard")
+            .long("dashboard")
+            .help("Enable the embedded web dashboard for this run (overrides config.toml)")
+            .action(ArgAction::SetTrue),
+    )
 }
 
-pub(crate) async fn execute(_args: &ArgMatches, configuration: Config) {
+pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
+    // Dashboard activation precedence, strongest first:
+    //   1. `--dashboard` CLI flag (explicit one-off)
+    //   2. `RING_DASHBOARD=true|1|yes` env var (systemd / docker / CI)
+    //   3. `[dashboard] enabled = true` in config.toml (persistent)
+    // The env var lets operators flip the dashboard on without rewriting
+    // the on-disk config — same spirit as `RING_TOKEN` / `RING_SECRET_KEY`.
+    if args.get_flag("dashboard") {
+        configuration.dashboard.enabled = true;
+    } else if let Ok(val) = std::env::var("RING_DASHBOARD") {
+        if matches!(
+            val.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ) {
+            configuration.dashboard.enabled = true;
+        }
+    }
+    // Optional override of the bind address; useful in containers where
+    // the default `127.0.0.1:3031` is unreachable from the host.
+    if let Ok(addr) = std::env::var("RING_DASHBOARD_LISTEN") {
+        if !addr.trim().is_empty() {
+            configuration.dashboard.listen_address = addr;
+        }
+    }
+
     // Validate the encryption key up front. Anything that touches a
     // secret (deployment env vars with `secretRef`, `POST /secrets`, ...)
     // would panic later on a missing or malformed key; failing here gives
@@ -82,6 +111,21 @@ pub(crate) async fn execute(_args: &ArgMatches, configuration: Config) {
         configuration.clone(),
         runtimes.clone(),
     ));
+
+    // Embedded dashboard — only spawned when explicitly enabled in config,
+    // so the default surface stays unchanged for existing users. Proxies
+    // to its own API over loopback so the browser sees a single origin.
+    if configuration.dashboard.enabled {
+        let listen = configuration.dashboard.listen_address.clone();
+        let api_port = configuration.api.port;
+        task::spawn(async move {
+            let mode = crate::dashboard::Mode::Embedded { api_port };
+            if let Err(e) = crate::dashboard::server::serve(mode, &listen).await {
+                eprintln!("Dashboard task failed: {}", e);
+            }
+        });
+    }
+
     let scheduler_handler = task::spawn(schedule(
         pool,
         configuration,

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -72,6 +72,35 @@ pub(crate) struct CloudHypervisorConfig {
     pub(crate) max_console_log_backups: Option<u32>,
 }
 
+/// User-facing configuration for the embedded web dashboard. Off by default
+/// to keep the server surface minimal until an operator opts in.
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct DashboardConfig {
+    /// When true, `ring server start` spawns the dashboard on
+    /// `listen_address`. When false (the default), the dashboard is not
+    /// served by this Ring instance — operators can still run
+    /// `ring dashboard` locally against any API.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// `host:port` for the dashboard to bind to. Distinct from the API
+    /// port to keep concerns separated.
+    #[serde(default = "default_dashboard_listen_address")]
+    pub(crate) listen_address: String,
+}
+
+fn default_dashboard_listen_address() -> String {
+    "127.0.0.1:3031".to_string()
+}
+
+impl Default for DashboardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_address: default_dashboard_listen_address(),
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, Default)]
 pub(crate) struct RuntimesConfig {
     #[serde(default)]
@@ -92,6 +121,8 @@ pub(crate) struct Config {
     pub(crate) docker: DockerConfig,
     #[serde(default)]
     pub(crate) runtime: RuntimesConfig,
+    #[serde(default)]
+    pub(crate) dashboard: DashboardConfig,
 }
 
 impl Config {
@@ -122,6 +153,7 @@ impl Default for Config {
             scheduler: Scheduler::default(),
             docker: DockerConfig::default(),
             runtime: RuntimesConfig::default(),
+            dashboard: DashboardConfig::default(),
         }
     }
 }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -1,0 +1,51 @@
+//! Web dashboard for Ring.
+//!
+//! Two modes share the same SvelteKit build (`dashboard/build/`):
+//!
+//! - [`Mode::Embedded`] — when `ring server start` is configured with
+//!   `[dashboard] enabled = true`, the server itself serves the dashboard
+//!   on a dedicated port. The dashboard's `/api/*` requests are forwarded
+//!   to the same Ring instance over loopback, since the API and dashboard
+//!   live in the same process.
+//! - [`Mode::Local`] — `ring dashboard` boots a tiny axum server on the
+//!   user's laptop. It serves the same embedded assets and reverse-proxies
+//!   `/api/*` to a remote Ring API, injecting the user's bearer token from
+//!   `auth.json`. Lets one operator monitor any cluster without exposing
+//!   the dashboard from the server.
+//!
+//! The bundled assets are baked at compile time by `rust-embed`, so a
+//! single binary ships with the UI regardless of mode.
+
+pub(crate) mod proxy;
+pub(crate) mod server;
+
+#[derive(Clone, Debug)]
+pub(crate) struct UpstreamApi {
+    /// Base URL of the Ring API, e.g. `http://prod-ring.internal:3030`.
+    pub url: String,
+    /// Bearer token to inject on every proxied request. None when the
+    /// dashboard is embedded in the same server (no auth needed
+    /// internally — the browser already authenticated against the API).
+    pub bearer_token: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum Mode {
+    /// Run alongside the API in `ring server start`. Proxies to localhost.
+    Embedded { api_port: u16 },
+    /// Run on the operator's machine via `ring dashboard`. Proxies to a
+    /// remote API with an injected token.
+    Local { upstream: UpstreamApi },
+}
+
+impl Mode {
+    pub(crate) fn upstream(&self) -> UpstreamApi {
+        match self {
+            Mode::Embedded { api_port } => UpstreamApi {
+                url: format!("http://127.0.0.1:{}", api_port),
+                bearer_token: None,
+            },
+            Mode::Local { upstream } => upstream.clone(),
+        }
+    }
+}

--- a/src/dashboard/proxy.rs
+++ b/src/dashboard/proxy.rs
@@ -1,0 +1,149 @@
+//! Reverse-proxy for `/api/*` requests from the dashboard to the upstream
+//! Ring API. Forwards method, path, query string, headers (minus hop-by-hop
+//! ones), and body. When the dashboard is in local mode, the operator's
+//! bearer token from `auth.json` is injected so the browser never sees it.
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use http_body_util::BodyExt;
+use reqwest::Client;
+use std::time::Duration;
+
+use super::UpstreamApi;
+
+#[derive(Clone)]
+pub(crate) struct ProxyState {
+    client: Client,
+    upstream: UpstreamApi,
+}
+
+impl ProxyState {
+    pub(crate) fn new(upstream: UpstreamApi) -> anyhow::Result<Self> {
+        let client = Client::builder()
+            // Long enough for `--follow` log streams once we wire those up,
+            // short enough that a hung backend doesn't pile up sockets.
+            .timeout(Duration::from_secs(60))
+            .build()?;
+        Ok(Self { client, upstream })
+    }
+}
+
+pub(crate) async fn proxy_handler(State(state): State<ProxyState>, req: Request) -> Response {
+    match forward(state, req).await {
+        Ok(resp) => resp,
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("dashboard proxy error: {}", e),
+        )
+            .into_response(),
+    }
+}
+
+async fn forward(state: ProxyState, req: Request) -> anyhow::Result<Response> {
+    let (parts, body) = req.into_parts();
+    let body_bytes = body.collect().await?.to_bytes();
+
+    // Strip the `/api` prefix the dashboard uses so the upstream API sees
+    // the real path. e.g. `/api/deployments` → `/deployments`.
+    let upstream_path = parts
+        .uri
+        .path()
+        .strip_prefix("/api")
+        .unwrap_or(parts.uri.path());
+    let upstream_query = parts
+        .uri
+        .query()
+        .map(|q| format!("?{}", q))
+        .unwrap_or_default();
+    let upstream_url = format!("{}{}{}", state.upstream.url, upstream_path, upstream_query);
+
+    let method = reqwest::Method::from_bytes(parts.method.as_str().as_bytes())?;
+    let mut builder = state.client.request(method, &upstream_url);
+
+    // Forward headers, dropping hop-by-hop ones the proxy must rewrite.
+    let mut filtered = HeaderMap::new();
+    for (name, value) in parts.headers.iter() {
+        if is_hop_by_hop(name) {
+            continue;
+        }
+        // `Host` belongs to the upstream, not us.
+        if name == axum::http::header::HOST {
+            continue;
+        }
+        // Drop any inbound Authorization when we have a token to inject,
+        // to avoid double-auth scenarios.
+        if name == axum::http::header::AUTHORIZATION && state.upstream.bearer_token.is_some() {
+            continue;
+        }
+        filtered.insert(name.clone(), value.clone());
+    }
+    if let Some(token) = &state.upstream.bearer_token {
+        filtered.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", token))?,
+        );
+    }
+    builder = builder.headers(reqwest_headers(filtered));
+
+    if !body_bytes.is_empty() {
+        builder = builder.body(body_bytes.to_vec());
+    }
+
+    let resp = builder.send().await?;
+    let status = StatusCode::from_u16(resp.status().as_u16())?;
+    let resp_headers = resp.headers().clone();
+    let resp_bytes = resp.bytes().await?;
+
+    let mut out = Response::builder().status(status);
+    for (name, value) in resp_headers.iter() {
+        // Re-cast reqwest headers into axum's HeaderMap. They share the
+        // underlying type but the crate paths differ.
+        if let (Ok(n), Ok(v)) = (
+            HeaderName::from_bytes(name.as_str().as_bytes()),
+            HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            // Skip hop-by-hop response headers too.
+            if !is_hop_by_hop(&n) {
+                out = out.header(n, v);
+            }
+        }
+    }
+    Ok(out.body(Body::from(resp_bytes.to_vec()))?)
+}
+
+/// Per RFC 7230 §6.1, these headers apply only to the immediate connection
+/// and must not be forwarded by a proxy.
+fn is_hop_by_hop(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str().to_ascii_lowercase().as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn reqwest_headers(headers: HeaderMap) -> reqwest::header::HeaderMap {
+    let mut out = reqwest::header::HeaderMap::new();
+    for (name, value) in headers.iter() {
+        if let (Ok(n), Ok(v)) = (
+            reqwest::header::HeaderName::from_bytes(name.as_str().as_bytes()),
+            reqwest::header::HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            out.insert(n, v);
+        }
+    }
+    out
+}
+
+// Methods imported for `into_parts` on axum::http::Request<Body>.
+const _: fn() = || {
+    let _ = Method::GET;
+    let _ = Uri::from_static("/");
+};

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -1,0 +1,108 @@
+//! Embed the SvelteKit static build and serve it over axum. The same code
+//! powers both the embedded mode (inside `ring server start`) and the
+//! local mode (`ring dashboard`); the only difference is which upstream
+//! API the `/api/*` proxy points at.
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{any, get};
+use rust_embed::RustEmbed;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use tracing::info;
+
+use super::Mode;
+use super::proxy::{ProxyState, proxy_handler};
+
+/// `dashboard/build/` is produced by `bun run build` in the dashboard/
+/// directory. We embed every file at compile time so a single Rust binary
+/// ships with the UI. CI must run `bun run build` before `cargo build`.
+#[derive(RustEmbed)]
+#[folder = "dashboard/build/"]
+struct Assets;
+
+pub(crate) async fn serve(mode: Mode, listen_address: &str) -> anyhow::Result<()> {
+    let proxy_state = ProxyState::new(mode.upstream())?;
+
+    // Single router so `with_state` covers every route. Static routes
+    // ignore the state via `State<ProxyState>` extractor on the proxy
+    // handler only; asset handlers don't touch it.
+    let app: Router = Router::new()
+        .route("/", get(index))
+        .route("/api/{*path}", any(proxy_handler))
+        .route("/{*path}", get(asset))
+        .with_state(proxy_state);
+
+    let addr = SocketAddr::from_str(listen_address).map_err(|e| {
+        anyhow::anyhow!(
+            "Invalid dashboard listen address '{}': {}",
+            listen_address,
+            e
+        )
+    })?;
+
+    info!("Dashboard listening on http://{}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn index(State(_): State<ProxyState>) -> Response {
+    serve_file("index.html")
+}
+
+/// Match the conventions adapter-static produces: `foo` → `foo`,
+/// `foo.html`, or `foo/index.html`. Anything we can't resolve falls back
+/// to `index.html` so the SPA's client-side router can handle it.
+async fn asset(State(_): State<ProxyState>, Path(path): Path<String>, uri: Uri) -> Response {
+    if let Some(response) = try_serve(&path) {
+        return response;
+    }
+    let trimmed = uri.path().trim_start_matches('/');
+    if !trimmed.is_empty()
+        && let Some(response) = try_serve(trimmed)
+    {
+        return response;
+    }
+    serve_file("index.html")
+}
+
+fn try_serve(path: &str) -> Option<Response> {
+    if Assets::get(path).is_some() {
+        return Some(serve_file(path));
+    }
+    let with_html = format!("{path}.html");
+    if Assets::get(&with_html).is_some() {
+        return Some(serve_file(&with_html));
+    }
+    let index = format!("{}/index.html", path.trim_end_matches('/'));
+    if Assets::get(&index).is_some() {
+        return Some(serve_file(&index));
+    }
+    None
+}
+
+fn serve_file(path: &str) -> Response {
+    match Assets::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, mime.as_ref())
+                .body(Body::from(content.data.into_owned()))
+                .unwrap_or_else(|_| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to build response",
+                    )
+                        .into_response()
+                })
+        }
+        None => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate env_logger;
 mod commands {
     pub(crate) mod apply;
     pub(crate) mod context;
+    pub(crate) mod dashboard;
     pub(crate) mod deployment;
     pub(crate) mod doctor;
     pub(crate) mod init;
@@ -68,6 +69,7 @@ mod config {
     pub(crate) mod user;
 }
 
+mod dashboard;
 mod database;
 mod exit_code;
 mod serializer;
@@ -100,6 +102,7 @@ async fn main() {
                 .subcommand(commands::server::command_config()),
         )
         .subcommand(commands::apply::command_config())
+        .subcommand(commands::dashboard::command_config())
         .subcommand(commands::doctor::command_config())
         .subcommand(commands::login::command_config())
         .subcommand(
@@ -187,6 +190,9 @@ async fn main() {
         }
         Some(("apply", sub_matches)) => {
             commands::apply::apply(sub_matches, config, &client).await;
+        }
+        Some(("dashboard", sub_matches)) => {
+            commands::dashboard::execute(sub_matches, config, context.to_string()).await;
         }
         Some(("doctor", sub_matches)) => {
             commands::doctor::execute(sub_matches, config);


### PR DESCRIPTION
## Summary
- SvelteKit 5 dashboard embedded in the Ring binary, served by `ring dashboard` (local mode) or directly by `ring server` (embedded mode). Talks to the API over the `/api/*` prefix which the Rust side proxies to the local API socket — the dashboard JS never knows the API URL.
- Read-only by design: every page is a viewer over existing API data. No create/update/delete actions are exposed.

## Pages
- **`/`** — login (username + password → bearer token stored client-side).
- **`/deployments`** — list view with filters (namespace, runtime, status) and free-text search, status pills, replica counts, links to the per-deployment detail. Filter state is mirrored to the URL.
- **`/deployments/[id]`** — detail view: overview, resources, instances, ports, volumes, environment (literal values + `secretRef:` callout, never the resolved value), health checks, and a recent-events panel with consecutive-event grouping.
- **`/namespaces`** — list view with deployment counts per namespace.
- **`/secrets`** — list view: `name | namespace | created | updated`. **Values are never sent by the API and never displayed.**
- **`/configs`** — list view with click-to-expand for the `data` payload. Includes byte size, labels, and a namespace filter mirrored to the URL.

## Implementation notes
- **Shared primitives** live in `dashboard/src/lib/utils.ts` (`timeAgo`, `formatDate` — the latter normalises both RFC3339 and the SQL-style `YYYY-MM-DD HH:MM:SS.nnn UTC` timestamps that Ring returns on some endpoints) and the page chrome (`.page-header`, `.card`, `.btn-secondary`, `.filter-bar`, `.alert`, `.empty`) is hoisted into `dashboard/src/app.css` so each page is a thin layer over the shared CSS.
- **5-second polling** on every list/detail page. Lightweight by design: no SSE, no websockets, no streaming logs.
- **Embedded build** via `rust-embed`. `bun run build` writes static assets to `dashboard/build/` which the Rust binary embeds at compile time. CI must run the dashboard build before `cargo build`.
- **Config expand** uses a focusable `<button>` (with `aria-expanded` and `aria-controls`) so the data panel is reachable with the keyboard.

## Test plan
- [x] `bun run check` — 0 errors on the SvelteKit project.
- [x] `bun run build` — static export generated cleanly.
- [x] `cargo build` — embeds the dashboard, no Rust regressions.
- [x] Manual smoke test of the 5 routes (200 OK), login flow, namespace filter via `?namespace=` URL param on secrets/configs.