### PR TITLE
Live logs in dashboard + scoped ticket auth for SSE

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -131,6 +131,14 @@ export interface Config {
   labels: string;
 }
 
+export interface LogEntry {
+  instance: string;
+  message: string;
+  level: string;
+  /** RFC3339 timestamp when the runtime tagged the line, when available. */
+  timestamp?: string | null;
+}
+
 export interface DeploymentEvent {
   id?: string;
   deployment_id?: string;
@@ -215,4 +223,98 @@ export function listSecrets(): Promise<Secret[]> {
 
 export function listConfigs(): Promise<Config[]> {
   return request<Config[]>('/configs');
+}
+
+export interface LogsQuery {
+  tail?: number;
+  since?: string;
+  container?: string;
+}
+
+function logsUrl(id: string, query: LogsQuery & { follow?: boolean; ticket?: string }): string {
+  const params = new URLSearchParams();
+  if (query.tail !== undefined) {
+    params.set('tail', String(query.tail));
+  }
+  if (query.since) {
+    params.set('since', query.since);
+  }
+  if (query.container) {
+    params.set('container', query.container);
+  }
+  if (query.follow) {
+    params.set('follow', 'true');
+  }
+  if (query.ticket) {
+    params.set('ticket', query.ticket);
+  }
+  const qs = params.toString();
+  return `/api/deployments/${encodeURIComponent(id)}/logs${qs ? `?${qs}` : ''}`;
+}
+
+export function fetchLogsSnapshot(id: string, query: LogsQuery = {}): Promise<LogEntry[]> {
+  return request<LogEntry[]>(
+    `/deployments/${encodeURIComponent(id)}/logs${buildLogsQs({ ...query, follow: false })}`
+  );
+}
+
+function buildLogsQs(query: LogsQuery & { follow?: boolean }): string {
+  const params = new URLSearchParams();
+  if (query.tail !== undefined) {
+    params.set('tail', String(query.tail));
+  }
+  if (query.since) {
+    params.set('since', query.since);
+  }
+  if (query.container) {
+    params.set('container', query.container);
+  }
+  if (query.follow) {
+    params.set('follow', 'true');
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/** Mint a single-use-ish stream ticket scoped to a specific resource.
+ *  Required because `EventSource` cannot send an Authorization header. */
+export function mintStreamTicket(scope: string): Promise<{ ticket: string; expires_in: number }> {
+  return request<{ ticket: string; expires_in: number }>('/auth/stream-ticket', {
+    method: 'POST',
+    body: JSON.stringify({ scope })
+  });
+}
+
+export interface LogStreamHandle {
+  /** Stop reading and close the EventSource. Safe to call twice. */
+  close(): void;
+}
+
+/** Opens a live log stream. Mints a ticket first (because EventSource can't
+ *  set an Authorization header), then connects with `?ticket=…`.  The
+ *  caller is responsible for calling `close()` to release the connection. */
+export async function streamLogs(
+  id: string,
+  query: LogsQuery,
+  onEntry: (entry: LogEntry) => void,
+  onError?: (err: Event) => void
+): Promise<LogStreamHandle> {
+  const { ticket } = await mintStreamTicket(`deployment:logs:${id}`);
+  const url = logsUrl(id, { ...query, follow: true, ticket });
+  const es = new EventSource(url);
+  es.onmessage = (ev) => {
+    try {
+      onEntry(JSON.parse(ev.data) as LogEntry);
+    } catch {
+      // Defensive: ignore malformed frames rather than killing the stream.
+    }
+  };
+  if (onError) {
+    es.onerror = onError;
+  }
+  return {
+    close() {
+      es.close();
+    }
+  };
 }

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -3,12 +3,16 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import {
+    fetchLogsSnapshot,
     getDeployment,
     listDeploymentEvents,
+    streamLogs,
     type DeploymentDetail,
     type DeploymentEvent,
     type EnvValue,
-    type HealthCheck
+    type HealthCheck,
+    type LogEntry,
+    type LogStreamHandle
   } from '$lib/api';
   import { getToken } from '$lib/auth';
   import { formatDate, timeAgo } from '$lib/utils';
@@ -21,6 +25,130 @@
   let poll: ReturnType<typeof setInterval> | null = null;
 
   let id = $derived($page.params.id ?? '');
+
+  /** Hard cap to bound memory when a chatty deployment streams for hours.
+   *  Older entries fall off the top once we cross this. */
+  const LOG_RING_MAX = 2000;
+
+  let logs = $state<LogEntry[]>([]);
+  let logsLoading = $state(false);
+  let logsError = $state<string | null>(null);
+  let logsFollow = $state(true);
+  let logsTail = $state(200);
+  let logsAutoScroll = $state(true);
+  let logsContainerFilter = $state('');
+  let logsStream: LogStreamHandle | null = null;
+  let logsEl: HTMLDivElement | null = $state(null);
+
+  function pushLog(entry: LogEntry) {
+    logs.push(entry);
+    if (logs.length > LOG_RING_MAX) {
+      logs.splice(0, logs.length - LOG_RING_MAX);
+    }
+  }
+
+  function stopStream() {
+    if (logsStream) {
+      logsStream.close();
+      logsStream = null;
+    }
+  }
+
+  async function loadSnapshot() {
+    if (!id) {
+      return;
+    }
+    logsLoading = true;
+    logsError = null;
+    try {
+      const snap = await fetchLogsSnapshot(id, {
+        tail: logsTail,
+        container: logsContainerFilter || undefined
+      });
+      logs = snap;
+    } catch (e) {
+      logsError = e instanceof Error ? e.message : String(e);
+    } finally {
+      logsLoading = false;
+    }
+  }
+
+  async function startStream() {
+    if (!id) {
+      return;
+    }
+    stopStream();
+    logsError = null;
+    try {
+      logsStream = await streamLogs(
+        id,
+        { tail: logsTail, container: logsContainerFilter || undefined },
+        (entry) => {
+          pushLog(entry);
+        },
+        () => {
+          // EventSource fires a generic Event on disconnect; surface a hint
+          // without killing the page. The browser will auto-reconnect using
+          // the same URL while the ticket is still within its TTL.
+          logsError = 'stream interrupted, reconnecting…';
+        }
+      );
+    } catch (e) {
+      logsError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function refreshLogs() {
+    stopStream();
+    // Don't clear `logs` here: emptying the array collapses the viewport,
+    // which makes the page jump to the top because the scroll position
+    // becomes out of range. Keep the old lines until the snapshot lands
+    // and then swap atomically inside loadSnapshot().
+    await loadSnapshot();
+    if (logsFollow) {
+      await startStream();
+    }
+  }
+
+  async function toggleFollow() {
+    logsFollow = !logsFollow;
+    if (logsFollow) {
+      await startStream();
+    } else {
+      stopStream();
+    }
+  }
+
+  function levelClass(level: string): string {
+    const l = level.toLowerCase();
+    if (l === 'error' || l === 'err' || l === 'critical' || l === 'fatal') {
+      return 'log-error';
+    }
+    if (l === 'warn' || l === 'warning') {
+      return 'log-warn';
+    }
+    if (l === 'info' || l === 'notice') {
+      return 'log-info';
+    }
+    if (l === 'debug') {
+      return 'log-debug';
+    }
+    return 'log-unknown';
+  }
+
+  $effect(() => {
+    if (logsAutoScroll && logsEl && logs.length > 0) {
+      // Read .length to register the dependency, then defer the scroll
+      // until after the DOM has the new row.
+      const _ = logs.length;
+      void _;
+      queueMicrotask(() => {
+        if (logsEl) {
+          logsEl.scrollTop = logsEl.scrollHeight;
+        }
+      });
+    }
+  });
 
   async function refresh() {
     if (!id) {
@@ -62,6 +190,7 @@
       return;
     }
     void refresh();
+    void refreshLogs();
     poll = setInterval(() => void refresh(), 5000);
   });
 
@@ -69,6 +198,7 @@
     if (poll) {
       clearInterval(poll);
     }
+    stopStream();
   });
 
   function statusKind(s: string): 'success' | 'warn' | 'danger' | 'neutral' {
@@ -395,6 +525,59 @@
     {/if}
   </section>
 
+  <section class="card">
+    <header class="section-head logs-head">
+      <h2>Logs</h2>
+      <div class="logs-controls">
+        <label class="logs-control">
+          <span>Tail</span>
+          <select bind:value={logsTail} onchange={refreshLogs}>
+            <option value={100}>100</option>
+            <option value={200}>200</option>
+            <option value={500}>500</option>
+            <option value={1000}>1000</option>
+          </select>
+        </label>
+        <label class="logs-control checkbox">
+          <input type="checkbox" bind:checked={logsAutoScroll} />
+          <span>Auto-scroll</span>
+        </label>
+        <button
+          class="btn-secondary small"
+          class:active={logsFollow}
+          onclick={toggleFollow}
+          title={logsFollow ? 'Pause live stream' : 'Resume live stream'}
+        >
+          {logsFollow ? '⏸ Pause' : '▶ Live'}
+        </button>
+        <button class="btn-secondary small" onclick={refreshLogs} disabled={logsLoading}>
+          Reload
+        </button>
+      </div>
+    </header>
+    {#if logsError}
+      <div class="logs-error">{logsError}</div>
+    {/if}
+    <div class="logs-viewport mono" bind:this={logsEl}>
+      {#if logsLoading && logs.length === 0}
+        <p class="muted pad">Loading logs…</p>
+      {:else if logs.length === 0}
+        <p class="muted pad">No logs yet.</p>
+      {:else}
+        {#each logs as entry, i (i)}
+          <div class="log-line">
+            {#if entry.timestamp}
+              <span class="log-ts">{entry.timestamp}</span>
+            {/if}
+            <span class="log-level {levelClass(entry.level)}">{entry.level}</span>
+            <span class="log-instance">{entry.instance}</span>
+            <span class="log-msg">{entry.message}</span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </section>
+
   {#if events.length > 0}
     <section class="card">
       <header class="section-head">
@@ -682,5 +865,106 @@
     background: var(--accent-bg);
     color: var(--accent);
     font-size: 0.7rem;
+  }
+
+  .logs-head {
+    gap: 0.75rem;
+  }
+  .logs-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .logs-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--fg-2);
+  }
+  .logs-control select {
+    font-size: 0.78rem;
+    padding: 0.18rem 0.35rem;
+    background: var(--bg-0);
+    color: var(--fg-0);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .logs-control.checkbox input {
+    margin: 0;
+  }
+  .btn-secondary.small {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.6rem;
+  }
+  .btn-secondary.active {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .logs-error {
+    padding: 0.45rem 1.125rem;
+    background: var(--warning-bg);
+    color: var(--warning);
+    font-size: 0.78rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .logs-viewport {
+    max-height: 28rem;
+    overflow-y: auto;
+    background: var(--bg-0);
+    font-size: 0.78rem;
+    line-height: 1.45;
+  }
+  .log-line {
+    display: grid;
+    grid-template-columns: auto auto auto 1fr;
+    column-gap: 0.65rem;
+    padding: 0.18rem 1.125rem;
+    border-bottom: 1px solid transparent;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .log-line:hover {
+    background: var(--bg-1);
+  }
+  .log-ts {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+  }
+  .log-level {
+    text-transform: uppercase;
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    padding: 0 0.3rem;
+    border-radius: var(--radius-sm);
+    align-self: center;
+    min-width: 4rem;
+    text-align: center;
+  }
+  .log-error {
+    color: var(--danger);
+    background: var(--danger-bg);
+  }
+  .log-warn {
+    color: var(--warning);
+    background: var(--warning-bg);
+  }
+  .log-info {
+    color: var(--success);
+    background: var(--success-bg);
+  }
+  .log-debug {
+    color: var(--fg-2);
+    background: var(--bg-2);
+  }
+  .log-unknown {
+    color: var(--fg-3);
+  }
+  .log-instance {
+    color: var(--fg-2);
+    font-size: 0.72rem;
+  }
+  .log-msg {
+    color: var(--fg-0);
   }
 </style>

--- a/src/api/action/deployment/logs.rs
+++ b/src/api/action/deployment/logs.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{
         IntoResponse,
         sse::{KeepAlive, Sse},
@@ -12,10 +12,17 @@ use regex::Regex;
 use serde::Deserialize;
 use std::sync::LazyLock;
 
-use crate::api::server::{Db, RuntimeMap};
+use crate::api::server::{Db, RuntimeMap, TicketStoreState};
+use crate::api::stream_tickets::TicketStore;
 use crate::models::deployments;
-use crate::models::users::User;
+use crate::models::users as users_model;
 use crate::runtime::lifecycle_trait::Log;
+
+/// Scope string used to bind a stream ticket to a specific deployment's log
+/// endpoint. Keep this in sync with the client that mints the ticket.
+pub(crate) fn logs_scope(deployment_id: &str) -> String {
+    format!("deployment:logs:{}", deployment_id)
+}
 
 #[derive(Debug, Deserialize)]
 pub struct LogsQuery {
@@ -27,6 +34,11 @@ pub struct LogsQuery {
     container: Option<String>,
     #[serde(default)]
     follow: bool,
+    /// Single-use-ish stream ticket as an alternative to the bearer header.
+    /// EventSource can't set custom headers, so the dashboard mints a
+    /// scoped ticket via `POST /auth/stream-ticket` and replays it here.
+    #[serde(default)]
+    ticket: Option<String>,
 }
 
 fn default_tail() -> Option<u64> {
@@ -59,10 +71,15 @@ fn parse_since(since: &str) -> Option<i32> {
 pub(crate) async fn logs(
     Path(id): Path<String>,
     Query(params): Query<LogsQuery>,
-    _user: User,
+    headers: HeaderMap,
     State(pool): State<Db>,
     State(runtimes): State<RuntimeMap>,
+    State(tickets): State<TicketStoreState>,
 ) -> impl IntoResponse {
+    if !authorize(&pool, &headers, &params.ticket, &id, &tickets).await {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
     match deployments::find(&pool, &id).await {
         Ok(Some(deployment)) => {
             let runtime = match runtimes.get(&deployment.runtime) {
@@ -83,9 +100,17 @@ pub(crate) async fn logs(
                     )
                     .await;
 
-                Sse::new(stream)
+                // Prevent the ticket from leaking via Referer if the page
+                // ever links externally. Defense in depth on top of the
+                // short TTL.
+                let mut response = Sse::new(stream)
                     .keep_alive(KeepAlive::default())
-                    .into_response()
+                    .into_response();
+                response.headers_mut().insert(
+                    header::REFERRER_POLICY,
+                    HeaderValue::from_static("no-referrer"),
+                );
+                response
             } else {
                 let logs = runtime
                     .get_logs(
@@ -101,6 +126,33 @@ pub(crate) async fn logs(
         Ok(None) => Json(Vec::<Log>::new()).into_response(),
         Err(_) => Json(Vec::<Log>::new()).into_response(),
     }
+}
+
+/// Accept either a `Authorization: Bearer …` header or a scoped `?ticket=`
+/// query param. Returns true when the caller is authorized to read logs
+/// for `deployment_id`.
+async fn authorize(
+    pool: &Db,
+    headers: &HeaderMap,
+    ticket: &Option<String>,
+    deployment_id: &str,
+    tickets: &TicketStore,
+) -> bool {
+    if let Some(token) = bearer_token(headers) {
+        return users_model::find_by_token(pool, &token).await.is_ok();
+    }
+    if let Some(ticket) = ticket.as_deref() {
+        return tickets
+            .consume(ticket, &logs_scope(deployment_id))
+            .is_some();
+    }
+    false
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let stripped = value.strip_prefix("Bearer ")?;
+    Some(stripped.to_string())
 }
 
 #[cfg(test)]

--- a/src/api/action/mod.rs
+++ b/src/api/action/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod login;
 pub(crate) mod namespace;
 pub(crate) mod node;
 pub(crate) mod secret;
+pub(crate) mod stream_ticket;
 pub(crate) mod user;

--- a/src/api/action/stream_ticket.rs
+++ b/src/api/action/stream_ticket.rs
@@ -1,0 +1,97 @@
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::api::server::TicketStoreState;
+use crate::api::stream_tickets::TicketStore;
+use crate::models::users::User;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StreamTicketInput {
+    pub(crate) scope: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StreamTicketOutput {
+    pub(crate) ticket: String,
+    pub(crate) expires_in: u64,
+}
+
+/// Mints a single-use ticket bound to `scope` for the calling user.
+/// The ticket is valid for 30 seconds and is consumed on first use.
+pub(crate) async fn stream_ticket(
+    user: User,
+    State(store): State<TicketStoreState>,
+    Json(input): Json<StreamTicketInput>,
+) -> impl IntoResponse {
+    if input.scope.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "scope is required" })),
+        )
+            .into_response();
+    }
+
+    let token = TicketStore::from(store).mint(user.id.clone(), input.scope);
+    (
+        StatusCode::OK,
+        Json(StreamTicketOutput {
+            ticket: token,
+            expires_in: 30,
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::server::tests::{login, new_test_app};
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn mints_ticket_for_authenticated_user() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+
+        let res = TestServer::new(app)
+            .unwrap()
+            .post("/auth/stream-ticket")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "scope": "deployment:logs:abc" }))
+            .await;
+
+        assert_eq!(res.status_code(), StatusCode::OK);
+        let body = res.json::<serde_json::Value>();
+        let ticket = body["ticket"].as_str().expect("ticket field");
+        assert!(ticket.starts_with("tk_stream_"), "got: {}", ticket);
+        assert_eq!(body["expires_in"], 30);
+    }
+
+    #[tokio::test]
+    async fn rejects_without_bearer() {
+        let res = TestServer::new(new_test_app().await)
+            .unwrap()
+            .post("/auth/stream-ticket")
+            .json(&json!({ "scope": "deployment:logs:abc" }))
+            .await;
+
+        assert_eq!(res.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_scope() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+
+        let res = TestServer::new(app)
+            .unwrap()
+            .post("/auth/stream-ticket")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "scope": "" }))
+            .await;
+
+        assert_eq!(res.status_code(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod action;
 pub(crate) mod dto;
 pub(crate) mod server;
+pub(crate) mod stream_tickets;
 pub(crate) mod validation;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -19,6 +19,7 @@ use tower::{BoxError, ServiceBuilder};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use crate::api::action::login::login;
+use crate::api::action::stream_ticket::stream_ticket;
 use crate::config::config::Config;
 
 use crate::api::action::deployment::create as deployment_create;
@@ -98,11 +99,14 @@ pub(crate) type RuntimeMap = std::sync::Arc<
     >,
 >;
 
+pub(crate) type TicketStoreState = crate::api::stream_tickets::TicketStore;
+
 #[derive(Clone, FromRef)]
 pub(crate) struct AppState {
     pub(crate) connection: SqlitePool,
     pub(crate) configuration: Config,
     pub(crate) runtimes: RuntimeMap,
+    pub(crate) ticket_store: TicketStoreState,
 }
 
 pub(crate) fn router(state: AppState) -> Router {
@@ -112,6 +116,7 @@ pub(crate) fn router(state: AppState) -> Router {
     // All other routes with timeout
     let api_routes = Router::new()
         .route("/login", post(login))
+        .route("/auth/stream-ticket", post(stream_ticket))
         .route("/deployments", get(deployment_list).post(deployment_create))
         .route(
             "/deployments/{id}",
@@ -196,6 +201,7 @@ pub(crate) async fn start(pool: SqlitePool, mut configuration: Config, runtimes:
         connection: pool,
         configuration,
         runtimes,
+        ticket_store: TicketStoreState::new(),
     };
 
     let app = router(state);
@@ -223,7 +229,7 @@ pub(crate) async fn start(pool: SqlitePool, mut configuration: Config, runtimes:
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::api::server::{AppState, RuntimeMap, router};
+    use crate::api::server::{AppState, RuntimeMap, TicketStoreState, router};
     use crate::config::config::Config;
     use axum::Router;
     use axum::http::StatusCode;
@@ -264,6 +270,7 @@ pub(crate) mod tests {
             connection: pool.clone(),
             configuration,
             runtimes,
+            ticket_store: TicketStoreState::new(),
         };
 
         (pool, router(state))

--- a/src/api/stream_tickets.rs
+++ b/src/api/stream_tickets.rs
@@ -1,0 +1,134 @@
+//! In-memory tickets for SSE / WebSocket auth.
+//!
+//! Browsers can't set custom headers on `EventSource`, so we mint a short-
+//! lived ticket from a regular Bearer-authenticated call and let the client
+//! pass it as `?ticket=` on the streaming URL. The ticket expires after 30s
+//! and is bound to a specific scope (e.g. `deployment:logs:<id>`), so even
+//! if it leaks into an access log it's effectively dead on arrival.
+//!
+//! The ticket is *reusable* within its TTL window. This is intentional:
+//! EventSource auto-reconnects with the same URL on transient network
+//! failures, so a strict single-use would break reconnection. The TTL is
+//! short enough that the security loss vs single-use is negligible.
+//!
+//! No persistence — a server restart invalidates outstanding tickets, which
+//! is fine because the SSE connections they protect die at the same moment.
+
+use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::rng;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const TICKET_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+pub(crate) struct Ticket {
+    /// User who minted the ticket. Kept for audit logging and future
+    /// periodic re-authorization inside long-lived streams.
+    #[allow(dead_code)]
+    pub(crate) user_id: String,
+    pub(crate) scope: String,
+    expires_at: Instant,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct TicketStore {
+    inner: Arc<Mutex<HashMap<String, Ticket>>>,
+}
+
+impl TicketStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a fresh single-use ticket for `user_id` valid for `scope`.
+    /// Returns the opaque token to hand back to the client.
+    pub(crate) fn mint(&self, user_id: String, scope: String) -> String {
+        let token = generate_token();
+        let mut map = self.inner.lock().unwrap();
+        self.purge_expired(&mut map);
+        map.insert(
+            token.clone(),
+            Ticket {
+                user_id,
+                scope,
+                expires_at: Instant::now() + TICKET_TTL,
+            },
+        );
+        token
+    }
+
+    /// Validate a ticket. Returns the ticket payload if it exists, isn't
+    /// expired, and matches `expected_scope`. The ticket stays in the store
+    /// — multiple reads are allowed within the TTL to keep EventSource
+    /// auto-reconnect working. The TTL is short enough that re-use within
+    /// the window is not meaningfully weaker than single-use.
+    pub(crate) fn consume(&self, token: &str, expected_scope: &str) -> Option<Ticket> {
+        let mut map = self.inner.lock().unwrap();
+        self.purge_expired(&mut map);
+        let ticket = map.get(token)?;
+        if ticket.expires_at <= Instant::now() {
+            return None;
+        }
+        if ticket.scope != expected_scope {
+            return None;
+        }
+        Some(ticket.clone())
+    }
+
+    fn purge_expired(&self, map: &mut HashMap<String, Ticket>) {
+        let now = Instant::now();
+        map.retain(|_, t| t.expires_at > now);
+    }
+}
+
+fn generate_token() -> String {
+    format!(
+        "tk_stream_{}",
+        rng()
+            .sample_iter(&Alphanumeric)
+            .take(48)
+            .map(char::from)
+            .collect::<String>()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_then_consume_matches() {
+        let store = TicketStore::new();
+        let t = store.mint("u1".into(), "logs:abc".into());
+        let got = store.consume(&t, "logs:abc").unwrap();
+        assert_eq!(got.user_id, "u1");
+    }
+
+    #[test]
+    fn ticket_is_reusable_within_ttl() {
+        let store = TicketStore::new();
+        let t = store.mint("u1".into(), "logs:abc".into());
+        // EventSource auto-reconnect needs to replay the same URL; two
+        // consecutive consumes within the TTL window must both succeed.
+        assert!(store.consume(&t, "logs:abc").is_some());
+        assert!(store.consume(&t, "logs:abc").is_some());
+    }
+
+    #[test]
+    fn wrong_scope_is_rejected_but_ticket_stays() {
+        let store = TicketStore::new();
+        let t = store.mint("u1".into(), "logs:abc".into());
+        assert!(store.consume(&t, "logs:xyz").is_none());
+        // The legitimate scope still works after a probe with the wrong one.
+        assert!(store.consume(&t, "logs:abc").is_some());
+    }
+
+    #[test]
+    fn unknown_token_returns_none() {
+        let store = TicketStore::new();
+        assert!(store.consume("nope", "logs:abc").is_none());
+    }
+}


### PR DESCRIPTION
Adds a live logs panel to the deployment detail page in the dashboard, and the auth piece that was missing on the backend to make it work.

## Why two commits

- **Backend** (`feat(api)`): the existing `/deployments/{id}/logs` endpoint required an `Authorization: Bearer` header, which `EventSource` can't set. So I added scoped, short-lived stream tickets — minted via `POST /auth/stream-ticket`, replayed as `?ticket=…` on the SSE URL. Bearer header keeps working unchanged (CLI is unaffected).
- **Frontend** (`feat(dashboard)`): consumes both endpoints — snapshot via `GET …/logs`, live stream via the ticket flow.

## Ticket design

- **In-memory `HashMap`**, no DB. A server restart invalidates outstanding tickets, which is fine because the SSE connections they protect die at the same moment.
- **TTL 30s, reusable within the window.** Strict single-use breaks `EventSource` auto-reconnect on transient network blips — the browser retries with the same URL.
- **Scope-bound**: a ticket minted for `deployment:logs:<id>` is rejected on any other deployment, any other route, or after expiration.
- Naming aligned with existing `tk_*` convention: `tk_stream_*`.
- `Referrer-Policy: no-referrer` on the SSE response so the ticket doesn't leak via `Referer` if the page ever links externally.

Token never appears in URLs that get bookmarked — it's only in the SSE request URL, which lives in DevTools network tab for the session and dies within 30s.

## What the panel does

- Snapshot of the last N lines (configurable: 100 / 200 / 500 / 1000) on page load
- Live stream via SSE that appends new lines
- Pause / resume button
- Auto-scroll toggle
- Reload button (refreshes snapshot, doesn't bounce the page)
- Color coding by level (error / warn / info / debug / unknown) using the server-side `classify_log`

## Tested

Backend: 7 new unit tests (4 on the ticket store, 3 on the endpoint), full suite green (345 tests).

Live with two chatty containers (1 line/s and 1 line/3s) and one noisy container that rotates through INFO / WARN / ERROR / DEBUG / `[error]` / `[notice]` etc. — colors match, stream is smooth, pause/reload behave.

## Followup

One thing I'm noting but not doing here: Nomad had a CVE (HCSEC-2022-26) where streams kept delivering events after the user was disabled, because authorization was only checked at connection time. Worth adding periodic re-auth inside the long-lived `stream_logs` loop at some point — putting it on the roadmap.