### PR TITLE
fix(security): unique random salt per password hash

### DIFF
--- a/documentation/help/faq.md
+++ b/documentation/help/faq.md
@@ -75,7 +75,6 @@ current = true
 host = "127.0.0.1"
 api.scheme = "http"
 api.port = 8080            # change here
-user.salt = "changeme"
 ```
 
 Then restart `ring server start`.

--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -30,7 +30,7 @@ Another process owns the port. Either stop it:
 sudo ss -tlnp | grep 3030              # find the PID
 ```
 
-Or change Ring's port in `~/.config/kemeter/ring/config.toml`. The full schema requires `current`, `host`, `api`, and `user`:
+Or change Ring's port in `~/.config/kemeter/ring/config.toml`. The schema requires `current`, `host`, and `api`:
 
 ```toml
 [contexts.default]
@@ -39,8 +39,6 @@ host = "127.0.0.1"
 
 api.scheme = "http"
 api.port = 3031                        # was 3030
-
-user.salt = "your-salt"
 ```
 
 See [reference: config.toml](/documentation/reference/config-toml) for every field.

--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -66,7 +66,6 @@ current = true
 host = "127.0.0.1"
 api.scheme = "http"
 api.port = 3030
-user.salt = "changeme"
 
 [contexts.default.runtime.cloud_hypervisor]
 firmware_path = "/path/to/hypervisor-fw"      # optional, defaults to ~/.config/kemeter/ring/cloud-hypervisor/vmlinux

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -443,14 +443,12 @@ current = true
 host = "127.0.0.1"
 api.scheme = "http"
 api.port = 3030
-user.salt = "changeme"
 
 [contexts.production]
 current = false
 host = "prod.example.com"
 api.scheme = "https"
 api.port = 443
-user.salt = "changeme"
 
 [scheduler]
 interval = 10

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -42,11 +42,7 @@ You can declare multiple `[contexts.<name>]` tables in the same file. The one wi
 | `port` | int | yes | — | TCP port. Default in the auto-fallback context is `3030`; explicit configs must set it |
 | `cors_origins` | array of string | no | `[]` | List of `Origin` values allowed by the API's CORS layer. Leave empty to disallow browser cross-origin calls |
 
-### `[contexts.<name>.user]`
-
-| Field | Type | Required | Default | Purpose |
-|---|---|---|---|---|
-| `salt` | string | yes | — | Salt used in the password-hashing pipeline. **Change from `"changeme"`** before exposing the API. Changing the salt invalidates all existing password hashes |
+> **No password salt to configure.** Earlier versions required a `[contexts.<name>.user]` table with a global `salt`. Ring now generates a unique random salt for every password hash, so there is nothing to set or keep secret. A leftover `user.salt` line in an existing config is ignored.
 
 ### `[contexts.<name>.scheduler]`
 
@@ -82,8 +78,6 @@ host = "127.0.0.1"
 
 api.scheme = "http"
 api.port = 3030
-
-user.salt = "$(openssl rand -hex 16)"     # replace with a real value
 ```
 
 ### Production with Cloud Hypervisor and TLS-fronted API
@@ -96,8 +90,6 @@ host = "0.0.0.0"
 api.scheme = "https"                       # because nginx in front terminates TLS
 api.port = 3030
 api.cors_origins = ["https://dashboard.example.com"]
-
-user.salt = "..."                          # your own value, kept secret
 
 [contexts.default.scheduler]
 interval = 5
@@ -119,21 +111,18 @@ current = true
 host = "127.0.0.1"
 api.scheme = "http"
 api.port = 3030
-user.salt = "local-dev-salt"
 
 [contexts.staging]
 current = false
 host = "ring-staging.example.com"
 api.scheme = "https"
 api.port = 443
-user.salt = "shared-with-staging-server"
 
 [contexts.production]
 current = false
 host = "ring-prod.example.com"
 api.scheme = "https"
 api.port = 443
-user.salt = "shared-with-prod-server"
 ```
 
 Switch context per command:

--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -149,7 +149,7 @@ Continue with [Your first deployment](/documentation/tutorials/first-deployment)
 
 **`Failed to connect to Docker daemon`** — the daemon isn't running, or your user isn't in the `docker` group. Run `sudo systemctl start docker`, and if needed `sudo usermod -aG docker $USER` then log out and back in.
 
