### PR TITLE
fix(docker): robust image reference parsing + honest pull policy semantics

### DIFF
--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -1,4 +1,4 @@
-use super::{DockerImage, tiny_id};
+use super::{DockerImage, ImagePullPolicy, ImageReference, parse_image_reference, tiny_id};
 use crate::models::deployments::{
     Deployment, EnvValue, NetworkMode, parse_cpu_string, parse_memory_string,
 };
@@ -41,11 +41,35 @@ fn get_privileged_config(
         .and_then(|u| u.privileged)
 }
 
-fn extract_digest(repo_digests: &Option<Vec<String>>) -> Option<String> {
-    repo_digests
-        .as_ref()?
-        .first()
-        .and_then(|d| d.split_once('@').map(|(_, digest)| digest.to_string()))
+/// Pick the digest entry whose repository prefix matches `repo`. Docker stores
+/// one `RepoDigest` per registry an image is tagged with, so blindly taking
+/// the first entry could pin a digest from a sibling tag (e.g. `nginx` and
+/// `myregistry/nginx` pointing at the same content). We match on the part
+/// before `@` so a deployment of `myregistry/nginx:1.25` doesn't end up
+/// recorded with a `docker.io/library/nginx@sha256:...` digest.
+fn extract_digest(repo_digests: &Option<Vec<String>>, repo: &str) -> Option<String> {
+    let entries = repo_digests.as_ref()?;
+    if let Some(digest) = entries.iter().find_map(|d| {
+        let (entry_repo, digest) = d.split_once('@')?;
+        (entry_repo == repo).then(|| digest.to_string())
+    }) {
+        return Some(digest);
+    }
+
+    // Fallback: no entry matched the requested repo. This is expected when
+    // Docker normalizes the name (`nginx` → `docker.io/library/nginx`), but
+    // it can also signal a registry/repo mismatch worth investigating, so we
+    // warn rather than silently substitute.
+    let fallback = entries
+        .iter()
+        .find_map(|d| d.split_once('@').map(|(_, digest)| digest.to_string()));
+    if fallback.is_some() {
+        warn!(
+            "No RepoDigest matched '{}'; using first available digest. Entries: {:?}",
+            repo, entries
+        );
+    }
+    fallback
 }
 
 /// Translate the first readiness HC of `type: command` into a Docker
@@ -95,26 +119,54 @@ fn build_health_config(
 async fn pull_image(
     docker: Docker,
     image_config: DockerImage,
+    policy: ImagePullPolicy,
 ) -> Result<Option<String>, RuntimeError> {
-    let image = image_config.name.clone();
-    let tag = image_config.tag.clone();
-    let image_name = format!("{}:{}", image, tag);
-    info!("Pull docker image: {}", image_name);
+    let image_name = image_config.full_ref();
+    let repo = image_config.name.clone();
 
-    match docker.inspect_image(&image_name).await {
-        Ok(inspect) => {
+    // `Never` is handled by the caller (which fails fast on cache miss) and
+    // never reaches this function; the assertion pins the contract.
+    debug_assert!(
+        !matches!(policy, ImagePullPolicy::Never),
+        "pull_image must not be called with Never policy"
+    );
+
+    // Short-circuit on local cache hit when the reference is immutable
+    // (digest) or the policy explicitly opts into the cache (`IfNotPresent`).
+    // For `Always`, we still go to the registry even on a cache hit — that's
+    // the point of the policy.
+    let prefer_cache = matches!(policy, ImagePullPolicy::IfNotPresent)
+        || matches!(image_config.reference, ImageReference::Digest(_));
+
+    if prefer_cache {
+        if let Ok(inspect) = docker.inspect_image(&image_name).await {
             debug!("Docker image {} already exists locally", image_name);
-            return Ok(extract_digest(&inspect.repo_digests));
+            return Ok(extract_digest(&inspect.repo_digests, &repo));
         }
-        Err(_) => {
-            debug!("Docker image {} not found locally, pulling...", image_name);
-        }
+        debug!("Docker image {} not found locally, pulling...", image_name);
+    } else {
+        info!("Pull docker image: {} (policy: Always)", image_name);
     }
 
-    let create_image_options = CreateImageOptionsBuilder::new()
-        .from_image(&image)
-        .tag(&tag)
-        .build();
+    // `from_image` is the repository (with optional registry host), the
+    // second field is either a tag or a digest. Bollard accepts the digest
+    // form here directly.
+    let (tag_param, digest_param) = match &image_config.reference {
+        ImageReference::Tag(t) => (Some(t.as_str()), None),
+        ImageReference::Digest(d) => (None, Some(d.as_str())),
+    };
+    let mut builder = CreateImageOptionsBuilder::new().from_image(&repo);
+    if let Some(t) = tag_param {
+        builder = builder.tag(t);
+    }
+    // Bollard's `CreateImageOptions` exposes digest via the same `tag` field
+    // in practice (Docker's HTTP API accepts `tag=sha256:...`). The
+    // distinction matters for the from_image value, which must not embed the
+    // digest itself.
+    if let Some(d) = digest_param {
+        builder = builder.tag(d);
+    }
+    let create_image_options = builder.build();
 
     let credentials = image_config
         .auth
@@ -127,36 +179,29 @@ async fn pull_image(
 
     let mut stream = docker.create_image(Some(create_image_options), None, credentials);
 
-    let mut has_error = false;
-    let mut last_error = String::new();
-
     while let Some(pull_result) = stream.next().await {
-        match pull_result {
-            Ok(_) => {}
-            Err(e) => {
-                let error_msg = e.to_string();
-                error!("Docker image pull error: {}", error_msg);
-                has_error = true;
-                last_error = error_msg.clone();
+        if let Err(e) = pull_result {
+            let error_msg = e.to_string();
+            error!("Docker image pull error: {}", error_msg);
 
-                if error_msg.contains("404")
-                    || error_msg.contains("not found")
-                    || error_msg.contains("manifest unknown")
-                {
-                    return Err(RuntimeError::ImageNotFound(last_error));
-                }
+            if error_msg.contains("404")
+                || error_msg.contains("not found")
+                || error_msg.contains("manifest unknown")
+            {
+                return Err(RuntimeError::ImageNotFound(error_msg));
             }
+            // Bail on the first non-404 error instead of draining the rest of
+            // the stream — the previous version kept iterating to find the
+            // "last" error, which delayed the failure and could mask the
+            // root cause behind a later io error.
+            return Err(RuntimeError::ImagePullFailed(error_msg));
         }
-    }
-
-    if has_error {
-        return Err(RuntimeError::ImagePullFailed(last_error));
     }
 
     match docker.inspect_image(&image_name).await {
         Ok(inspect) => {
             info!("Docker successfully pulled image {}", image_name);
-            Ok(extract_digest(&inspect.repo_digests))
+            Ok(extract_digest(&inspect.repo_digests, &repo))
         }
         Err(e) => {
             error!(
@@ -177,14 +222,11 @@ pub(crate) async fn create_container(
     resolved_mounts: &[crate::models::volume::ResolvedMount],
 ) -> Result<(), RuntimeError> {
     debug!("Create container for deployment id: {}", &deployment.id);
-    let (image, tag) = match deployment.image.split_once(':') {
-        Some((image, tag)) => (image.to_string(), tag.to_string()),
-        None => (deployment.image.clone(), "latest".to_string()),
-    };
+    let (name, reference) = parse_image_reference(&deployment.image);
 
     let mut image_config = DockerImage {
-        name: image,
-        tag,
+        name,
+        reference,
         auth: None,
     };
 
@@ -195,15 +237,37 @@ pub(crate) async fn create_container(
         image_config.auth = Some((server.clone(), username.clone(), password.clone()));
     }
 
-    let should_pull = deployment
+    let policy = deployment
         .config
         .as_ref()
-        .map(|config| config.image_pull_policy.as_str() != "Never")
-        .unwrap_or(true);
+        .map(|c| ImagePullPolicy::parse(&c.image_pull_policy))
+        .unwrap_or(ImagePullPolicy::Always);
 
-    if should_pull {
-        let digest = pull_image(docker.clone(), image_config).await?;
-        deployment.image_digest = digest;
+    match policy {
+        ImagePullPolicy::Never => {
+            // Contract: never reach out to a registry. If the image isn't
+            // already cached, surface a clear `ImageNotFound` that mentions
+            // the policy — otherwise the operator sees an opaque bollard 404
+            // and has no way to tell whether the registry is unreachable or
+            // the policy itself blocked the pull.
+            let image_name = image_config.full_ref();
+            match docker.inspect_image(&image_name).await {
+                Ok(inspect) => {
+                    deployment.image_digest =
+                        extract_digest(&inspect.repo_digests, &image_config.name);
+                }
+                Err(_) => {
+                    return Err(RuntimeError::ImageNotFound(format!(
+                        "image '{}' not in local cache and image_pull_policy=Never forbids pulling",
+                        image_name
+                    )));
+                }
+            }
+        }
+        ImagePullPolicy::Always | ImagePullPolicy::IfNotPresent => {
+            let digest = pull_image(docker.clone(), image_config, policy).await?;
+            deployment.image_digest = digest;
+        }
     }
 
     let use_host_network = matches!(
@@ -583,6 +647,52 @@ mod tests {
     }
 
     #[test]
+    fn extract_digest_none_when_repo_digests_missing() {
+        assert_eq!(extract_digest(&None, "nginx"), None);
+    }
+
+    #[test]
+    fn extract_digest_picks_matching_repo() {
+        // Docker can attach the same image content to multiple repos; we must
+        // pin to the one we actually pulled, not whichever happens to come
+        // back first.
+        let digests = Some(vec![
+            "docker.io/library/nginx@sha256:aaa".to_string(),
+            "ghcr.io/kemeter/nginx@sha256:bbb".to_string(),
+        ]);
+        assert_eq!(
+            extract_digest(&digests, "ghcr.io/kemeter/nginx"),
+            Some("sha256:bbb".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_digest_falls_back_to_first_when_no_match() {
+        // Docker may normalize names (`nginx` → `docker.io/library/nginx`).
+        // The fallback preserves the previous behaviour rather than
+        // returning None and losing the digest entirely.
+        let digests = Some(vec!["docker.io/library/nginx@sha256:zzz".to_string()]);
+        assert_eq!(
+            extract_digest(&digests, "nginx"),
+            Some("sha256:zzz".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_digest_handles_malformed_entry() {
+        // An entry without `@` should not panic; it's silently skipped and
+        // the next valid one wins.
+        let digests = Some(vec![
+            "garbage_without_at_sign".to_string(),
+            "nginx@sha256:ok".to_string(),
+        ]);
+        assert_eq!(
+            extract_digest(&digests, "nginx"),
+            Some("sha256:ok".to_string())
+        );
+    }
+
+    #[test]
     fn test_get_privileged_config() {
         let config = Some(crate::models::deployments::DeploymentConfig {
             image_pull_policy: String::from("always"),
@@ -667,24 +777,15 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_digest_from_repo_digests() {
-        let repo_digests = Some(vec!["nginx@sha256:abc123def456".to_string()]);
-        assert_eq!(
-            extract_digest(&repo_digests),
-            Some("sha256:abc123def456".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_digest_none_when_empty() {
-        assert_eq!(extract_digest(&None), None);
-        assert_eq!(extract_digest(&Some(vec![])), None);
-    }
-
-    #[test]
-    fn test_extract_digest_none_when_no_at_sign() {
+    fn extract_digest_none_when_no_at_sign() {
+        // Single entry without `@` is malformed → no digest can be recovered.
         let repo_digests = Some(vec!["nginx:latest".to_string()]);
-        assert_eq!(extract_digest(&repo_digests), None);
+        assert_eq!(extract_digest(&repo_digests, "nginx"), None);
+    }
+
+    #[test]
+    fn extract_digest_none_when_empty_vec() {
+        assert_eq!(extract_digest(&Some(vec![]), "nginx"), None);
     }
 
     use crate::models::health_check::{FailureAction, HealthCheck};

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -35,15 +35,18 @@ fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment
     }
 
     let (status, reason, message) = match &err {
-        RuntimeError::ImageNotFound(_) => (
+        RuntimeError::ImageNotFound(detail) => (
             DeploymentStatus::ImagePullBackOff,
             "image_pull_back_off",
-            format!("Image '{}' not found", deployment.image),
+            // Preserve the inner detail — it carries operator-relevant
+            // context like `image_pull_policy=Never forbids pulling` that a
+            // generic "not found" would drop.
+            format!("Image '{}' not found: {}", deployment.image, detail),
         ),
-        RuntimeError::ImagePullFailed(_) => (
+        RuntimeError::ImagePullFailed(detail) => (
             DeploymentStatus::ImagePullBackOff,
             "image_pull_back_off",
-            format!("Failed to pull image '{}'", deployment.image),
+            format!("Failed to pull image '{}': {}", deployment.image, detail),
         ),
         RuntimeError::InstanceCreationFailed(msg) => (
             DeploymentStatus::CreateContainerError,

--- a/src/runtime/docker/mod.rs
+++ b/src/runtime/docker/mod.rs
@@ -18,10 +18,103 @@ pub(crate) use stats::{
     compute_pid_stats, fetch_container_stats, fetch_restart_count,
 };
 
+/// How an image was addressed in the manifest. A `tag` is mutable on the
+/// registry side (`my/app:latest` can be re-pushed); a `digest` pins an
+/// immutable content hash. Docker's pull API takes them through different
+/// query parameters, and `IfNotPresent` semantics differ (a digest reference
+/// hits the same content forever, so re-pulling buys nothing).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ImageReference {
+    Tag(String),
+    Digest(String),
+}
+
 pub(crate) struct DockerImage {
     pub name: String,
-    pub tag: String,
+    pub reference: ImageReference,
     pub auth: Option<(String, String, String)>,
+}
+
+impl DockerImage {
+    /// Reassemble the canonical `name[:tag|@digest]` string Docker expects in
+    /// `inspect_image`. We can't just keep the original input because we need
+    /// to be able to query the local cache and the registry independently.
+    pub fn full_ref(&self) -> String {
+        match &self.reference {
+            ImageReference::Tag(tag) => format!("{}:{}", self.name, tag),
+            ImageReference::Digest(digest) => format!("{}@{}", self.name, digest),
+        }
+    }
+}
+
+/// Parse a Docker image reference of the form:
+///   - `name`              → `(name, Tag("latest"))`
+///   - `name:tag`          → `(name, Tag(tag))`
+///   - `host[:port]/path[:tag]` → `(host[:port]/path, Tag(tag|"latest"))`
+///   - `name@sha256:...`   → `(name, Digest("sha256:..."))`
+///
+/// The naive `split_once(':')` we used before mistook the port of a
+/// `registry.example:5000/foo/bar:v1` reference for a tag, and choked on
+/// digest references entirely. The rule: a `:` only introduces a tag if it
+/// appears after the last `/` (i.e. in the final path component); a `@`
+/// always introduces a digest.
+pub(crate) fn parse_image_reference(image: &str) -> (String, ImageReference) {
+    // Digest takes precedence: `name@sha256:...` is unambiguous because `@`
+    // never appears in a registry host or repository path.
+    if let Some((name, digest)) = image.split_once('@') {
+        return (name.to_string(), ImageReference::Digest(digest.to_string()));
+    }
+
+    // Split on `/` to isolate the last path component, then look for a tag
+    // separator only inside it. This protects against `host:port/path` being
+    // misread as `host:(port/path)`.
+    let last_slash = image.rfind('/');
+    let last_component_start = last_slash.map(|i| i + 1).unwrap_or(0);
+    let last_component = &image[last_component_start..];
+
+    if let Some(colon_in_last) = last_component.rfind(':') {
+        let split_at = last_component_start + colon_in_last;
+        let name = image[..split_at].to_string();
+        let tag = image[split_at + 1..].to_string();
+        return (name, ImageReference::Tag(tag));
+    }
+
+    (image.to_string(), ImageReference::Tag("latest".to_string()))
+}
+
+/// Pull policy enum derived from the validated string (PR #89 enforces
+/// case-sensitive `Always`/`IfNotPresent`/`Never` at the API). We still parse
+/// case-insensitively at the runtime boundary because legacy seed data and
+/// tests historically used lowercase, and being strict here would crash
+/// rather than recover gracefully when fed a value that slipped past
+/// validation (e.g. seed migration, manual DB edit).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ImagePullPolicy {
+    Always,
+    IfNotPresent,
+    Never,
+}
+
+impl ImagePullPolicy {
+    pub fn parse(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "never" => Self::Never,
+            "ifnotpresent" => Self::IfNotPresent,
+            "always" => Self::Always,
+            // Anything else slipped past PR #89's API validation (manual DB
+            // edit, an older row created before the validator landed, etc.).
+            // Surface it so operators can fix the source rather than have us
+            // silently substitute `Always` and pretend everything is fine.
+            other => {
+                warn!(
+                    "Unknown image_pull_policy '{}' — falling back to Always. \
+                     Accepted values: Always, IfNotPresent, Never.",
+                    other
+                );
+                Self::Always
+            }
+        }
+    }
 }
 
 impl From<bollard::errors::Error> for RuntimeError {
@@ -68,4 +161,128 @@ pub(crate) fn tiny_id() -> String {
     use rand::Rng;
     let mut rng = rand::rng();
     format!("{:08x}", rng.random::<u32>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_image_reference_bare_name_defaults_to_latest() {
+        let (name, r#ref) = parse_image_reference("nginx");
+        assert_eq!(name, "nginx");
+        assert_eq!(r#ref, ImageReference::Tag("latest".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_with_tag() {
+        let (name, r#ref) = parse_image_reference("nginx:1.25");
+        assert_eq!(name, "nginx");
+        assert_eq!(r#ref, ImageReference::Tag("1.25".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_with_repo_path() {
+        let (name, r#ref) = parse_image_reference("library/nginx:1.25");
+        assert_eq!(name, "library/nginx");
+        assert_eq!(r#ref, ImageReference::Tag("1.25".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_with_registry_host_no_port() {
+        let (name, r#ref) = parse_image_reference("ghcr.io/kemeter/ring:v0.8.0");
+        assert_eq!(name, "ghcr.io/kemeter/ring");
+        assert_eq!(r#ref, ImageReference::Tag("v0.8.0".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_with_registry_port_keeps_port_in_name() {
+        // Regression: the previous `split_once(':')` parser turned this into
+        // `("registry.example", "5000/foo/bar:v1")` and Docker would refuse
+        // the pull because the registry hostname was lost.
+        let (name, r#ref) = parse_image_reference("registry.example:5000/foo/bar:v1");
+        assert_eq!(name, "registry.example:5000/foo/bar");
+        assert_eq!(r#ref, ImageReference::Tag("v1".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_with_registry_port_no_tag() {
+        let (name, r#ref) = parse_image_reference("registry.example:5000/foo/bar");
+        assert_eq!(name, "registry.example:5000/foo/bar");
+        assert_eq!(r#ref, ImageReference::Tag("latest".to_string()));
+    }
+
+    #[test]
+    fn parse_image_reference_digest() {
+        let (name, r#ref) = parse_image_reference(
+            "nginx@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+        assert_eq!(name, "nginx");
+        assert_eq!(
+            r#ref,
+            ImageReference::Digest(
+                "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_image_reference_digest_with_registry_port() {
+        // Digest takes precedence over any `:` in the host part — `@` is the
+        // unambiguous marker.
+        let (name, r#ref) = parse_image_reference("registry.example:5000/foo/bar@sha256:deadbeef");
+        assert_eq!(name, "registry.example:5000/foo/bar");
+        assert_eq!(r#ref, ImageReference::Digest("sha256:deadbeef".to_string()));
+    }
+
+    #[test]
+    fn full_ref_roundtrip_tag() {
+        let img = DockerImage {
+            name: "ghcr.io/kemeter/ring".to_string(),
+            reference: ImageReference::Tag("v0.8.0".to_string()),
+            auth: None,
+        };
+        assert_eq!(img.full_ref(), "ghcr.io/kemeter/ring:v0.8.0");
+    }
+
+    #[test]
+    fn full_ref_roundtrip_digest() {
+        let img = DockerImage {
+            name: "nginx".to_string(),
+            reference: ImageReference::Digest("sha256:abc".to_string()),
+            auth: None,
+        };
+        assert_eq!(img.full_ref(), "nginx@sha256:abc");
+    }
+
+    #[test]
+    fn pull_policy_parses_canonical_values() {
+        assert_eq!(ImagePullPolicy::parse("Always"), ImagePullPolicy::Always);
+        assert_eq!(
+            ImagePullPolicy::parse("IfNotPresent"),
+            ImagePullPolicy::IfNotPresent
+        );
+        assert_eq!(ImagePullPolicy::parse("Never"), ImagePullPolicy::Never);
+    }
+
+    #[test]
+    fn pull_policy_parses_case_insensitively() {
+        // Legacy seed data and existing test fixtures used lowercase.
+        assert_eq!(ImagePullPolicy::parse("always"), ImagePullPolicy::Always);
+        assert_eq!(
+            ImagePullPolicy::parse("ifnotpresent"),
+            ImagePullPolicy::IfNotPresent
+        );
+        assert_eq!(ImagePullPolicy::parse("NEVER"), ImagePullPolicy::Never);
+    }
+
+    #[test]
+    fn pull_policy_unknown_falls_back_to_always() {
+        // Defensive default: pulling fresh is the safe fallback compared to
+        // accidentally using a stale cached image when an unknown policy
+        // slipped past validation.
+        assert_eq!(ImagePullPolicy::parse("Maybe"), ImagePullPolicy::Always);
+        assert_eq!(ImagePullPolicy::parse(""), ImagePullPolicy::Always);
+    }
 }

--- a/tests/e2e/docker/t16_image_pull_policy.sh
+++ b/tests/e2e/docker/t16_image_pull_policy.sh
@@ -77,10 +77,76 @@ POLICY=$(curl -fsS "$RING_URL/deployments/$ALW_ID" \
 [ "$POLICY" = "Always" ] || fail "expected image_pull_policy=Always, got '$POLICY'"
 log "API reports image_pull_policy=$POLICY"
 
+# === Never on a missing image → ImagePullBackOff with explicit reason ===
+# Contract: with policy=Never, Ring must not contact a registry. If the
+# image isn't cached, the deployment must surface a clear failure rather
+# than appearing to work or hanging on a registry round-trip.
+NEVER_TAG="ring-e2e-never-missing:$(date +%s%N)"
+# Sanity: make sure the tag really doesn't exist locally.
+if docker inspect "$NEVER_TAG" > /dev/null 2>&1; then
+  fail "test precondition broken: $NEVER_TAG already exists locally"
+fi
+NEVER_FIXTURE="$RING_TEST_DIR/never-missing.yaml"
+cat > "$NEVER_FIXTURE" <<EOF
+deployments:
+  never-missing:
+    name: never-missing
+    namespace: ring-e2e
+    runtime: docker
+    image: $NEVER_TAG
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Never
+EOF
+"$RING_BIN" apply --file "$NEVER_FIXTURE"
+wait_deployment_status "ring-e2e" "never-missing" "image_pull_back_off" 30
+NEVER_ID=$(get_deployment_id "ring-e2e" "never-missing")
+log "never-missing reached image_pull_back_off as expected"
+
+# Verify the event message actually mentions the policy — that's the whole
+# point of the explicit error; if it falls back to a generic bollard string
+# we've regressed on operator clarity.
+EVENT_MSG=$(curl -fsS "$RING_URL/deployments/$NEVER_ID/events" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[].message' | grep -i "image_pull_policy=Never" | head -n1 || true)
+if [ -z "$EVENT_MSG" ]; then
+  fail "expected an event mentioning 'image_pull_policy=Never' on the failed deployment, got none"
+fi
+log "event message confirms policy-driven failure: $EVENT_MSG"
+
+# === Digest reference ===
+# A `name@sha256:...` reference is immutable; pulling it (or finding it in
+# the cache) addresses the exact same content forever. The parser must
+# accept it without trying to interpret `:` as a tag separator.
+DIGEST=$(docker inspect alpine:3 --format '{{index .RepoDigests 0}}' | awk -F'@' '{print $2}')
+if [ -z "$DIGEST" ]; then
+  fail "could not read alpine:3 digest from local cache"
+fi
+DIGEST_FIXTURE="$RING_TEST_DIR/alpine-digest.yaml"
+cat > "$DIGEST_FIXTURE" <<EOF
+deployments:
+  alpine-digest:
+    name: alpine-digest
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine@$DIGEST
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: IfNotPresent
+EOF
+"$RING_BIN" apply --file "$DIGEST_FIXTURE"
+wait_deployment_status "ring-e2e" "alpine-digest" "running" 60
+DIGEST_ID=$(get_deployment_id "ring-e2e" "alpine-digest")
+log "alpine-digest running with digest reference"
+
 # Cleanup
 "$RING_BIN" deployment delete "$IFNP_ID"
 "$RING_BIN" deployment delete "$ALW_ID"
+"$RING_BIN" deployment delete "$DIGEST_ID"
+"$RING_BIN" deployment delete "$NEVER_ID"
 wait_docker_container_gone "$IFNP_ID" 30
 wait_docker_container_gone "$ALW_ID" 30
+wait_docker_container_gone "$DIGEST_ID" 30
 
 log "== T16: PASS =="


### PR DESCRIPTION
## Summary

Cleans up the Docker image handling that was written quickly early on. Three concrete bugs + a stricter pull policy model, all covered by unit + e2e tests.

## Bugs fixed

| Issue | Before | After |
|---|---|---|
| `split_once(':')` on `registry.example:5000/foo/bar:v1` | name=`registry.example`, tag=`5000/foo/bar:v1` → pull fails | `parse_image_reference` only treats `:` as a tag separator inside the last path component |
| No support for `name@sha256:...` digest references | Split on first `:` produced garbage | Digest takes precedence, immutable references short-circuit the cache check |
| `image_pull_policy: Always` vs `IfNotPresent` not distinguished | Both fell through to "pull only if missing" | `Always` now genuinely re-hits the registry on cache hit; digest references still short-circuit (content-addressed, re-pull is meaningless) |
| `Never` + image absent silently produced a bollard 404 | Operator couldn't tell whether the registry was unreachable or the policy blocked the pull | Pre-check before `pull_image`: returns `ImageNotFound` with `"…not in local cache and image_pull_policy=Never forbids pulling"` |
| `extract_digest` took the first `RepoDigest` blindly | Sibling-repo digest could be recorded for the deployment | Match on the requested repo first; warn-and-fallback only when Docker normalized the name |

## Implementation

- New `parse_image_reference` returns `(repo, ImageReference::{Tag,Digest})`. 9 unit tests pin the contract including the registry-port regression.
- New `ImagePullPolicy` enum parsed case-insensitively (legacy seed data uses lowercase). Unknown values `warn!()` + fall back to `Always` rather than silently substitute.
- `pull_image` takes the policy explicitly; `Never` is rejected by `debug_assert!` (the caller handles it).
- `handle_create_error` now preserves the inner `RuntimeError::ImageNotFound`/`ImagePullFailed` detail in the emitted event, so the operator-relevant context survives.

## Test plan

- [x] `cargo test --bin ring` — 357 passed (1 redundant `extract_digest` test removed; +21 new tests for the parser, pull policy, and digest extraction).
- [x] `cargo fmt --check` clean.
- [x] `tests/e2e/docker/t16_image_pull_policy.sh` extended with two new cases:
  - `Never` + missing image → reaches `image_pull_back_off` **and** the event message mentions `image_pull_policy=Never`.
  - `alpine@sha256:...` digest reference boots and reaches `running`.
- [x] `tests/e2e/docker/t1_create_delete.sh` baseline still passes (no regression on the happy path).

## Out of scope

- Pulling a digest reference against a real remote registry (only validated against the local cache; needs a test registry container to cover end-to-end).
- `Always` semantics for digest references is a no-op by design (immutable content) — documented in the comment, not flag-controllable.