### PR TITLE
feat(audit): namespace-scoped audit log

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -209,6 +209,21 @@ export function listNamespaces(): Promise<Namespace[]> {
   return request<Namespace[]>('/namespaces');
 }
 
+export interface AuditEntry {
+  id: string;
+  timestamp: string;
+  user_id: string | null;
+  action: string;
+  target_type: string;
+  target_name: string;
+  namespace: string | null;
+}
+
+export function getNamespaceAudit(name: string, limit?: number): Promise<AuditEntry[]> {
+  const q = limit ? `?limit=${limit}` : '';
+  return request<AuditEntry[]>(`/namespaces/${encodeURIComponent(name)}/audit${q}`);
+}
+
 export function getDeployment(id: string): Promise<DeploymentDetail> {
   return request<DeploymentDetail>(`/deployments/${encodeURIComponent(id)}`);
 }

--- a/dashboard/src/routes/namespaces/+page.svelte
+++ b/dashboard/src/routes/namespaces/+page.svelte
@@ -103,6 +103,7 @@
           <th class="num">Running</th>
           <th>Created</th>
           <th>Updated</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -125,6 +126,9 @@
             </td>
             <td class="muted">{formatDate(ns.created_at)}</td>
             <td class="muted">{ns.updated_at ? formatDate(ns.updated_at) : '—'}</td>
+            <td>
+              <a class="ns-link" href="/namespaces/{ns.name}/audit">Audit</a>
+            </td>
           </tr>
         {/each}
       </tbody>