-**`Port 3030 already in use`** — another process owns the port. Either stop it (`sudo ss -tlnp | grep 3030` to find the PID) or change Ring's port in `~/.config/kemeter/ring/config.toml`. The full file requires `current`, `host`, `api`, and `user`:
+**`Port 3030 already in use`** — another process owns the port. Either stop it (`sudo ss -tlnp | grep 3030` to find the PID) or change Ring's port in `~/.config/kemeter/ring/config.toml`. The file requires `current`, `host`, and `api`:
 
 ```toml
 [contexts.default]
@@ -158,8 +158,6 @@ host = "127.0.0.1"
 
 api.scheme = "http"
 api.port = 3031
-
-user.salt = "your-salt"
 ```
 
 See [reference: config.toml](/documentation/reference/config-toml) for every field.

--- a/src/api/action/user/create.rs
+++ b/src/api/action/user/create.rs
@@ -4,7 +4,6 @@ use crate::api::action::user::validation::{
 use crate::api::dto::user::UserOutput;
 use crate::api::server::Db;
 use crate::api::validation::ViolationList;
-use crate::config::config::Config;
 use crate::models::users as users_model;
 use crate::models::users::User;
 use axum::response::{IntoResponse, Response};
@@ -15,7 +14,6 @@ use validator::Validate;
 
 pub(crate) async fn create(
     State(pool): State<Db>,
-    State(configuration): State<Config>,
     _user: User,
     Json(input): Json<UserInput>,
 ) -> Result<(StatusCode, Json<UserOutput>), Response> {
@@ -24,14 +22,13 @@ pub(crate) async fn create(
         return Err(violations.into_response());
     }
 
-    let password_hash = users_model::hash_password(&input.password, &configuration.user.salt)
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "errors": ["Password hashing failed"] })),
-            )
-                .into_response()
-        })?;
+    let password_hash = users_model::hash_password(&input.password).map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "errors": ["Password hashing failed"] })),
+        )
+            .into_response()
+    })?;
 
     users_model::create(&pool, &input.username, &password_hash)
         .await

--- a/src/api/action/user/update.rs
+++ b/src/api/action/user/update.rs
@@ -3,7 +3,6 @@ use crate::api::action::user::validation::{
 };
 use crate::api::server::Db;
 use crate::api::validation::ViolationList;
-use crate::config::config::Config;
 use crate::models::users as users_model;
 use crate::models::users::User;
 use axum::extract::State;
