### PR TITLE
fix(cli): human error messages instead of raw HTTP status

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -747,3 +747,36 @@ For a single-command help on any subcommand:
 ```bash
 ring <command> --help
 ```
+
+## Error messages
+
+When a command fails, the CLI prints a single human line to `stderr`,
+prefixed with `error:`, and exits non-zero. It does **not** echo the raw
+HTTP status — the status code is a category, and the message is composed
+from what the command already knows (the resource and the name you typed).
+
+```bash
+$ ring deployment delete web
+error: deployment 'web' not found
+
+$ ring deployment inspect web
+error: deployment 'web' not found
+
+$ ring config delete app
+error: config 'app' not found
+```
+
+Mapping by status category:
+
+| Situation                         | Message                                                   |
+| --------------------------------- | --------------------------------------------------------- |
+| Resource missing (`404`)          | `error: <kind> '<name>' not found`                        |
+| Conflict / has dependents (`409`) | `error: <kind> '<name>' already exists or still has dependents` |
+| Not authorized (`401`/`403`)      | `error: not authorized to act on <kind> '<name>'`         |
+| Listing, not authorized           | `error: cannot list <kind> in namespace '<ns>': not authorized` |
+| Anything else                     | `error: <kind> '<name>': request failed (<status>)`       |
+
+Validation failures on `apply` / `user` create are the exception: the
+server returns a structured RFC 7807 `problem+json` body, and the CLI
+renders every violation with its property path (see `ring apply`). The
+exit code still reflects the HTTP status in all cases.

