### PR TITLE
fix(cli): human message when the server is unreachable on login

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -85,6 +85,18 @@ ring login --username admin --password changeme
 ring login -u alice -p secret
 ```
 
+If the server is unreachable (down, wrong host/port), the CLI prints a
+single actionable line and exits non-zero — not the underlying transport
+trace:
+
+```
+$ ring login -u admin -p changeme
+error: cannot reach the server at http://localhost:3030 — is it running? (connection refused)
+```
+
+A timeout (`the server ... did not respond in time`) and a malformed
+request are reported the same way: one line, no nested error chain.
+
 ## Deployments
 
 ### `ring apply`

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,4 +1,4 @@
-use crate::commands::problem_json::render_response_error;
+use crate::commands::problem_json::{render_response_error, transport_error};
 use crate::config::config::Config;
 use crate::exit_code;
 use clap::Arg;
@@ -42,7 +42,8 @@ pub(crate) async fn execute(
     let config_directory = get_config_dir();
     let config_file = format!("{}/auth.json", config_directory);
 
-    let api_url = format!("{}/login", configuration.get_api_url());
+    let base_url = configuration.get_api_url();
+    let api_url = format!("{}/login", base_url);
     let request = client
         .post(&api_url)
         .json(&json!({
@@ -96,7 +97,7 @@ pub(crate) async fn execute(
             println!("Logging in as {}", username);
         }
         Err(err) => {
-            eprintln!("Connection failed: {}", err);
+            eprintln!("{}", transport_error(&err, &base_url));
             exit_code::from_reqwest_error(&err).exit();
         }
     }

--- a/src/commands/problem_json.rs
+++ b/src/commands/problem_json.rs
@@ -146,9 +146,55 @@ pub(crate) fn http_error_global_list(status: u16, kind: &str) -> String {
     }
 }
 
+/// Turn a transport-level `reqwest::Error` (no HTTP response was ever
+/// received) into one human line, instead of dumping reqwest's nested
+/// source chain (`error sending request for url (...): error trying to
+/// connect: tcp connect error: Connection refused (os error 111)`).
+///
+/// This is the counterpart of the status-based path (`render_response_error`):
+/// that one handles a server that *answered* with a status; this one
+/// handles a server that never answered at all (down, unreachable, slow).
+/// `endpoint` is the base URL the command was trying to reach, surfaced
+/// so the user can check it.
+pub(crate) fn transport_error(err: &reqwest::Error, endpoint: &str) -> String {
+    if err.is_connect() {
+        format!(
+            "error: cannot reach the server at {endpoint} — is it running? (connection refused)"
+        )
+    } else if err.is_timeout() {
+        format!("error: the server at {endpoint} did not respond in time (timeout)")
+    } else if err.is_request() {
+        format!("error: could not send the request to {endpoint} (malformed request)")
+    } else {
+        // Body/decode error or anything else without an HTTP status: keep
+        // it short, the detailed chain helps no one at the CLI.
+        format!("error: request to {endpoint} failed")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // `reqwest::Error` can't be constructed by hand, so drive a real
+    // connection to a port nothing listens on: that yields a connect
+    // error deterministically and fast (no network, no DNS).
+    #[tokio::test]
+    async fn transport_error_on_refused_connection_is_human() {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:1/login") // port 1: nothing binds it
+            .timeout(std::time::Duration::from_secs(2))
+            .send()
+            .await
+            .expect_err("connecting to a dead port must fail");
+
+        let msg = transport_error(&err, "http://127.0.0.1:1");
+        assert!(msg.starts_with("error: "), "got: {msg}");
+        assert!(msg.contains("http://127.0.0.1:1"), "got: {msg}");
+        // Must not leak reqwest's nested source chain.
+        assert!(!msg.contains("os error"), "leaked OS detail: {msg}");
+        assert!(!msg.contains("tcp connect error"), "leaked chain: {msg}");
+    }
 
     #[test]
     fn http_error_global_list_has_no_scope() {

--- a/tests/e2e/server/t4_login_server_down.sh
+++ b/tests/e2e/server/t4_login_server_down.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# T4-server: `ring login` against a server that is down must print one
+# human line, not reqwest's nested source chain.
+#
+# Before this change the user saw:
+#   Connection failed: error sending request for url (http://127.0.0.1:PORT/login):
+#   error trying to connect: tcp connect error: Connection refused (os error 111)
+#
+# This proves, against the *real compiled binary*, that a transport error
+# (no HTTP response at all — server down) is rendered as a single
+# actionable line and exits non-zero. No server is started on purpose:
+# the config points at a port nothing listens on.
+#
+# Invariants:
+#   1. login to a down server → "error: cannot reach the server at <url>"
+#   2. no reqwest chain leak ("os error", "tcp connect error", "trying to connect")
+#   3. exit code is non-zero
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+# A port we deliberately leave unbound. 1 is privileged and never listened
+# to by a normal process; the connect() refuses immediately.
+PORT=1
+URL="http://127.0.0.1:$PORT"
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t4-server-salt"
+scheduler.interval = 1
+EOF
+
+cleanup() { rm -rf "$CFG"; }
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+log "== T4-server: login against a down server =="
+
+set +e
+OUT=$("$RING_BIN" login --username admin --password changeme 2>&1)
+RC=$?
+set -e
+
+# --- Invariant 1: human, actionable line mentioning the endpoint ---
+echo "$OUT" | grep -qF "error: cannot reach the server at $URL" \
+  || { echo "$OUT" >&2; fail "1: expected \"error: cannot reach the server at $URL\""; }
+log "1 (human message): present"
+
+# --- Invariant 2: no reqwest source-chain leak ---
+if echo "$OUT" | grep -qiE 'os error|tcp connect error|trying to connect|error sending request'; then
+  echo "$OUT" >&2
+  fail "2: reqwest source chain leaked to the user"
+fi
+log "2 (no chain leak): clean"
+
+# --- Invariant 3: non-zero exit ---
+[ "$RC" -ne 0 ] || fail "3: login to a down server must exit non-zero (got $RC)"
+log "3 (exit code): non-zero ($RC)"
+
+log "== T4-server: all invariants passed =="


### PR DESCRIPTION
## Problem

When the server is down (or the host/port is wrong), `ring login` dumped
reqwest's nested source chain at the user:

```
$ ring login -u admin -p changeme
Connection failed: error sending request for url (http://localhost:3030/login): error trying to connect: tcp connect error: Connection refused (os error 111)
```

This is a transport failure — no HTTP response was ever received — so the
status-based error path does not apply, and the raw chain helps no one.

## Approach

`transport_error(&reqwest::Error, endpoint)` in `commands/problem_json.rs`
classifies the failure (`is_connect` / `is_timeout` / `is_request`) and
returns one actionable line that names the endpoint the user can check.
Wired into `ring login`. No API change.

## Result

```
$ ring login -u admin -p changeme
error: cannot reach the server at http://localhost:3030 — is it running? (connection refused)
```

Timeout and malformed-request cases are reported the same way: one line,
no nested chain.

## Tests

- Unit test that drives a real connection to a dead port (deterministic,
  no network/DNS) and asserts the message is human and leaks no chain.
  Full suite green (394 passed, 0 failed).
- `tests/e2e/server/t4_login_server_down.sh`: 3 invariants against the
  real compiled binary (human line present, no reqwest chain leak,
  non-zero exit). Stable over 3 consecutive runs.
- Docs: `reference/cli.md`, `ring login` section.

## Note

Touches `commands/problem_json.rs`, which is also extended by the
human-error-messages change on a sibling branch. A small, benign merge
conflict is expected there (both add helper functions side by side; keep
both).