### PR TITLE
refactor(auth): single auth middleware with request-extension identity

### DIFF
--- a/src/api/action/deployment/logs.rs
+++ b/src/api/action/deployment/logs.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderValue, StatusCode, header},
     response::{
         IntoResponse,
         sse::{KeepAlive, Sse},
@@ -12,10 +12,8 @@ use regex::Regex;
 use serde::Deserialize;
 use std::sync::LazyLock;
 
-use crate::api::server::{Db, RuntimeMap, TicketStoreState};
-use crate::api::stream_tickets::TicketStore;
+use crate::api::server::{Db, RuntimeMap};
 use crate::models::deployments;
-use crate::models::users as users_model;
 use crate::runtime::lifecycle_trait::Log;
 
 /// Scope string used to bind a stream ticket to a specific deployment's log
@@ -34,11 +32,10 @@ pub struct LogsQuery {
     container: Option<String>,
     #[serde(default)]
     follow: bool,
-    /// Single-use-ish stream ticket as an alternative to the bearer header.
-    /// EventSource can't set custom headers, so the dashboard mints a
-    /// scoped ticket via `POST /auth/stream-ticket` and replays it here.
-    #[serde(default)]
-    ticket: Option<String>,
+    // NOTE: the dashboard still appends `?ticket=<t>` here (EventSource can't
+    // set headers). It's consumed upstream by `api::auth::auth_middleware`;
+    // `serde_urlencoded` ignores the unknown key, so it's intentionally absent
+    // from this struct.
 }
 
 fn default_tail() -> Option<u64> {
@@ -71,15 +68,12 @@ fn parse_since(since: &str) -> Option<i32> {
 pub(crate) async fn logs(
     Path(id): Path<String>,
     Query(params): Query<LogsQuery>,
-    headers: HeaderMap,
     State(pool): State<Db>,
     State(runtimes): State<RuntimeMap>,
-    State(tickets): State<TicketStoreState>,
 ) -> impl IntoResponse {
-    if !authorize(&pool, &headers, &params.ticket, &id, &tickets).await {
-        return StatusCode::UNAUTHORIZED.into_response();
-    }
-
+    // Auth (Bearer or scoped ticket) is enforced upstream by
+    // `api::auth::auth_middleware`, which already validated the ticket against
+    // this exact `deployment:logs:<id>` scope before the request reached here.
     match deployments::find(&pool, &id).await {
         Ok(Some(deployment)) => {
             let runtime = match runtimes.get(&deployment.runtime) {
@@ -126,33 +120,6 @@ pub(crate) async fn logs(
         Ok(None) => Json(Vec::<Log>::new()).into_response(),
         Err(_) => Json(Vec::<Log>::new()).into_response(),
     }
-}
-
-/// Accept either a `Authorization: Bearer …` header or a scoped `?ticket=`
-/// query param. Returns true when the caller is authorized to read logs
-/// for `deployment_id`.
-async fn authorize(
-    pool: &Db,
-    headers: &HeaderMap,
-    ticket: &Option<String>,
-    deployment_id: &str,
-    tickets: &TicketStore,
-) -> bool {
-    if let Some(token) = bearer_token(headers) {
-        return users_model::find_by_token(pool, &token).await.is_ok();
-    }
-    if let Some(ticket) = ticket.as_deref() {
-        return tickets
-            .consume(ticket, &logs_scope(deployment_id))
-            .is_some();
-    }
-    false
-}
-
-fn bearer_token(headers: &HeaderMap) -> Option<String> {
-    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
-    let stripped = value.strip_prefix("Bearer ")?;
-    Some(stripped.to_string())
 }
 
 #[cfg(test)]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,0 +1,335 @@
+//! Centralised authentication.
+//!
+//! Auth used to be an `impl FromRequestParts for User` that every protected
+//! handler triggered by taking a `User` parameter. That made the public/private
+//! boundary an implicit per-signature convention and duplicated a DB lookup per
+//! request. It also forced the SSE logs route to re-implement auth by hand.
+//!
+//! Now a single [`auth_middleware`] resolves the caller once (Bearer token OR
+//! scoped stream ticket), puts an [`AuthContext`] in the request extensions and
+//! short-circuits with 401 otherwise. The router declares which routes the
+//! layer covers (see `server::router`), so `/login` and `/healthz` are public
+//! by construction, not by accident.
+//!
+//! Identity provenance matters: a Bearer token grants full access; a stream
+//! ticket is bound to a single `deployment:logs:<id>` scope and must NEVER
+//! authorise anything else (see [`AuthSource`] and `RequireFullAccess`).
+
+use axum::{
+    Json,
+    extract::{FromRequestParts, Request, State},
+    http::{StatusCode, header, request::Parts},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+
+use crate::api::server::AppState;
+use crate::models::users as users_model;
+use crate::models::users::User;
+
+/// How the caller proved their identity. A ticket-sourced request is only ever
+/// valid for the exact log scope the ticket was minted for.
+#[derive(Clone, Debug)]
+pub(crate) enum AuthSource {
+    /// Authenticated with a user Bearer token: full access.
+    Bearer,
+    /// Authenticated with a stream ticket scoped to this string
+    /// (e.g. `deployment:logs:<id>`): logs-only, scope-restricted.
+    // `scope` is read by `RequireFullAccess` (currently dead_code until a
+    // route adopts it) and is the audit trail of *what* a ticket unlocked;
+    // keep it even though no live path reads it yet.
+    Ticket {
+        #[allow(dead_code)]
+        scope: String,
+    },
+}
+
+/// Resolved identity for the current request, injected by [`auth_middleware`]
+/// and read back by the [`User`] extractor and the logs handler.
+#[derive(Clone, Debug)]
+pub(crate) struct AuthContext {
+    pub(crate) user: User,
+    /// Identity provenance. Consumed by `RequireFullAccess`; not yet read by a
+    /// live route, but it's the security-relevant Bearer-vs-Ticket distinction
+    /// and the future audit log's source field.
+    #[allow(dead_code)]
+    pub(crate) source: AuthSource,
+}
+
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({ "error": "Invalid token" })),
+    )
+        .into_response()
+}
+
+fn bearer_token(req: &Request) -> Option<String> {
+    let value = req.headers().get(header::AUTHORIZATION)?.to_str().ok()?;
+    value.strip_prefix("Bearer ").map(|s| s.to_string())
+}
+
+/// Pull `?ticket=<t>` out of the raw query string. We avoid the `Query`
+/// extractor here because the middleware must not consume the request body or
+/// fail other query parsing — it only cares about this one optional key.
+fn ticket_param(req: &Request) -> Option<String> {
+    let query = req.uri().query()?;
+    url::form_urlencoded::parse(query.as_bytes())
+        .find(|(k, _)| k == "ticket")
+        .map(|(_, v)| v.into_owned())
+}
+
+/// Single auth gate. Applied via `route_layer` to the protected router only;
+/// `/login` and `/healthz` live in a router without this layer.
+pub(crate) async fn auth_middleware(
+    State(state): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    // Bearer wins when present: it's the full-access path.
+    if let Some(token) = bearer_token(&req) {
+        return match users_model::find_by_token(&state.connection, &token).await {
+            Ok(user) => {
+                req.extensions_mut().insert(AuthContext {
+                    user,
+                    source: AuthSource::Bearer,
+                });
+                next.run(req).await
+            }
+            Err(_) => unauthorized(),
+        };
+    }
+
+    // Fall back to a stream ticket. A ticket is only ever valid for the exact
+    // `deployment:logs:<id>` scope it was minted for, so we derive the expected
+    // scope from the request path and let the store enforce the equality. This
+    // keeps the ticket strictly logs-only: a ticket presented on any other
+    // path won't match a logs scope and is rejected here.
+    if let Some(ticket) = ticket_param(&req) {
+        if let Some(expected_scope) = logs_scope_from_path(req.uri().path())
+            && let Some(t) = state.ticket_store.consume(&ticket, &expected_scope)
+            && let Ok(Some(user)) = users_model::find(&state.connection, &t.user_id).await
+        {
+            req.extensions_mut().insert(AuthContext {
+                user,
+                source: AuthSource::Ticket { scope: t.scope },
+            });
+            return next.run(req).await;
+        }
+        return unauthorized();
+    }
+
+    unauthorized()
+}
+
+/// Derive the expected ticket scope from the request path. Only the SSE logs
+/// route `/deployments/{id}/logs` can be reached with a ticket; any other path
+/// yields `None`, so the ticket can't authorise anything else. The scope
+/// string format is owned by `deployment::logs::logs_scope` — we call it here
+/// so the two never drift.
+fn logs_scope_from_path(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("/deployments/")?;
+    let id = rest.strip_suffix("/logs")?;
+    // Reject nested/empty segments so only the exact route shape matches.
+    if id.is_empty() || id.contains('/') {
+        return None;
+    }
+    Some(crate::api::action::deployment::logs::logs_scope(id))
+}
+
+/// `User` is now a thin read of the [`AuthContext`] the middleware installed.
+/// No header parsing, no DB hit. Fails CLOSED (500) if the context is missing,
+/// which only happens if a `User`-taking handler is mounted on a route the
+/// auth layer doesn't cover — a wiring bug we want to surface loudly, never a
+/// silent anonymous `User`.
+impl<S> FromRequestParts<S> for User
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<AuthContext>()
+            .map(|ctx| ctx.user.clone())
+            .ok_or_else(|| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "auth context missing: route not behind auth middleware" })),
+                )
+                    .into_response()
+            })
+    }
+}
+
+/// Extractor for handlers that must reject ticket-scoped identities. Use this
+/// (instead of `User`) on any route a stream ticket must not reach. The logs
+/// handler does NOT use it: it accepts tickets but checks the scope itself.
+#[allow(dead_code)]
+pub(crate) struct RequireFullAccess(pub(crate) User);
+
+impl<S> FromRequestParts<S> for RequireFullAccess
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        match parts.extensions.get::<AuthContext>() {
+            Some(ctx) => match ctx.source {
+                AuthSource::Bearer => Ok(RequireFullAccess(ctx.user.clone())),
+                AuthSource::Ticket { .. } => Err(unauthorized()),
+            },
+            None => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "auth context missing: route not behind auth middleware" })),
+            )
+                .into_response()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::logs_scope_from_path;
+    use crate::api::server::tests::{login, new_test_app};
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    #[test]
+    fn scope_only_derived_for_exact_logs_route() {
+        assert_eq!(
+            logs_scope_from_path("/deployments/abc/logs").as_deref(),
+            Some("deployment:logs:abc")
+        );
+        // Any other path must yield None so a ticket authorises nothing else.
+        assert_eq!(logs_scope_from_path("/deployments"), None);
+        assert_eq!(logs_scope_from_path("/deployments/abc"), None);
+        assert_eq!(logs_scope_from_path("/deployments/abc/events"), None);
+        assert_eq!(logs_scope_from_path("/deployments//logs"), None);
+        assert_eq!(logs_scope_from_path("/deployments/a/b/logs"), None);
+        assert_eq!(logs_scope_from_path("/secrets/abc"), None);
+        assert_eq!(logs_scope_from_path("/"), None);
+    }
+
+    #[tokio::test]
+    async fn public_routes_need_no_auth() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        // /healthz and /login live in the router without the auth layer.
+        assert_eq!(server.get("/healthz").await.status_code(), StatusCode::OK);
+        let login = server
+            .post("/login")
+            .json(&json!({ "username": "admin", "password": "changeme" }))
+            .await;
+        assert_eq!(login.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn protected_route_without_token_is_401() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        assert_eq!(
+            server.get("/deployments").await.status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_route_is_404_not_401() {
+        // The route_layer pitfall: auth must NOT turn a missing route into a
+        // 401. No token, nonexistent path → 404.
+        let server = TestServer::new(new_test_app().await).unwrap();
+        assert_eq!(
+            server.get("/does-not-exist").await.status_code(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_bearer_reaches_protected_route() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+        let res = server
+            .get("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(res.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ticket_authorizes_its_scoped_logs_route() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let mint = server
+            .post("/auth/stream-ticket")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "scope": "deployment:logs:dep1" }))
+            .await;
+        let ticket = mint.json::<serde_json::Value>()["ticket"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Same deployment id as the ticket scope → middleware lets it through
+        // (handler then returns empty logs for an unknown deployment).
+        let res = server
+            .get("/deployments/dep1/logs")
+            .add_query_param("ticket", &ticket)
+            .await;
+        assert_eq!(res.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ticket_rejected_on_different_deployment_scope() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let mint = server
+            .post("/auth/stream-ticket")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "scope": "deployment:logs:dep1" }))
+            .await;
+        let ticket = mint.json::<serde_json::Value>()["ticket"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Ticket minted for dep1 must NOT open dep2's logs.
+        let res = server
+            .get("/deployments/dep2/logs")
+            .add_query_param("ticket", &ticket)
+            .await;
+        assert_eq!(res.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn ticket_does_not_authorize_non_logs_route() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let mint = server
+            .post("/auth/stream-ticket")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "scope": "deployment:logs:dep1" }))
+            .await;
+        let ticket = mint.json::<serde_json::Value>()["ticket"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // A ticket is logs-only: presenting it on any other protected route
+        // must be rejected (no logs scope derivable from this path).
+        let res = server
+            .get("/deployments")
+            .add_query_param("ticket", &ticket)
+            .await;
+        assert_eq!(res.status_code(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod action;
+pub(crate) mod auth;
 pub(crate) mod dto;
 pub(crate) mod server;
 pub(crate) mod stream_tickets;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,17 +1,12 @@
 use axum::{
-    Json, RequestPartsExt, Router,
+    Router,
     error_handling::HandleErrorLayer,
-    extract::{FromRef, FromRequestParts},
-    http::{HeaderValue, Method, StatusCode, header, request::Parts},
+    http::{HeaderValue, Method, StatusCode, header},
+    middleware::from_fn_with_state,
     routing::{delete, get, post, put},
-};
-use axum_extra::{
-    TypedHeader,
-    headers::{Authorization, authorization::Bearer},
 };
 use axum_macros::FromRef;
 use log::{error, info, warn};
-use serde_json::json;
 use sqlx::SqlitePool;
 use std::time::Duration;
 
@@ -55,42 +50,13 @@ use crate::api::action::secret::list as secret_list;
 
 use crate::api::action::healthz::healthz;
 
-use crate::models::users as users_model;
-use crate::models::users::User;
+use crate::api::auth::auth_middleware;
 
 pub(crate) type Db = SqlitePool;
 
-impl<S> FromRequestParts<S> for User
-where
-    AppState: FromRef<S>,
-    S: Send + Sync,
-{
-    type Rejection = (StatusCode, Json<serde_json::Value>);
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let TypedHeader(Authorization(bearer)) = parts
-            .extract::<TypedHeader<Authorization<Bearer>>>()
-            .await
-            .map_err(|_| {
-                (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({ "error": "Invalid token" })),
-                )
-            })?;
-
-        let token = bearer.token();
-        let app_state = AppState::from_ref(state);
-
-        let user = users_model::find_by_token(&app_state.connection, token).await;
-        match user {
-            Ok(user) => Ok(user),
-            Err(_) => Err((
-                StatusCode::UNAUTHORIZED,
-                Json(json!({ "error": "Invalid token" })),
-            )),
-        }
-    }
-}
+// Authentication lives in `crate::api::auth`: a single middleware resolves the
+// caller and the `User` extractor just reads the resulting `AuthContext` from
+// request extensions.
 
 pub(crate) type RuntimeMap = std::sync::Arc<
     std::collections::HashMap<
@@ -110,12 +76,22 @@ pub(crate) struct AppState {
 }
 
 pub(crate) fn router(state: AppState) -> Router {
-    // Routes that support long-lived connections (SSE streaming) - no timeout
-    let streaming_routes = Router::new().route("/deployments/{id}/logs", get(deployment_logs));
-
-    // All other routes with timeout
-    let api_routes = Router::new()
+    // Public routes: no auth layer, by construction. Keeping these in their
+    // own router (instead of relying on merge() + route_layer scoping, which
+    // axum does not document) makes the public surface unambiguous.
+    let public_routes = Router::new()
         .route("/login", post(login))
+        .route("/healthz", get(healthz));
+
+    // SSE: protected, but NO timeout layer — a tower Timeout would kill the
+    // long-lived stream. The auth middleware only wraps the request→response
+    // head, so it doesn't interfere with the streaming body.
+    let streaming_routes = Router::new()
+        .route("/deployments/{id}/logs", get(deployment_logs))
+        .route_layer(from_fn_with_state(state.clone(), auth_middleware));
+
+    // All other routes: protected + 10s timeout.
+    let api_routes = Router::new()
         .route("/auth/stream-ticket", post(stream_ticket))
         .route("/deployments", get(deployment_list).post(deployment_create))
         .route(
@@ -139,7 +115,9 @@ pub(crate) fn router(state: AppState) -> Router {
         .route("/users/{id}", put(user_update))
         .route("/users/{id}", delete(user_delete))
         .route("/users/me", get(user_current))
-        .route("/healthz", get(healthz))
+        // Auth via route_layer: runs only when a route matches (so a 404
+        // stays a 404, not a 401) and is scoped to this router's routes.
+        .route_layer(from_fn_with_state(state.clone(), auth_middleware))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(|error: BoxError| async move {
@@ -159,6 +137,7 @@ pub(crate) fn router(state: AppState) -> Router {
     let cors_origins = state.configuration.api.cors_origins.clone();
 
     let mut app = Router::new()
+        .merge(public_routes)
         .merge(streaming_routes)
         .merge(api_routes)
         .with_state(state);


### PR DESCRIPTION
Centralises authentication into a single middleware instead of a per-handler
`User` extractor.

- One auth gate, applied at the router so the public/protected boundary is
  declared rather than implied by handler signatures.
- Identity is resolved once and passed via request extension; the `User`
  extractor reads it and fails closed if absent.
- The SSE logs route no longer carries its own auth path; it goes through the
  same middleware. Stream tickets remain strictly scoped to their logs route.

Behaviour is unchanged for clients. Tests cover the public/protected split,
unmatched routes staying 404, and ticket scope boundaries.