--- a/src/commands/config/delete.rs
+++ b/src/commands/config/delete.rs
@@ -2,6 +2,7 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
 
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -36,7 +37,7 @@ pub(crate) async fn execute(
                 if status == 204 {
                     println!("Config {} deleted ", deployment);
                 } else {
-                    eprintln!("Cannot delete Config {}: {}", deployment, status);
+                    eprintln!("{}", http_error(status.as_u16(), "config", deployment));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/config/inspect.rs
+++ b/src/commands/config/inspect.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::config::ConfigOutput;
+use crate::commands::problem_json::http_error;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -48,10 +49,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!(
-                    "Error: Failed to retrieve configuration details: {}",
-                    status
-                );
+                eprintln!("{}", http_error(status.as_u16(), "config", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/config/list.rs
+++ b/src/commands/config/list.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::config::ConfigOutput;
+use crate::commands::problem_json::http_error_list;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -42,13 +43,20 @@ pub(crate) async fn execute(
     let query = format!("{}/configs", api_url);
     let mut params: Vec<String> = Vec::new();
 
+    let mut ns_scope: Vec<String> = Vec::new();
     if args.contains_id("namespace") {
         let namespace = args.get_many::<String>("namespace").unwrap();
 
         for namespace in namespace {
             params.push(format!("namespace[]={}", namespace));
+            ns_scope.push(namespace.clone());
         }
     }
+    let ns_label = if ns_scope.is_empty() {
+        "all".to_string()
+    } else {
+        ns_scope.join(",")
+    };
 
     let query = if !params.is_empty() {
         format!("{}?{}", query, params.join("&"))
@@ -66,7 +74,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch configurations list: {}", status);
+                eprintln!("{}", http_error_list(status.as_u16(), "configs", &ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/deployment/delete.rs
+++ b/src/commands/deployment/delete.rs
@@ -2,6 +2,7 @@ use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
 
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -36,7 +37,7 @@ pub(crate) async fn execute(
                 if status == 204 {
                     println!("Deployment {} deleted ", deployment);
                 } else {
-                    eprintln!("Cannot delete deployment {}: {}", deployment, status);
+                    eprintln!("{}", http_error(status.as_u16(), "deployment", deployment));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/deployment/health_checks.rs
+++ b/src/commands/deployment/health_checks.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -91,7 +92,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch health checks: {}", status);
+                eprintln!("{}", http_error(status.as_u16(), "deployment", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/deployment/inspect.rs
+++ b/src/commands/deployment/inspect.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::deployment::DeploymentOutput;
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -61,7 +62,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch deployment: {}", status);
+                eprintln!("{}", http_error(status.as_u16(), "deployment", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/deployment/list.rs
+++ b/src/commands/deployment/list.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::deployment::DeploymentOutput;
+use crate::commands::problem_json::http_error_list;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -73,13 +74,20 @@ pub(crate) async fn execute(
     let mut query = format!("{}/deployments", api_url);
     let mut params: Vec<String> = Vec::new();
 
+    let mut ns_scope: Vec<String> = Vec::new();
     if args.contains_id("namespace") {
         let namespace = args.get_many::<String>("namespace").unwrap();
 
         for namespace in namespace {
             params.push(format!("namespace[]={}", namespace));
+            ns_scope.push(namespace.clone());
         }
     }
+    let ns_label = if ns_scope.is_empty() {
+        "all".to_string()
+    } else {
+        ns_scope.join(",")
+    };
 
     if args.contains_id("status") {
         let statuses = args.get_many::<String>("status").unwrap();
@@ -108,7 +116,10 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch deployments: {}", status);
+                eprintln!(
+                    "{}",
+                    http_error_list(status.as_u16(), "deployments", &ns_label)
+                );
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/deployment/metrics.rs
+++ b/src/commands/deployment/metrics.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::stats::DeploymentStatsOutput;
+use crate::commands::problem_json::http_error;
 use crate::config::config::{Config, load_auth_config};
 use clap::{Arg, ArgMatches, Command};
 
@@ -38,7 +39,7 @@ pub(crate) async fn execute(
     match response {
         Ok(res) => {
             if res.status() != 200 {
-                eprintln!("Unable to fetch metrics: {}", res.status());
+                eprintln!("{}", http_error(res.status().as_u16(), "deployment", id));
                 return;
             }
 

--- a/src/commands/namespace/list.rs
+++ b/src/commands/namespace/list.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::http_error_global_list;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::ArgMatches;
@@ -44,7 +45,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch namespaces: {}", status);
+                eprintln!("{}", http_error_global_list(status.as_u16(), "namespaces"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/namespace/prune.rs
+++ b/src/commands/namespace/prune.rs
@@ -1,4 +1,5 @@
 use crate::api::dto::deployment::DeploymentOutput;
+use crate::commands::problem_json::http_error_list;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -57,7 +58,11 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch deployments: {}", status);
+                let ns_label = namespace_filter.map(String::as_str).unwrap_or("all");
+                eprintln!(
+                    "{}",
+                    http_error_list(status.as_u16(), "deployments", ns_label)
+                );
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/problem_json.rs
+++ b/src/commands/problem_json.rs
@@ -98,9 +98,102 @@ pub(crate) async fn render_response_error(context: &str, response: Response) -> 
     status_u16
 }
 
+/// Compose a human message for a *category* HTTP status from what the CLI
+/// already knows — no response body required.
+///
+/// The status code is a category, not a sentence: the API answers `404`,
+/// and the client (which knows the command and its arguments) decides what
+/// to say. Keeping the wording here means one source of truth instead of
+/// the same phrase copy-pasted across a dozen commands, and zero per-route
+/// copy to maintain server-side.
+///
+/// This is *not* for `422` validation failures: there the server carries
+/// structured violations the client cannot invent — route those through
+/// [`render_response_error`] instead.
+///
+/// `kind` is the resource noun (`"deployment"`, `"config"`, …), `name` the
+/// identifier the user typed.
+pub(crate) fn http_error(status: u16, kind: &str, name: &str) -> String {
+    match status {
+        404 => format!("error: {kind} '{name}' not found"),
+        409 => format!("error: {kind} '{name}' already exists or still has dependents"),
+        401 | 403 => format!("error: not authorized to act on {kind} '{name}'"),
+        _ => format!("error: {kind} '{name}': request failed ({status})"),
+    }
+}
+
+/// Same idea as [`http_error`] but for *collection* endpoints (`list`),
+/// which have no single resource identifier. The namespace is the only
+/// context that scopes the failure, so it carries the message.
+///
+/// `kind` is the plural noun (`"deployments"`, `"secrets"`, …).
+pub(crate) fn http_error_list(status: u16, kind: &str, namespace: &str) -> String {
+    let scope = format!("cannot list {kind} in namespace '{namespace}'");
+    match status {
+        401 | 403 => format!("error: {scope}: not authorized"),
+        404 => format!("error: {scope}: namespace not found"),
+        _ => format!("error: {scope}: request failed ({status})"),
+    }
+}
+
+/// Like [`http_error_list`] but for *global* collections that no namespace
+/// scopes (`namespace list`, `user list`). No identifier, no namespace —
+/// just the category and the plural noun.
+pub(crate) fn http_error_global_list(status: u16, kind: &str) -> String {
+    match status {
+        401 | 403 => format!("error: not authorized to list {kind}"),
+        _ => format!("error: cannot list {kind}: request failed ({status})"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn http_error_global_list_has_no_scope() {
+        assert_eq!(
+            http_error_global_list(403, "namespaces"),
+            "error: not authorized to list namespaces"
+        );
+        assert_eq!(
+            http_error_global_list(502, "users"),
+            "error: cannot list users: request failed (502)"
+        );
+    }
+
+    #[test]
+    fn http_error_list_scopes_message_to_namespace() {
+        assert_eq!(
+            http_error_list(403, "deployments", "prod"),
+            "error: cannot list deployments in namespace 'prod': not authorized"
+        );
+        assert_eq!(
+            http_error_list(500, "secrets", "default"),
+            "error: cannot list secrets in namespace 'default': request failed (500)"
+        );
+    }
+
+    #[test]
+    fn http_error_maps_categories_to_human_messages() {
+        assert_eq!(
+            http_error(404, "deployment", "web"),
+            "error: deployment 'web' not found"
+        );
+        assert_eq!(
+            http_error(409, "namespace", "prod"),
+            "error: namespace 'prod' already exists or still has dependents"
+        );
+        assert_eq!(
+            http_error(403, "secret", "db-pass"),
+            "error: not authorized to act on secret 'db-pass'"
+        );
+        // Unknown status falls back to a status-tagged line, never a panic.
+        assert_eq!(
+            http_error(503, "config", "app"),
+            "error: config 'app': request failed (503)"
+        );
+    }
 
     #[test]
     fn problem_details_round_trips_full_shape() {

--- a/src/commands/secret/delete.rs
+++ b/src/commands/secret/delete.rs
@@ -4,6 +4,7 @@ use clap::Command;
 use serde::Deserialize;
 use std::io::{self, Write};
 
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -111,7 +112,7 @@ pub(crate) async fn execute(
                     }
                 }
                 _ => {
-                    eprintln!("Failed to delete secret: {}", status);
+                    eprintln!("{}", http_error(status.as_u16(), "secret", id));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/secret/list.rs
+++ b/src/commands/secret/list.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::http_error_list;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -47,13 +48,20 @@ pub(crate) async fn execute(
     let auth_config = load_auth_config(configuration.name.clone());
     let mut params: Vec<String> = Vec::new();
 
+    let mut ns_scope: Vec<String> = Vec::new();
     if args.contains_id("namespace")
         && let Some(namespaces) = args.get_many::<String>("namespace")
     {
         for namespace in namespaces {
             params.push(format!("namespace[]={}", namespace));
+            ns_scope.push(namespace.clone());
         }
     }
+    let ns_label = if ns_scope.is_empty() {
+        "all".to_string()
+    } else {
+        ns_scope.join(",")
+    };
 
     let query = if !params.is_empty() {
         format!("{}/secrets?{}", api_url, params.join("&"))
@@ -71,7 +79,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch secrets list: {}", status);
+                eprintln!("{}", http_error_list(status.as_u16(), "secrets", &ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/user/delete.rs
+++ b/src/commands/user/delete.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::http_error;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -33,7 +34,7 @@ pub(crate) async fn execute(
             if status == 204 {
                 println!("User {} deleted ", id)
             } else {
-                eprintln!("Cannot delete user: {}", status);
+                eprintln!("{}", http_error(status.as_u16(), "user", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
         }

--- a/src/commands/user/list.rs
+++ b/src/commands/user/list.rs
@@ -1,3 +1,4 @@
+use crate::commands::problem_json::http_error_global_list;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -51,7 +52,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("Unable to fetch users: {}", status);
+                eprintln!("{}", http_error_global_list(status.as_u16(), "users"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/user/update.rs
+++ b/src/commands/user/update.rs
@@ -1,5 +1,5 @@
 use crate::api::dto::user::UserOutput;
-use crate::commands::problem_json::render_response_error;
+use crate::commands::problem_json::{http_error, render_response_error};
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -52,7 +52,7 @@ pub(crate) async fn execute(
         Ok(resp) => {
             let status = resp.status();
             if !status.is_success() {
-                eprintln!("Unable to fetch current user: {}", status);
+                eprintln!("{}", http_error(status.as_u16(), "user", "current"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
             resp

--- a/tests/e2e/server/t3_cli_error_messages.sh
+++ b/tests/e2e/server/t3_cli_error_messages.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# T3-server: CLI surfaces human error messages, not raw HTTP status.
+#
+# Before this change, `ring deployment delete inexistant` printed
+# `Cannot delete deployment inexistant: 404 Not Found` — the bare HTTP
+# status leaked to the user, who has no idea whether *their* resource is
+# missing or the server is broken. The fix maps the status *category* to a
+# message the CLI composes from what it already knows (no API change).
+#
+# This proves the behaviour against the *real compiled binary* over a TCP
+# socket — the Rust unit tests on `http_error` cannot show that the message
+# actually reaches the user's terminal through the command's error path.
+#
+# Invariants:
+#   1. deployment delete <missing>  → "error: deployment '<x>' not found"
+#                                      AND no raw "404"/"Not Found" leak
+#   2. deployment inspect <missing> → same message, same no-leak
+#   3. config delete <missing>      → "error: config '<x>' not found"
+#   4. exit code is non-zero on the not-found path
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t3-server-salt"
+scheduler.interval = 1
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="$KEY"
+
+log "== T3-server: CLI human error messages =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+# Real CLI auth round-trip so subsequent commands are authenticated.
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "ring login failed against the real server"
+
+MISSING="definitely-does-not-exist-$RANDOM"
+
+# Capture stderr+stdout and the exit code of a command expected to fail.
+run_fail() {
+  set +e
+  OUT=$("$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+assert_human_no_leak() {
+  local label="$1" kind="$2"
+  # Must contain the composed human line.
+  echo "$OUT" | grep -qF "error: ${kind} '${MISSING}' not found" \
+    || { echo "$OUT" >&2; fail "$label: expected \"error: ${kind} '${MISSING}' not found\""; }
+  # Must NOT leak the raw HTTP status the old code printed. We look for the
+  # *status code shape* the legacy `eprintln!("...: {}", status)` produced
+  # (e.g. `: 404 Not Found`), NOT the words "not found" — those are part of
+  # the correct human message and matching them case-insensitively would
+  # flag our own fix.
+  if echo "$OUT" | grep -qE '\b[0-9]{3} (Not Found|Unauthorized|Forbidden|Conflict)\b|: [0-9]{3}\b'; then
+    echo "$OUT" >&2
+    fail "$label: raw HTTP status leaked to the user"
+  fi
+  [ "$RC" -ne 0 ] || fail "$label: not-found path must exit non-zero (got $RC)"
+}
+
+# --- Invariant 1: deployment delete on a missing target ---
+run_fail "$RING_BIN" deployment delete "$MISSING"
+assert_human_no_leak "1 (deployment delete)" "deployment"
+log "1 (deployment delete missing): human message, no status leak, rc=$RC"
+
+# --- Invariant 2: deployment inspect on a missing target ---
+run_fail "$RING_BIN" deployment inspect "$MISSING"
+assert_human_no_leak "2 (deployment inspect)" "deployment"
+log "2 (deployment inspect missing): human message, no status leak, rc=$RC"
+
+# --- Invariant 3: config delete on a missing target ---
+run_fail "$RING_BIN" config delete "$MISSING"
+assert_human_no_leak "3 (config delete)" "config"
+log "3 (config delete missing): human message, no status leak, rc=$RC"
+
+log "== T3-server: all invariants passed =="


### PR DESCRIPTION
## Problem

When a command failed against the API, the CLI echoed the raw HTTP status
to the user:

```
$ ring deployment delete web
Cannot delete deployment web: 404 Not Found
```

The user cannot tell whether *their* resource is missing or the server is
broken. The anti-pattern was duplicated, with inconsistent wording, across
~14 sites (`delete`, `inspect`, `list`, …).

## Approach

The HTTP status is a *category*, not a sentence. The server keeps
answering plain status codes (no API change); the client — which knows the
command and the arguments the user typed — composes the message.

Three helpers in `commands/problem_json.rs`:

- `http_error(status, kind, name)` — resource addressed by id
- `http_error_list(status, kind, namespace)` — namespace-scoped collections
- `http_error_global_list(status, kind)` — global collections (no scope)

Wired across `deployment delete/inspect/list/health_checks/metrics`,
`config delete/inspect/list`, `namespace list/prune`,
`secret list/delete`, `user list/delete/update`.

`422` validation responses are unchanged: the server returns structured
RFC 7807 `problem+json` the client cannot invent, so those keep flowing
through `render_response_error`. Exit codes are preserved in all cases.

## Result

```
$ ring deployment delete web
error: deployment 'web' not found

$ ring deployment inspect web
error: deployment 'web' not found
```

## Tests

- 3 unit tests on the helpers; full suite green (396 passed, 0 failed).
- `tests/e2e/server/t3_cli_error_messages.sh`: 3 invariants against the
  real compiled binary over a TCP socket (human message present, no raw
  status leak, non-zero exit). Stable over 3 consecutive runs.
- Docs: `reference/cli.md` § Error messages.

## Out of scope

`login` against a down server is a `reqwest` transport error, not an HTTP
status — handled separately.