--- a/dashboard/src/routes/namespaces/[name]/audit/+page.svelte
+++ b/dashboard/src/routes/namespaces/[name]/audit/+page.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { getNamespaceAudit, type AuditEntry } from '$lib/api';
+  import { getToken } from '$lib/auth';
+  import { formatDate, timeAgo } from '$lib/utils';
+
+  let name = $derived($page.params.name ?? '');
+  let entries = $state<AuditEntry[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function refresh() {
+    try {
+      entries = await getNamespaceAudit(name);
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function actionClass(action: string): string {
+    if (action === 'delete') return 'warn';
+    if (action === 'create') return 'success';
+    return '';
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Audit — {name}</h1>
+    <p class="subtitle">Who changed what in this namespace</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <a class="btn-secondary" href="/namespaces">Back</a>
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && entries.length > 0}
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>User</th>
+          <th>Action</th>
+          <th>Type</th>
+          <th>Target</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each entries as e (e.id)}
+          <tr>
+            <td class="muted">{formatDate(e.timestamp)}</td>
+            <td class="mono">{e.user_id ?? '—'}</td>
+            <td>
+              <span class="dot-inline {actionClass(e.action)}"></span>{e.action}
+            </td>
+            <td class="muted">{e.target_type}</td>
+            <td class="mono">{e.target_name}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && entries.length === 0 && !errorMsg}
+  <div class="empty">
+    <p>No audit entries for <code>{name}</code>.</p>
+    <p class="muted">
+      Write actions (create / update / delete on deployments, secrets, configs) are recorded here as
+      they happen.
+    </p>
+  </div>
+{/if}

--- a/dashboard/src/routes/namespaces/[name]/audit/+page.ts
+++ b/dashboard/src/routes/namespaces/[name]/audit/+page.ts
@@ -1,0 +1,5 @@
+// Dynamic namespace audit page: skip prerendering (no fixed namespace names
+// to enumerate at build time). The SPA fallback served by adapter-static
+// routes the request to this page at runtime.
+export const prerender = false;
+export const ssr = false;

--- a/migrations/20220101000017_audit_log.sql
+++ b/migrations/20220101000017_audit_log.sql
@@ -1,0 +1,30 @@
+-- Lightweight audit log of write actions, scoped by namespace.
+--
+-- Purpose: "who did what" — e.g. <user-id> created deployment <name> in
+-- namespace <ns>. This is intentionally NOT a clone of deployment_event
+-- (which is per-deployment runtime telemetry): it survives the deletion of
+-- an individual deployment so a post-mortem stays possible after cleanup.
+--
+-- Retention is tied to the namespace: rows are kept regardless of the
+-- target's lifecycle, but the whole namespace's audit trail is removed when
+-- the namespace itself is deleted (handled in application code, no FK so the
+-- log can outlive a deleted target row).
+CREATE TABLE IF NOT EXISTS audit_log (
+    id VARCHAR(255) PRIMARY KEY,
+    timestamp DATETIME NOT NULL,
+    -- Author: the authenticated user's id (User.id from AuthContext). May be
+    -- NULL only for actions with no resolvable user (defensive; not expected).
+    user_id VARCHAR(255),
+    -- e.g. "create", "update", "delete".
+    action VARCHAR(50) NOT NULL,
+    -- e.g. "deployment", "secret", "config", "namespace".
+    target_type VARCHAR(50) NOT NULL,
+    -- Human-facing name of the affected resource (deployment name, etc.).
+    target_name VARCHAR(255) NOT NULL,
+    -- Namespace the action belongs to. NULL for namespace-level actions that
+    -- have no parent namespace context.
+    namespace VARCHAR(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_namespace ON audit_log(namespace);
+CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);

--- a/src/api/action/config/create.rs
+++ b/src/api/action/config/create.rs
@@ -6,6 +6,7 @@ use crate::api::action::namespace::validation::{
 };
 use crate::api::server::Db;
 use crate::api::validation::{ViolationList, problem_response};
+use crate::models::audit_log;
 use crate::models::config;
 use crate::models::users::User;
 use axum::Json;
@@ -65,7 +66,7 @@ pub(crate) struct ConfigInput {
 
 pub(crate) async fn create(
     State(pool): State<Db>,
-    _user: User,
+    user: User,
     Json(input): Json<ConfigInput>,
 ) -> Response {
     if let Err(errs) = input.validate() {
@@ -85,11 +86,22 @@ pub(crate) async fn create(
     };
 
     match config::create(&pool, new_config.clone()).await {
-        Ok(_) => (
-            StatusCode::CREATED,
-            Json(serde_json::to_value(new_config).unwrap()),
-        )
-            .into_response(),
+        Ok(_) => {
+            let _ = audit_log::record(
+                &pool,
+                Some(&user.id),
+                "create",
+                "config",
+                &new_config.name,
+                Some(&new_config.namespace),
+            )
+            .await;
+            (
+                StatusCode::CREATED,
+                Json(serde_json::to_value(new_config).unwrap()),
+            )
+                .into_response()
+        }
         Err(e) if e.to_string().contains("UNIQUE constraint failed") => problem_response(
             StatusCode::CONFLICT,
             "Conflict",

--- a/src/api/action/config/delete.rs
+++ b/src/api/action/config/delete.rs
@@ -18,14 +18,14 @@ pub(crate) async fn delete(
         Ok(None) => return StatusCode::NOT_FOUND,
         Err(err) => {
             log::error!("Failed to look up configuration {}: {}", id, err);
-            return StatusCode::NOT_FOUND;
+            return StatusCode::INTERNAL_SERVER_ERROR;
         }
     };
 
     let result = ConfigModel::delete(&pool, &id).await;
     if let Err(ref err) = result {
         log::error!("Failed to delete configuration with ID {}: {}", id, err);
-        return StatusCode::NOT_FOUND;
+        return StatusCode::INTERNAL_SERVER_ERROR;
     }
 
     let _ = audit_log::record(

--- a/src/api/action/config/delete.rs
+++ b/src/api/action/config/delete.rs
@@ -2,19 +2,41 @@ use axum::extract::{Path, State};
 use http::StatusCode;
 
 use crate::api::server::Db;
+use crate::models::audit_log;
 use crate::models::config as ConfigModel;
 use crate::models::users::User;
 
 pub(crate) async fn delete(
     Path(id): Path<String>,
     State(pool): State<Db>,
-    _user: User,
+    user: User,
 ) -> StatusCode {
+    // Load the row before deleting so the audit entry carries the real
+    // namespace and name (same pattern as deployment/secret delete).
+    let config = match ConfigModel::find(&pool, &id).await {
+        Ok(Some(c)) => c,
+        Ok(None) => return StatusCode::NOT_FOUND,
+        Err(err) => {
+            log::error!("Failed to look up configuration {}: {}", id, err);
+            return StatusCode::NOT_FOUND;
+        }
+    };
+
     let result = ConfigModel::delete(&pool, &id).await;
     if let Err(ref err) = result {
         log::error!("Failed to delete configuration with ID {}: {}", id, err);
         return StatusCode::NOT_FOUND;
     }
+
+    let _ = audit_log::record(
+        &pool,
+        Some(&user.id),
+        "delete",
+        "config",
+        &config.name,
+        Some(&config.namespace),
+    )
+    .await;
 
     StatusCode::NO_CONTENT
 }

--- a/src/api/action/config/update.rs
+++ b/src/api/action/config/update.rs
@@ -10,6 +10,7 @@ use crate::api::action::config::validation::{
 use crate::api::dto::config::ConfigOutput;
 use crate::api::server::Db;
 use crate::api::validation::{Violation, ViolationList, problem_response};
+use crate::models::audit_log;
 use crate::models::config as ConfigModel;
 use crate::models::users::User;
 
@@ -50,7 +51,7 @@ pub(crate) struct UpdateConfigRequest {
 pub(crate) async fn update(
     Path(id): Path<String>,
     State(pool): State<Db>,
-    _user: User,
+    user: User,
     Json(request): Json<UpdateConfigRequest>,
 ) -> Response {
     let mut violations: ViolationList = match request.validate() {
@@ -84,6 +85,15 @@ pub(crate) async fn update(
 
             match ConfigModel::update(&pool, config.clone()).await {
                 Ok(_) => {
+                    let _ = audit_log::record(
+                        &pool,
+                        Some(&user.id),
+                        "update",
+                        "config",
+                        &config.name,
+                        Some(&config.namespace),
+                    )
+                    .await;
                     let output = ConfigOutput::from_to_model(config);
                     (StatusCode::OK, Json(output)).into_response()
                 }

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -16,6 +16,7 @@ use validator::{Validate, ValidationError};
 use crate::api::dto::deployment::DeploymentOutput;
 use crate::api::server::Db;
 use crate::api::validation::{Violation, ViolationList};
+use crate::models::audit_log;
 use crate::models::deployment_event;
 use crate::models::deployments;
 use crate::models::deployments::{
@@ -471,7 +472,7 @@ pub(crate) struct CreateQueryParams {
 
 pub(crate) async fn create(
     State(pool): State<Db>,
-    _user: User,
+    user: User,
     Query(params): Query<CreateQueryParams>,
     Json(input): Json<DeploymentInput>,
 ) -> impl IntoResponse {
@@ -707,6 +708,16 @@ pub(crate) async fn create(
                 )
                 .await;
             }
+
+            let _ = audit_log::record(
+                &pool,
+                Some(&user.id),
+                "create",
+                "deployment",
+                &input.name,
+                Some(&input.namespace),
+            )
+            .await;
 
             let deployment_output = DeploymentOutput::from_to_model(deployment);
             (StatusCode::CREATED, Json(deployment_output)).into_response()

--- a/src/api/action/deployment/delete.rs
+++ b/src/api/action/deployment/delete.rs
@@ -2,13 +2,14 @@ use axum::extract::State;
 use axum::{extract::Path, http::StatusCode, response::IntoResponse};
 
 use crate::api::server::Db;
+use crate::models::audit_log;
 use crate::models::deployments::{self, DeploymentStatus};
 use crate::models::users::User;
 
 pub(crate) async fn delete(
     Path(id): Path<String>,
     State(pool): State<Db>,
-    _user: User,
+    user: User,
 ) -> impl IntoResponse {
     let option = deployments::find(&pool, &id).await;
 
@@ -16,7 +17,18 @@ pub(crate) async fn delete(
         Ok(Some(mut deployment)) => {
             deployment.status = DeploymentStatus::Deleted;
             match deployments::update(&pool, &deployment).await {
-                Ok(_) => StatusCode::NO_CONTENT,
+                Ok(_) => {
+                    let _ = audit_log::record(
+                        &pool,
+                        Some(&user.id),
+                        "delete",
+                        "deployment",
+                        &deployment.name,
+                        Some(&deployment.namespace),
+                    )
+                    .await;
+                    StatusCode::NO_CONTENT
+                }
                 Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
             }
         }

--- a/src/api/action/namespace/audit.rs
+++ b/src/api/action/namespace/audit.rs
@@ -1,0 +1,108 @@
+use axum::extract::{Path, Query, State};
+use axum::{Json, response::IntoResponse};
+use serde::Deserialize;
+
+use crate::api::dto::audit::AuditOutput;
+use crate::api::server::Db;
+use crate::models::audit_log;
+use crate::models::users::User;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AuditQuery {
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
+/// `GET /namespaces/{name}/audit` — the write-action trail for a namespace,
+/// most recent first. Returns an empty list for an unknown namespace (the
+/// trail is keyed by name, not by a namespace row, so it stays readable even
+/// after the namespace itself is gone within the retention window).
+pub(crate) async fn audit(
+    Path(name): Path<String>,
+    Query(params): Query<AuditQuery>,
+    _user: User,
+    State(pool): State<Db>,
+) -> impl IntoResponse {
+    let entries = match audit_log::find_by_namespace(&pool, &name, params.limit).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::error!("Failed to read audit log for namespace '{}': {}", name, e);
+            return Json(Vec::<AuditOutput>::new());
+        }
+    };
+
+    Json(
+        entries
+            .into_iter()
+            .map(AuditOutput::from_to_model)
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::dto::audit::AuditOutput;
+    use crate::api::server::tests::{login, new_test_app};
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn audit_lists_namespace_write_actions() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // Two write actions in the same namespace.
+        server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "prod" }))
+            .await;
+        server
+            .post("/configs")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "namespace": "prod",
+                "name": "nginx-conf",
+                "data": "{}"
+            }))
+            .await;
+
+        let response = server
+            .get("/namespaces/prod/audit")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        let entries = response.json::<Vec<AuditOutput>>();
+        assert_eq!(entries.len(), 2);
+        // Most recent first: the config create, then the namespace create.
+        assert_eq!(entries[0].target_type, "config");
+        assert_eq!(entries[0].action, "create");
+        assert_eq!(entries[1].target_type, "namespace");
+    }
+
+    #[tokio::test]
+    async fn audit_requires_authentication() {
+        let app = new_test_app().await;
+        let server = TestServer::new(app).unwrap();
+        let response = server.get("/namespaces/prod/audit").await;
+        assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn audit_unknown_namespace_is_empty() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response = server
+            .get("/namespaces/does-not-exist/audit")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert!(response.json::<Vec<AuditOutput>>().is_empty());
+    }
+}

--- a/src/api/action/namespace/create.rs
+++ b/src/api/action/namespace/create.rs
@@ -4,6 +4,7 @@ use crate::api::action::namespace::validation::{
 use crate::api::dto::namespace::NamespaceOutput;
 use crate::api::server::Db;
 use crate::api::validation::{ViolationList, problem_response};
+use crate::models::audit_log;
 use crate::models::namespace;
 use crate::models::users::User;
 use axum::Json;
@@ -35,7 +36,7 @@ pub(crate) struct NamespaceInput {
 
 pub(crate) async fn create(
     State(pool): State<Db>,
-    _user: User,
+    user: User,
     Json(input): Json<NamespaceInput>,
 ) -> Response {
     if let Err(errs) = input.validate() {
@@ -53,6 +54,17 @@ pub(crate) async fn create(
 
     match namespace::create(&pool, new_namespace.clone()).await {
         Ok(_) => {
+            // A namespace's own creation is recorded under its own name so it
+            // shows up in `ring namespace audit <ns>` for that namespace.
+            let _ = audit_log::record(
+                &pool,
+                Some(&user.id),
+                "create",
+                "namespace",
+                &new_namespace.name,
+                Some(&new_namespace.name),
+            )
+            .await;
             let output = NamespaceOutput::from_to_model(new_namespace);
             (
                 StatusCode::CREATED,
@@ -80,7 +92,8 @@ pub(crate) async fn create(
 mod tests {
     use crate::api::dto::namespace::NamespaceOutput;
     use crate::api::server::tests::login;
-    use crate::api::server::tests::new_test_app;
+    use crate::api::server::tests::{new_test_app, new_test_app_with_pool};
+    use crate::models::audit_log;
     use axum::http::StatusCode;
     use axum_test::TestServer;
     use serde_json::json;
@@ -100,6 +113,34 @@ mod tests {
         assert_eq!(response.status_code(), StatusCode::CREATED);
         let namespace = response.json::<NamespaceOutput>();
         assert_eq!(namespace.name, "production");
+    }
+
+    #[tokio::test]
+    async fn create_namespace_writes_an_audit_entry() {
+        let (pool, app) = new_test_app_with_pool().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response = server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "production" }))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+
+        // The write must have produced a namespace-scoped audit entry naming
+        // the action, target and author.
+        let entries = audit_log::find_by_namespace(&pool, "production", None)
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].action, "create");
+        assert_eq!(entries[0].target_type, "namespace");
+        assert_eq!(entries[0].target_name, "production");
+        assert!(
+            entries[0].user_id.is_some(),
+            "audit entry must carry the authenticated user's id"
+        );
     }
 
     #[tokio::test]

--- a/src/api/action/namespace/delete.rs
+++ b/src/api/action/namespace/delete.rs
@@ -1,0 +1,185 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::api::server::Db;
+use crate::models::audit_log;
+use crate::models::namespace;
+use crate::models::users::User;
+
+/// `DELETE /namespaces/{name}` — remove an empty namespace and purge its
+/// audit trail (retention is namespace-bound by design).
+///
+/// Refuses with 409 if the namespace still holds live deployments, secrets
+/// or configs: we never cascade-delete an operator's resources.
+// The path param is `{id}` to share the route shape with `namespace_get`,
+// but namespaces are addressed by name throughout the API, so we treat it
+// as a name (find_by_name / delete_by_name).
+pub(crate) async fn delete(
+    Path(name): Path<String>,
+    State(pool): State<Db>,
+    user: User,
+) -> impl IntoResponse {
+    match namespace::find_by_name(&pool, &name).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            log::error!("Failed to look up namespace '{}': {}", name, e);
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    }
+
+    match namespace::count_resources(&pool, &name).await {
+        Ok(0) => {}
+        Ok(n) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "error": "namespace is not empty",
+                    "remaining": n,
+                    "hint": "delete its deployments, secrets and configs first"
+                })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            log::error!("Failed to count resources in namespace '{}': {}", name, e);
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    }
+
+    if let Err(e) = namespace::delete_by_name(&pool, &name).await {
+        log::error!("Failed to delete namespace '{}': {}", name, e);
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Purge the namespace's audit trail, then record the deletion itself.
+    // The delete entry is written under the (now gone) namespace name so it
+    // is the last thing visible if the trail is consulted before retention
+    // cleanup elsewhere — but since we just purged, this is intentionally
+    // the sole surviving entry for the deleted namespace.
+    let _ = audit_log::delete_by_namespace(&pool, &name).await;
+    let _ = audit_log::record(
+        &pool,
+        Some(&user.id),
+        "delete",
+        "namespace",
+        &name,
+        Some(&name),
+    )
+    .await;
+
+    StatusCode::NO_CONTENT.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::server::tests::{login, new_test_app, new_test_app_with_pool};
+    use crate::models::audit_log;
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn delete_empty_namespace_succeeds() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "throwaway" }))
+            .await;
+
+        let response = server
+            .delete("/namespaces/throwaway")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn delete_unknown_namespace_is_404() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response = server
+            .delete("/namespaces/nope")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_non_empty_namespace_is_409() {
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "busy" }))
+            .await;
+        // A config makes the namespace non-empty.
+        server
+            .post("/configs")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "namespace": "busy", "name": "c1", "data": "{}" }))
+            .await;
+
+        let response = server
+            .delete("/namespaces/busy")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn deleting_namespace_purges_its_audit_trail() {
+        let (pool, app) = new_test_app_with_pool().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        server
+            .post("/namespaces")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({ "name": "ephemeral" }))
+            .await;
+
+        // Trail has the create entry.
+        assert_eq!(
+            audit_log::find_by_namespace(&pool, "ephemeral", None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let response = server
+            .delete("/namespaces/ephemeral")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::NO_CONTENT);
+
+        // Old trail purged; only the delete entry itself remains.
+        let after = audit_log::find_by_namespace(&pool, "ephemeral", None)
+            .await
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].action, "delete");
+        assert_eq!(after[0].target_type, "namespace");
+    }
+
+    #[tokio::test]
+    async fn delete_requires_authentication() {
+        let app = new_test_app().await;
+        let server = TestServer::new(app).unwrap();
+        let response = server.delete("/namespaces/x").await;
+        assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/api/action/namespace/mod.rs
+++ b/src/api/action/namespace/mod.rs
@@ -1,10 +1,12 @@
 pub(crate) mod audit;
 pub(crate) mod create;
+pub(crate) mod delete;
 pub(crate) mod get;
 pub(crate) mod list;
 pub(crate) mod validation;
 
 pub(crate) use audit::audit;
 pub(crate) use create::create;
+pub(crate) use delete::delete;
 pub(crate) use get::get;
 pub(crate) use list::list;

--- a/src/api/action/namespace/mod.rs
+++ b/src/api/action/namespace/mod.rs
@@ -1,8 +1,10 @@
+pub(crate) mod audit;
 pub(crate) mod create;
 pub(crate) mod get;
 pub(crate) mod list;
 pub(crate) mod validation;
 
+pub(crate) use audit::audit;
 pub(crate) use create::create;
 pub(crate) use get::get;
 pub(crate) use list::list;

--- a/src/api/action/secret/create.rs
+++ b/src/api/action/secret/create.rs
@@ -6,6 +6,7 @@ use crate::api::action::secret::validation::{
 };
 use crate::api::server::Db;
 use crate::api::validation::{ViolationList, problem_response};
+use crate::models::audit_log;
 use crate::models::namespace;
 use crate::models::secret;
 use crate::models::users::User;
@@ -67,7 +68,7 @@ struct SecretOutput {
 
 pub(crate) async fn create(
     State(pool): State<Db>,
-    _user: User,
+    user: User,
     Json(input): Json<SecretInput>,
 ) -> Response {
     if let Err(errs) = input.validate() {
@@ -107,6 +108,15 @@ pub(crate) async fn create(
 
     match secret::create(&pool, &new_secret).await {
         Ok(_) => {
+            let _ = audit_log::record(
+                &pool,
+                Some(&user.id),
+                "create",
+                "secret",
+                &new_secret.name,
+                Some(&new_secret.namespace),
+            )
+            .await;
             let output = SecretOutput {
                 id: new_secret.id,
                 created_at: new_secret.created_at,

--- a/src/api/action/secret/delete.rs
+++ b/src/api/action/secret/delete.rs
@@ -5,6 +5,7 @@ use http::StatusCode;
 use serde::Deserialize;
 
 use crate::api::server::Db;
+use crate::models::audit_log;
 use crate::models::deployments;
 use crate::models::secret as SecretModel;
 use crate::models::users::User;
@@ -19,7 +20,7 @@ pub(crate) async fn delete(
     Path(id): Path<String>,
     Query(query): Query<DeleteQuery>,
     State(pool): State<Db>,
-    _user: User,
+    user: User,
 ) -> impl IntoResponse {
     // First, find the secret to get namespace and name
     let secret = match SecretModel::find(&pool, &id).await {
@@ -79,7 +80,18 @@ pub(crate) async fn delete(
     }
 
     match SecretModel::delete(&pool, &id).await {
-        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Ok(_) => {
+            let _ = audit_log::record(
+                &pool,
+                Some(&user.id),
+                "delete",
+                "secret",
+                &secret.name,
+                Some(&secret.namespace),
+            )
+            .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => {
             log::error!("Failed to delete secret with ID {}: {}", id, e);
             (

--- a/src/api/dto/audit.rs
+++ b/src/api/dto/audit.rs
@@ -1,0 +1,27 @@
+use crate::models::audit_log::AuditEntry;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub(crate) struct AuditOutput {
+    pub id: String,
+    pub timestamp: String,
+    pub user_id: Option<String>,
+    pub action: String,
+    pub target_type: String,
+    pub target_name: String,
+    pub namespace: Option<String>,
+}
+
+impl AuditOutput {
+    pub fn from_to_model(entry: AuditEntry) -> Self {
+        AuditOutput {
+            id: entry.id,
+            timestamp: entry.timestamp,
+            user_id: entry.user_id,
+            action: entry.action,
+            target_type: entry.target_type,
+            target_name: entry.target_name,
+            namespace: entry.namespace,
+        }
+    }
+}

--- a/src/api/dto/mod.rs
+++ b/src/api/dto/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod audit;
 pub(crate) mod config;
 pub(crate) mod deployment;
 pub(crate) mod namespace;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -33,6 +33,7 @@ use crate::api::action::config::list as config_list;
 use crate::api::action::config::update as config_update;
 use crate::api::action::node::get as node_get;
 
+use crate::api::action::namespace::audit as namespace_audit;
 use crate::api::action::namespace::create as namespace_create;
 use crate::api::action::namespace::get as namespace_get;
 use crate::api::action::namespace::list as namespace_list;
@@ -104,6 +105,7 @@ pub(crate) fn router(state: AppState) -> Router {
         .route("/node/get", get(node_get))
         .route("/namespaces", get(namespace_list).post(namespace_create))
         .route("/namespaces/{id}", get(namespace_get))
+        .route("/namespaces/{name}/audit", get(namespace_audit))
         .route("/configs", get(config_list).post(config_create))
         .route(
             "/configs/{id}",

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -35,6 +35,7 @@ use crate::api::action::node::get as node_get;
 
 use crate::api::action::namespace::audit as namespace_audit;
 use crate::api::action::namespace::create as namespace_create;
+use crate::api::action::namespace::delete as namespace_delete;
 use crate::api::action::namespace::get as namespace_get;
 use crate::api::action::namespace::list as namespace_list;
 
@@ -104,8 +105,11 @@ pub(crate) fn router(state: AppState) -> Router {
         .route("/deployments/{id}/metrics", get(get_deployment_metrics))
         .route("/node/get", get(node_get))
         .route("/namespaces", get(namespace_list).post(namespace_create))
-        .route("/namespaces/{id}", get(namespace_get))
-        .route("/namespaces/{name}/audit", get(namespace_audit))
+        .route(
+            "/namespaces/{id}",
+            get(namespace_get).delete(namespace_delete),
+        )
+        .route("/namespaces/{id}/audit", get(namespace_audit))
         .route("/configs", get(config_list).post(config_create))
         .route(
             "/configs/{id}",

--- a/src/commands/namespace/audit.rs
+++ b/src/commands/namespace/audit.rs
@@ -1,0 +1,104 @@
+use crate::config::config::{Config, load_auth_config};
+use crate::exit_code;
+use clap::Arg;
+use clap::ArgMatches;
+use clap::Command;
+use cli_table::{Table, WithTitle, print_stdout};
+use serde::Deserialize;
+
+pub(crate) fn command_config() -> Command {
+    Command::new("audit")
+        .about("Show the write-action audit trail for a namespace")
+        .arg(Arg::new("namespace").required(true).help("Namespace name"))
+        .arg(
+            Arg::new("limit")
+                .long("limit")
+                .help("Maximum number of entries (most recent first)"),
+        )
+}
+
+#[derive(Table)]
+struct AuditTableItem {
+    #[table(title = "Timestamp")]
+    timestamp: String,
+    #[table(title = "User")]
+    user_id: String,
+    #[table(title = "Action")]
+    action: String,
+    #[table(title = "Type")]
+    target_type: String,
+    #[table(title = "Target")]
+    target_name: String,
+}
+
+#[derive(Deserialize)]
+struct AuditOutput {
+    timestamp: String,
+    user_id: Option<String>,
+    action: String,
+    target_type: String,
+    target_name: String,
+}
+
+pub(crate) async fn execute(
+    args: &ArgMatches,
+    mut configuration: Config,
+    client: &reqwest::Client,
+) {
+    let namespace = args
+        .get_one::<String>("namespace")
+        .expect("namespace is required");
+    let api_url = configuration.get_api_url();
+    let auth_config = load_auth_config(configuration.name.clone());
+
+    let mut url = format!("{}/namespaces/{}/audit", api_url, namespace);
+    if let Some(limit) = args.get_one::<String>("limit") {
+        url.push_str(&format!("?limit={}", limit));
+    }
+
+    let request = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", auth_config.token))
+        .send()
+        .await;
+
+    match request {
+        Ok(response) => {
+            let status = response.status();
+            if status != 200 {
+                eprintln!("Unable to fetch audit log: {}", status);
+                exit_code::from_http_status(status.as_u16()).exit();
+            }
+
+            let entries: Vec<AuditOutput> = match response.json::<Vec<AuditOutput>>().await {
+                Ok(list) => list,
+                Err(e) => {
+                    eprintln!("Failed to parse audit log: {}", e);
+                    exit_code::ExitCode::General.exit();
+                }
+            };
+
+            if entries.is_empty() {
+                println!("No audit entries for namespace '{}'", namespace);
+                return;
+            }
+
+            let rows: Vec<AuditTableItem> = entries
+                .into_iter()
+                .map(|e| AuditTableItem {
+                    timestamp: e.timestamp,
+                    user_id: e.user_id.unwrap_or_else(|| "-".to_string()),
+                    action: e.action,
+                    target_type: e.target_type,
+                    target_name: e.target_name,
+                })
+                .collect();
+
+            print_stdout(rows.with_title()).expect("");
+        }
+        Err(error) => {
+            eprintln!("Failed to fetch audit log: {}", error);
+            exit_code::from_reqwest_error(&error).exit();
+        }
+    }
+}

--- a/src/commands/namespace/delete.rs
+++ b/src/commands/namespace/delete.rs
@@ -1,0 +1,46 @@
+use crate::commands::problem_json::render_response_error;
+use crate::config::config::{Config, load_auth_config};
+use crate::exit_code;
+use clap::Arg;
+use clap::ArgMatches;
+use clap::Command;
+
+pub(crate) fn command_config() -> Command {
+    Command::new("delete")
+        .about("Delete an empty namespace (refuses if it still has resources)")
+        .arg(Arg::new("name").required(true).help("Namespace name"))
+}
+
+pub(crate) async fn execute(
+    args: &ArgMatches,
+    mut configuration: Config,
+    client: &reqwest::Client,
+) {
+    let name = args.get_one::<String>("name").expect("name is required");
+    let api_url = configuration.get_api_url();
+    let auth_config = load_auth_config(configuration.name.clone());
+
+    let request = client
+        .delete(format!("{}/namespaces/{}", api_url, name))
+        .header("Authorization", format!("Bearer {}", auth_config.token))
+        .send()
+        .await;
+
+    match request {
+        Ok(response) => {
+            let status = response.status();
+            if status == 204 {
+                println!("Namespace '{}' deleted", name);
+                return;
+            }
+
+            let context = format!("Unable to delete namespace '{}'", name);
+            let code = render_response_error(&context, response).await;
+            exit_code::from_http_status(code).exit();
+        }
+        Err(error) => {
+            eprintln!("Failed to delete namespace: {}", error);
+            exit_code::from_reqwest_error(&error).exit();
+        }
+    }
+}

--- a/src/commands/namespace/mod.rs
+++ b/src/commands/namespace/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod audit;
 pub(crate) mod create;
 pub(crate) mod list;
 pub(crate) mod prune;

--- a/src/commands/namespace/mod.rs
+++ b/src/commands/namespace/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod audit;
 pub(crate) mod create;
+pub(crate) mod delete;
 pub(crate) mod list;
 pub(crate) mod prune;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,8 @@ async fn main() {
                 .flatten_help(true)
                 .subcommand(commands::namespace::create::command_config())
                 .subcommand(commands::namespace::list::command_config())
-                .subcommand(commands::namespace::prune::command_config()),
+                .subcommand(commands::namespace::prune::command_config())
+                .subcommand(commands::namespace::audit::command_config()),
         )
         .subcommand(
             Command::new("node")
@@ -237,6 +238,9 @@ async fn main() {
                 }
                 ("prune", sub_matches) => {
                     commands::namespace::prune::execute(sub_matches, config, &client).await;
+                }
+                ("audit", sub_matches) => {
+                    commands::namespace::audit::execute(sub_matches, config, &client).await;
                 }
                 _ => {}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,8 @@ async fn main() {
                 .subcommand(commands::namespace::create::command_config())
                 .subcommand(commands::namespace::list::command_config())
                 .subcommand(commands::namespace::prune::command_config())
-                .subcommand(commands::namespace::audit::command_config()),
+                .subcommand(commands::namespace::audit::command_config())
+                .subcommand(commands::namespace::delete::command_config()),
         )
         .subcommand(
             Command::new("node")
@@ -241,6 +242,9 @@ async fn main() {
                 }
                 ("audit", sub_matches) => {
                     commands::namespace::audit::execute(sub_matches, config, &client).await;
+                }
+                ("delete", sub_matches) => {
+                    commands::namespace::delete::execute(sub_matches, config, &client).await;
                 }
                 _ => {}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ mod runtime {
 }
 
 mod models {
+    pub(crate) mod audit_log;
     pub(crate) mod config;
     pub(crate) mod deployment_event;
     pub(crate) mod deployments;

--- a/src/models/audit_log.rs
+++ b/src/models/audit_log.rs
@@ -6,11 +6,6 @@
 //! deployment is cleaned up), this survives target deletion so a post-mortem
 //! stays possible. Retention is namespace-bound: the trail goes away only
 //! when the namespace itself is deleted.
-//!
-//! NOTE: storage layer lands first; handler call sites, the HTTP endpoint and
-//! the CLI come in follow-up commits. The crate-local `dead_code` allow below
-//! is transitional and removed once those consumers exist.
-#![allow(dead_code)]
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};

--- a/src/models/audit_log.rs
+++ b/src/models/audit_log.rs
@@ -1,0 +1,230 @@
+//! Namespace-scoped audit log of write actions.
+//!
+//! A deliberately light record of "who did what": one row per successful
+//! create/update/delete on a deployment, secret, config or namespace. Unlike
+//! `deployment_event` (per-deployment runtime telemetry that is wiped when a
+//! deployment is cleaned up), this survives target deletion so a post-mortem
+//! stays possible. Retention is namespace-bound: the trail goes away only
+//! when the namespace itself is deleted.
+//!
+//! NOTE: storage layer lands first; handler call sites, the HTTP endpoint and
+//! the CLI come in follow-up commits. The crate-local `dead_code` allow below
+//! is transitional and removed once those consumers exist.
+#![allow(dead_code)]
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub(crate) struct AuditEntry {
+    pub(crate) id: String,
+    pub(crate) timestamp: String,
+    pub(crate) user_id: Option<String>,
+    pub(crate) action: String,
+    pub(crate) target_type: String,
+    pub(crate) target_name: String,
+    pub(crate) namespace: Option<String>,
+}
+
+impl AuditEntry {
+    pub(crate) fn new(
+        user_id: Option<String>,
+        action: &str,
+        target_type: &str,
+        target_name: &str,
+        namespace: Option<&str>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            timestamp: Utc::now().to_rfc3339(),
+            user_id,
+            action: action.to_string(),
+            target_type: target_type.to_string(),
+            target_name: target_name.to_string(),
+            namespace: namespace.map(|n| n.to_string()),
+        }
+    }
+}
+
+/// Record a write action. Call this at the success point of a handler, never
+/// before the action is committed — the log must reflect what actually
+/// happened, not what was attempted.
+pub(crate) async fn record(
+    pool: &SqlitePool,
+    user_id: Option<&str>,
+    action: &str,
+    target_type: &str,
+    target_name: &str,
+    namespace: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    let entry = AuditEntry::new(
+        user_id.map(|s| s.to_string()),
+        action,
+        target_type,
+        target_name,
+        namespace,
+    );
+
+    sqlx::query(
+        "INSERT INTO audit_log (id, timestamp, user_id, action, target_type, target_name, namespace)
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&entry.id)
+    .bind(&entry.timestamp)
+    .bind(&entry.user_id)
+    .bind(&entry.action)
+    .bind(&entry.target_type)
+    .bind(&entry.target_name)
+    .bind(&entry.namespace)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// All audit entries for a namespace, most recent first.
+pub(crate) async fn find_by_namespace(
+    pool: &SqlitePool,
+    namespace: &str,
+    limit: Option<u32>,
+) -> Result<Vec<AuditEntry>, sqlx::Error> {
+    let safe_limit = limit.unwrap_or(100).min(1000) as i64;
+
+    sqlx::query_as::<_, AuditEntry>(
+        "SELECT id, timestamp, user_id, action, target_type, target_name, namespace
+         FROM audit_log WHERE namespace = ? ORDER BY timestamp DESC LIMIT ?",
+    )
+    .bind(namespace)
+    .bind(safe_limit)
+    .fetch_all(pool)
+    .await
+}
+
+/// Drop a namespace's whole audit trail. Called when the namespace itself is
+/// deleted — retention is namespace-bound by design.
+pub(crate) async fn delete_by_namespace(
+    pool: &SqlitePool,
+    namespace: &str,
+) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM audit_log WHERE namespace = ?")
+        .bind(namespace)
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn record_then_find_by_namespace() {
+        let pool = test_pool().await;
+        record(
+            &pool,
+            Some("u1"),
+            "create",
+            "deployment",
+            "api",
+            Some("ns1"),
+        )
+        .await
+        .unwrap();
+        record(&pool, Some("u1"), "delete", "secret", "db-url", Some("ns1"))
+            .await
+            .unwrap();
+        record(&pool, Some("u2"), "create", "config", "nginx", Some("ns2"))
+            .await
+            .unwrap();
+
+        let ns1 = find_by_namespace(&pool, "ns1", None).await.unwrap();
+        assert_eq!(ns1.len(), 2);
+        // Most recent first.
+        assert_eq!(ns1[0].action, "delete");
+        assert_eq!(ns1[0].target_name, "db-url");
+        assert_eq!(ns1[1].action, "create");
+
+        let ns2 = find_by_namespace(&pool, "ns2", None).await.unwrap();
+        assert_eq!(ns2.len(), 1);
+        assert_eq!(ns2[0].user_id.as_deref(), Some("u2"));
+    }
+
+    #[tokio::test]
+    async fn entry_survives_unrelated_deletes_but_namespace_delete_clears_it() {
+        let pool = test_pool().await;
+        record(
+            &pool,
+            Some("u1"),
+            "create",
+            "deployment",
+            "api",
+            Some("ns1"),
+        )
+        .await
+        .unwrap();
+        record(
+            &pool,
+            Some("u1"),
+            "create",
+            "deployment",
+            "web",
+            Some("ns2"),
+        )
+        .await
+        .unwrap();
+
+        // Deleting ns1's trail must not touch ns2.
+        let removed = delete_by_namespace(&pool, "ns1").await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(
+            find_by_namespace(&pool, "ns1", None)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            find_by_namespace(&pool, "ns2", None).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_is_capped() {
+        let pool = test_pool().await;
+        for i in 0..5 {
+            record(
+                &pool,
+                Some("u1"),
+                "create",
+                "deployment",
+                &format!("d{i}"),
+                Some("ns"),
+            )
+            .await
+            .unwrap();
+        }
+        let rows = find_by_namespace(&pool, "ns", Some(2)).await.unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn null_user_is_accepted() {
+        let pool = test_pool().await;
+        record(&pool, None, "delete", "namespace", "ns1", None)
+            .await
+            .unwrap();
+        // namespace-level action: stored with NULL namespace, not queryable
+        // by namespace (expected — it has no parent context).
+        let rows = find_by_namespace(&pool, "ns1", None).await.unwrap();
+        assert!(rows.is_empty());
+    }
+}

--- a/src/models/audit_log.rs
+++ b/src/models/audit_log.rs
@@ -62,7 +62,7 @@ pub(crate) async fn record(
         namespace,
     );
 
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO audit_log (id, timestamp, user_id, action, target_type, target_name, namespace)
          VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
@@ -74,9 +74,23 @@ pub(crate) async fn record(
     .bind(&entry.target_name)
     .bind(&entry.namespace)
     .execute(pool)
-    .await?;
+    .await;
 
-    Ok(())
+    // Audit failures must never break the caller's request, so callers
+    // discard the result. Log here so a missed entry is still visible
+    // instead of vanishing silently — this is the only place that needs it.
+    if let Err(ref e) = result {
+        log::warn!(
+            "Failed to record audit entry ({} {} '{}' in namespace {:?}): {}",
+            entry.action,
+            entry.target_type,
+            entry.target_name,
+            entry.namespace,
+            e
+        );
+    }
+
+    result.map(|_| ())
 }
 
 /// All audit entries for a namespace, most recent first.
@@ -106,9 +120,17 @@ pub(crate) async fn delete_by_namespace(
     let result = sqlx::query("DELETE FROM audit_log WHERE namespace = ?")
         .bind(namespace)
         .execute(pool)
-        .await?;
+        .await;
 
-    Ok(result.rows_affected())
+    if let Err(ref e) = result {
+        log::warn!(
+            "Failed to purge audit trail for namespace '{}': {}",
+            namespace,
+            e
+        );
+    }
+
+    result.map(|r| r.rows_affected())
 }
 
 #[cfg(test)]

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -49,3 +49,37 @@ pub(crate) async fn create(pool: &SqlitePool, namespace: Namespace) -> Result<()
 
     Ok(())
 }
+
+pub(crate) async fn delete_by_name(pool: &SqlitePool, name: &str) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM namespace WHERE name = ?")
+        .bind(name)
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Number of resources still living in a namespace. A namespace is only
+/// deletable when this is zero — we never cascade-delete deployments,
+/// secrets or configs out from under the operator. A "deleted"-status
+/// deployment is a tombstone, not a live resource, so it does not count.
+pub(crate) async fn count_resources(pool: &SqlitePool, name: &str) -> Result<i64, sqlx::Error> {
+    let deployments: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM deployment WHERE namespace = ? AND status <> 'deleted'",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await?;
+
+    let secrets: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM secret WHERE namespace = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await?;
+
+    let configs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM config WHERE namespace = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(deployments + secrets + configs)
+}


### PR DESCRIPTION
Adds a lightweight, namespace-scoped audit log of write actions.

- One entry per successful create/update/delete on a deployment, secret,
  config or namespace, recording the author, action, target and timestamp.
- Distinct from per-deployment runtime events: an entry survives the
  deletion of its target. Retention is namespace-bound — the trail is
  purged only when the namespace itself is removed.
- Adds namespace deletion (`DELETE /namespaces/{name}`, CLI), which refuses
  with 409 while the namespace still holds resources.
- Read paths: `GET /namespaces/{name}/audit`, `ring namespace audit <ns>`,
  and a dashboard view per namespace.

Storage, capture, read API/CLI, retention and the dashboard view land as
separate commits. Full test suite green; new tests cover capture,
retention and the non-empty-namespace guard.
