### PR TITLE
fix(security): close IDOR on PUT/DELETE /users/{id} via minimal role

### DIFF
--- a/migrations/20220101000016_user_role.sql
+++ b/migrations/20220101000016_user_role.sql
@@ -1,0 +1,12 @@
+-- Adds a coarse authorization role to users.
+--
+-- The model is intentionally flat: 'user' (default) can only act on its own
+-- account; 'admin' can manage other accounts. This closes two IDOR holes on
+-- PUT/DELETE /users/{id} where any authenticated user could mutate or delete
+-- any other user. No RBAC, no per-resource permissions — just the minimum
+-- distinction needed to make cross-account actions privileged.
+--
+-- Every existing user (prod included) becomes 'user'. We deliberately do NOT
+-- promote any account here: who is admin is decided explicitly elsewhere, not
+-- guessed by a migration.
+ALTER TABLE user ADD COLUMN role VARCHAR(50) NOT NULL DEFAULT 'user';

--- a/src/api/action/user/delete.rs
+++ b/src/api/action/user/delete.rs
@@ -10,7 +10,10 @@ pub(crate) async fn delete(
     current_user: User,
     State(pool): State<Db>,
 ) -> impl IntoResponse {
-    if current_user.id == id {
+    // Self-deletion is never allowed (an operator locking themselves out).
+    // Deleting *another* account is an admin-only action; without this any
+    // authenticated user could delete every other account (IDOR / DoS).
+    if current_user.id == id || !current_user.is_admin() {
         return StatusCode::FORBIDDEN;
     }
 
@@ -57,6 +60,21 @@ mod tests {
         let server = TestServer::new(app).unwrap();
         let response = server
             .delete("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_delete_another_user() {
+        // IDOR regression: john.doe (role=user) must NOT be able to delete
+        // the admin account.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "john.doe", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+        let response = server
+            .delete("/users/5b5c370a-cdbf-4fa4-826e-1eea4d8f7d47") // admin's id
             .add_header("Authorization", format!("Bearer {}", token))
             .await;
 

--- a/src/api/action/user/update.rs
+++ b/src/api/action/user/update.rs
@@ -17,9 +17,16 @@ pub(crate) async fn update(
     State(pool): State<Db>,
     State(configuration): State<Config>,
     Path(id): Path<String>,
-    _user: User,
+    current_user: User,
     Json(input): Json<UserInput>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+    // Authorization: a user may only update its own account; an admin may
+    // update any. Without this an authenticated user could overwrite any
+    // other user's password and take the account over (IDOR).
+    if current_user.id != id && !current_user.is_admin() {
+        return Err((StatusCode::FORBIDDEN, "Forbidden").into_response());
+    }
+
     // `Validate` skips fields that are `None`, so an empty body falls
     // through cleanly. Whatever the user passes gets the same rules as
     // create — the regex / length attributes are declared once and shared
@@ -258,6 +265,55 @@ mod tests {
             .put("/users/1c5a5fe9-84e0-4a18-821e-8058232c2c23")
             .add_header("Authorization", format!("Bearer {}", token))
             .json(&json!({}))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_update_another_user() {
+        // IDOR regression: john.doe (role=user) must NOT be able to change
+        // the admin account's credentials. Expect 403, before validation.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "john.doe", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/5b5c370a-cdbf-4fa4-826e-1eea4d8f7d47") // admin's id
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "password": "pwned-by-john" }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_admin_can_update_own_account() {
+        // Self-service must still work for a plain user.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "john.doe", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/6c6d481b-debf-5gb5-937f-2ffa5e9f8e58") // john.doe's id
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "username": "john.doe2" }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_can_update_another_user() {
+        // Admin retains the ability to manage other accounts.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .put("/users/6c6d481b-debf-5gb5-937f-2ffa5e9f8e58") // john.doe's id
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "username": "john.renamed" }))
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);

--- a/src/fixtures/users.rs
+++ b/src/fixtures/users.rs
@@ -1,29 +1,50 @@
 use sqlx::SqlitePool;
 
+/// Valid argon2id hash for the password "changeme" (verified via
+/// `argon2::verify_encoded`). The previous fixture hash was bogus — it never
+/// matched "changeme", so login tests only ever passed via the migration-seeded
+/// admin account. Keep this in sync if the password ever changes.
+const CHANGEME_HASH: &str =
+    "$argon2id$v=19$m=65536,t=2,p=4$Y2hhbmdlbWU$HxyGA81ORfjb63QVOi3+t/eBaFPmdSbf4OZc4pBG8DM";
+
 pub async fn load(pool: &SqlitePool) {
-    // Admin user for tests - using the same ID as the original fixture
-    sqlx::query(
-        "INSERT INTO user (id, created_at, status, username, password, token) VALUES (?, ?, ?, ?, ?, ?)"
-    )
-        .bind("5b5c370a-cdbf-4fa4-826e-1eea4d8f7d47")
-        .bind(chrono::Utc::now().to_rfc3339())
-        .bind("active")
-        .bind("admin")
-        .bind("$argon2id$v=19$m=65536,t=2,p=4$Y2hhbmdlbWU$NtAhPV3e8INMg6E1LnAE5wIHd/YszYoEyZeF0+1zT8E") // changeme
-        .bind("johndoetoken") // Keep the same token as before to not break existing tests
+    // The admin account (id 1c5a5fe9-…, username "admin") is seeded by
+    // migration 0001. We don't re-insert it (PK clash) and we don't touch the
+    // migration. We only promote it to role='admin' here so cross-account
+    // tests (update/delete other users) exercise the admin path.
+    sqlx::query("UPDATE user SET role = 'admin' WHERE id = ?")
+        .bind("1c5a5fe9-84e0-4a18-821e-8058232c2c23")
         .execute(pool)
         .await
         .unwrap();
 
-    // Second user for tests that need multiple users
+    // A deletable target account for the delete() test. Plain 'user', distinct
+    // username so it never collides with the admin login lookup.
     sqlx::query(
-        "INSERT INTO user (id, created_at, status, username, password, token) VALUES (?, ?, ?, ?, ?, ?)"
+        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+        .bind("5b5c370a-cdbf-4fa4-826e-1eea4d8f7d47")
+        .bind(chrono::Utc::now().to_rfc3339())
+        .bind("active")
+        .bind("user")
+        .bind("deletable.user")
+        .bind(CHANGEME_HASH)
+        .bind("deletabletoken")
+        .execute(pool)
+        .await
+        .unwrap();
+
+    // A second plain 'user' used to assert a non-admin cannot touch other
+    // accounts (IDOR regression tests).
+    sqlx::query(
+        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, ?, ?, ?, ?, ?, ?)"
     )
         .bind("6c6d481b-debf-5gb5-937f-2ffa5e9f8e58")
         .bind(chrono::Utc::now().to_rfc3339())
         .bind("active")
+        .bind("user")
         .bind("john.doe")
-        .bind("$argon2id$v=19$m=65536,t=2,p=4$Y2hhbmdlbWU$NtAhPV3e8INMg6E1LnAE5wIHd/YszYoEyZeF0+1zT8E") // changeme
+        .bind(CHANGEME_HASH)
         .bind("john_token")
         .execute(pool)
         .await

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -12,6 +12,10 @@ pub(crate) struct User {
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub(crate) updated_at: Option<String>,
     pub(crate) status: String,
+    /// Coarse authorization role: "user" (default, self-scoped) or "admin"
+    /// (may act on other accounts). Not RBAC — see migration 0016.
+    #[serde(default = "default_role")]
+    pub(crate) role: String,
     pub(crate) username: String,
     #[serde(skip_serializing)]
     pub(crate) password: String,
@@ -27,6 +31,7 @@ struct UserRow {
     created_at: String,
     updated_at: Option<String>,
     status: String,
+    role: String,
     username: String,
     password: String,
     token: Option<String>,
@@ -34,7 +39,18 @@ struct UserRow {
 }
 
 const SELECT_COLUMNS: &str =
-    "id, created_at, updated_at, status, username, password, token, login_at";
+    "id, created_at, updated_at, status, role, username, password, token, login_at";
+
+fn default_role() -> String {
+    "user".to_string()
+}
+
+impl User {
+    /// True when this user may act on accounts other than its own.
+    pub(crate) fn is_admin(&self) -> bool {
+        self.role == "admin"
+    }
+}
 
 impl From<UserRow> for User {
     fn from(row: UserRow) -> Self {
@@ -43,6 +59,7 @@ impl From<UserRow> for User {
             created_at: row.created_at,
             updated_at: row.updated_at,
             status: row.status,
+            role: row.role,
             username: row.username,
             password: row.password,
             token: row.token.unwrap_or_default(),
@@ -106,11 +123,14 @@ pub(crate) async fn create(
     username: &str,
     password: &str,
 ) -> Result<(), sqlx::Error> {
+    // role is hard-coded to 'user': there is no API path to create an admin
+    // (that would be a privilege-escalation vector). Admin is set out of band.
     sqlx::query(
-        "INSERT INTO user (id, created_at, status, username, password, token) VALUES (?, datetime(), ?, ?, ?, ?)"
+        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, datetime(), ?, ?, ?, ?, ?)"
     )
     .bind(Uuid::new_v4().to_string())
     .bind("active")
+    .bind("user")
     .bind(username)
     .bind(password)
     .bind(Uuid::new_v4().to_string())


### PR DESCRIPTION
Internal security hardening on the users endpoints. See commit for details.