@@ -15,7 +14,6 @@ use validator::Validate;
 
 pub(crate) async fn update(
     State(pool): State<Db>,
-    State(configuration): State<Config>,
     Path(id): Path<String>,
     current_user: User,
     Json(input): Json<UserInput>,
@@ -46,14 +44,13 @@ pub(crate) async fn update(
     }
 
     if let Some(password) = input.password {
-        let password_hash = users_model::hash_password(&password, &configuration.user.salt)
-            .map_err(|_| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "errors": ["Password hashing failed"] })),
-                )
-                    .into_response()
-            })?;
+        let password_hash = users_model::hash_password(&password).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "errors": ["Password hashing failed"] })),
+            )
+                .into_response()
+        })?;
 
         user.password = password_hash;
     }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -114,7 +114,6 @@ pub(crate) struct Config {
     pub(crate) name: String,
     pub(crate) host: String,
     pub(crate) api: config::api::Api,
-    pub(crate) user: config::user::User,
     #[serde(default)]
     pub(crate) scheduler: Scheduler,
     #[serde(default)]
@@ -146,9 +145,6 @@ impl Default for Config {
                 scheme: "http".to_string(),
                 port: 3030,
                 cors_origins: Vec::new(),
-            },
-            user: config::user::User {
-                salt: "changeme".to_string(),
             },
             scheduler: Scheduler::default(),
             docker: DockerConfig::default(),
@@ -345,7 +341,6 @@ host = "0.0.0.0"
 current = true
 api.scheme = "http"
 api.port = 3030
-user.salt = "changeme"
 
 [contexts.dev.runtime.cloud_hypervisor]
 seccomp = "false"
@@ -355,7 +350,6 @@ host = "10.0.0.1"
 current = false
 api.scheme = "http"
 api.port = 3030
-user.salt = "changeme"
 "#;
 
     #[test]
@@ -397,7 +391,6 @@ host = "1.1.1.1"
 current = false
 api.scheme = "http"
 api.port = 3030
-user.salt = "x"
 "#;
         let contexts = make_contexts(toml_str);
         assert!(pick_context(contexts, "missing").is_none());

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -1,6 +1,0 @@
-use serde::Deserialize;
-
-#[derive(Deserialize, Debug, Clone)]
-pub(crate) struct User {
-    pub(crate) salt: String,
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,6 @@ mod api;
 mod config {
     pub(crate) mod api;
     pub(crate) mod config;
-    pub(crate) mod user;
 }
 
 mod dashboard;

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -1,3 +1,5 @@
+use aes_gcm::aead::OsRng;
+use aes_gcm::aead::rand_core::RngCore;
 use argon2::{self, Config as Argon2Config};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
@@ -160,8 +162,21 @@ pub(crate) async fn delete(pool: &SqlitePool, user: &User) -> Result<(), sqlx::E
     Ok(())
 }
 
-/// Hash a password using Argon2id
-pub(crate) fn hash_password(password: &str, salt: &str) -> Result<String, argon2::Error> {
+/// Hash a password using Argon2id with a unique, randomly generated salt.
+///
+/// The salt MUST be unique per password (OWASP Password Storage): a shared or
+/// static salt lets an attacker who obtains the database attack every hash in
+/// parallel and reveals which users share a password. `hash_encoded` embeds
+/// this salt in the returned string, so `verify_encoded` reads it back from
+/// the stored hash — no salt needs to be carried in config.
+///
+/// We use `OsRng` (OS entropy) rather than a thread-local PRNG: Ring forks
+/// processes (the scheduler), and a userspace CSPRNG isn't guaranteed to
+/// reseed across fork. This mirrors the nonce generation in `models::secret`.
+pub(crate) fn hash_password(password: &str) -> Result<String, argon2::Error> {
+    let mut salt = [0u8; 16];
+    OsRng.fill_bytes(&mut salt);
+
     let argon2_config = Argon2Config {
         variant: argon2::Variant::Argon2id,
         version: argon2::Version::Version13,
@@ -173,5 +188,40 @@ pub(crate) fn hash_password(password: &str, salt: &str) -> Result<String, argon2
         hash_length: 32,
     };
 
-    argon2::hash_encoded(password.as_bytes(), salt.as_bytes(), &argon2_config)
+    argon2::hash_encoded(password.as_bytes(), &salt, &argon2_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash_password;
+
+    #[test]
+    fn same_password_yields_distinct_hashes() {
+        // Unique per-password salt (OWASP): the same password hashed twice
+        // must not collide, otherwise shared passwords are detectable in DB.
+        let a = hash_password("hunter2").unwrap();
+        let b = hash_password("hunter2").unwrap();
+        assert_ne!(a, b, "salt is not unique per call");
+    }
+
+    #[test]
+    fn fresh_hash_verifies() {
+        let h = hash_password("hunter2").unwrap();
+        assert!(argon2::verify_encoded(&h, b"hunter2").unwrap());
+        assert!(!argon2::verify_encoded(&h, b"wrong").unwrap());
+    }
+
+    #[test]
+    fn legacy_shared_salt_hash_still_verifies() {
+        // Regression guard: accounts created by the OLD code path used a
+        // shared static salt. argon2 embeds the salt in the encoded string,
+        // so `verify_encoded` reads it back from the stored hash — switching
+        // hash_password to a random salt must NOT lock out existing users.
+        // This is a real "changeme"/salt="changeme" argon2id hash.
+        let legacy = "$argon2id$v=19$m=65536,t=2,p=4$Y2hhbmdlbWU$HxyGA81ORfjb63QVOi3+t/eBaFPmdSbf4OZc4pBG8DM";
+        assert!(
+            argon2::verify_encoded(legacy, b"changeme").unwrap(),
+            "an existing account's password must still verify after the fix"
+        );
+    }
 }


### PR DESCRIPTION
Password hashing now generates a unique, random salt per password instead of
using a single shared value from configuration. This aligns with OWASP
Password Storage guidance (salt must be unique per password).

- `hash_password` derives a fresh random salt internally (OS entropy, same
  source already used for nonce generation); the salt is embedded in the
  encoded Argon2id string as before.
- The configuration salt field is removed, along with its dead module.

Existing stored hashes keep their embedded salt, so verification is
unaffected — no migration, no forced password reset. Tests cover salt
uniqueness, fresh-hash verification, and backward verification of
previously-stored hashes.
