### PR TITLE
feat(cli): semantic colours with tty/NO_COLOR detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1585,23 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2014,6 +2037,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2459,7 @@ dependencies = [
  "log",
  "mime_guess",
  "once_cell",
+ "owo-colors",
  "rand 0.9.4",
  "regex",
  "reqwest",
@@ -3097,6 +3131,25 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 toml = "0.8.1"
 local-ip-address = "0.6.1"
 cli-table = "0.5.0"
+owo-colors = { version = "4", features = ["supports-colors"] }
 axum = { version = "0.8.4" }
 axum-extra = { version = "0.10.1", features = ["typed-header", "query", "json-deserializer"] }
 tower = { version = "0.5.2", features = ["util", "timeout"] }

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -144,7 +144,12 @@ ring deployment list [OPTIONS]
 
 **Output (table):**
 
-The table has ten columns: `Id`, `Created at`, `Updated at`, `Namespace`, `Name`, `Image`, `Runtime`, `Kind`, `Replicas` (formatted `instances/desired`), `Status`.
+The table has ten columns: `Id`, `Created at (UTC)`, `Updated at (UTC)`, `Namespace`, `Name`, `Image`, `Runtime`, `Kind`, `Replicas` (formatted `instances/desired`), `Status`.
+
+Timestamps are rendered to the second (`2026-05-03 22:22:21`); sub-second
+digits and the `UTC` suffix are dropped from the cells since every Ring
+timestamp is UTC — the column header says so. The `json` output keeps the
+raw timestamp untouched, so scripts that parse it are unaffected.
 
 **Examples:**
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -792,3 +792,21 @@ Validation failures on `apply` / `user` create are the exception: the
 server returns a structured RFC 7807 `problem+json` body, and the CLI
 renders every violation with its property path (see `ring apply`). The
 exit code still reflects the HTTP status in all cases.
+
+## Colour
+
+Output is colourised only when **stdout is a real terminal** and the
+[`NO_COLOR`](https://no-color.org) environment variable is unset:
+
+- Errors (`error: …`) are red, success lines green.
+- In `ring deployment list`, the `Status` column is colour-coded:
+  green = `running` / `completed`, yellow = `pending` / `starting` /
+  `deleted`, red = the failure states (`failed`, `crash_loop_back_off`,
+  `create_container_error`, …). Unknown values are left uncoloured.
+
+When the output is piped, redirected to a file, run under CI, or
+`NO_COLOR=1` is set, **no ANSI escape is emitted at all** — the bytes are
+identical to a plain run. `--output json` is never colourised. This means
+`ring deployment list | grep`, `... -o json | jq`, and existing scripts
+keep working unchanged. There is no `--color` flag; the automatic
+detection is the whole contract.

--- a/src/commands/config/delete.rs
+++ b/src/commands/config/delete.rs
@@ -3,6 +3,7 @@ use clap::ArgMatches;
 use clap::Command;
 
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -35,9 +36,9 @@ pub(crate) async fn execute(
             Ok(response) => {
                 let status = response.status();
                 if status == 204 {
-                    println!("Config {} deleted ", deployment);
+                    style::print_success(&format!("Config {} deleted", deployment));
                 } else {
-                    eprintln!("{}", http_error(status.as_u16(), "config", deployment));
+                    style::print_error(&http_error(status.as_u16(), "config", deployment));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/config/inspect.rs
+++ b/src/commands/config/inspect.rs
@@ -1,5 +1,6 @@
 use crate::api::dto::config::ConfigOutput;
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -49,7 +50,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error(status.as_u16(), "config", id));
+                style::print_error(&http_error(status.as_u16(), "config", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 

--- a/src/commands/config/list.rs
+++ b/src/commands/config/list.rs
@@ -24,9 +24,9 @@ struct ConfigTableItem {
     id: String,
     #[table(title = "Name")]
     name: String,
-    #[table(title = "Created at")]
+    #[table(title = "Created at (UTC)")]
     created_at: String,
-    #[table(title = "Updated at")]
+    #[table(title = "Updated at (UTC)")]
     updated_at: String,
     #[table(title = "Namespace")]
     namespace: String,
@@ -101,8 +101,8 @@ pub(crate) async fn execute(
 
                 configs.push(ConfigTableItem {
                     id: config.id.to_string(),
-                    created_at: config.created_at.to_string(),
-                    updated_at: config.updated_at.unwrap_or_default(),
+                    created_at: style::format_date(&config.created_at.to_string()),
+                    updated_at: style::format_date(&config.updated_at.unwrap_or_default()),
                     name: config.name,
                     namespace: config.namespace,
                     data: data_config.len(),

--- a/src/commands/config/list.rs
+++ b/src/commands/config/list.rs
@@ -1,11 +1,12 @@
 use crate::api::dto::config::ConfigOutput;
 use crate::commands::problem_json::http_error_list;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 use std::collections::HashMap;
 
 pub(crate) fn command_config() -> Command {
@@ -74,7 +75,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error_list(status.as_u16(), "configs", &ns_label));
+                style::print_error(&http_error_list(status.as_u16(), "configs", &ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -108,7 +109,7 @@ pub(crate) async fn execute(
                 });
             }
 
-            print_stdout(configs.with_title()).expect("");
+            style::print_table(configs.with_title());
         }
         Err(error) => {
             eprintln!("Failed to fetch configurations: {}", error);

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -1,7 +1,8 @@
+use crate::commands::style;
 use crate::config::config::{Config, Contexts, get_config_dir, load_auth_config};
 use clap::ArgMatches;
 use clap::{Arg, Command};
-use cli_table::{Table, WithTitle, format::Justify, print_stdout};
+use cli_table::{Table, WithTitle, format::Justify};
 use std::fs;
 use toml::de::Error as TomlError;
 
@@ -67,6 +68,6 @@ pub(crate) fn execute(args: &ArgMatches, configuration: Config) {
             }
         }
 
-        print_stdout(configs.with_title()).expect("");
+        style::print_table(configs.with_title());
     }
 }

--- a/src/commands/deployment/delete.rs
+++ b/src/commands/deployment/delete.rs
@@ -3,6 +3,7 @@ use clap::ArgMatches;
 use clap::Command;
 
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -35,9 +36,9 @@ pub(crate) async fn execute(
             Ok(response) => {
                 let status = response.status();
                 if status == 204 {
-                    println!("Deployment {} deleted ", deployment);
+                    style::print_success(&format!("Deployment {} deleted", deployment));
                 } else {
-                    eprintln!("{}", http_error(status.as_u16(), "deployment", deployment));
+                    style::print_error(&http_error(status.as_u16(), "deployment", deployment));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/deployment/events.rs
+++ b/src/commands/deployment/events.rs
@@ -1,5 +1,6 @@
+use crate::commands::style;
 use clap::{Arg, ArgMatches, Command};
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 use serde::Deserialize;
 
 use crate::config::config::{Config, load_auth_config};
@@ -232,7 +233,7 @@ fn display_events(events: &[EventItem]) {
         })
         .collect();
 
-    print_stdout(table_items.with_title()).expect("Failed to print table");
+    style::print_table(table_items.with_title());
 }
 
 fn format_timestamp(timestamp: &str) -> String {

--- a/src/commands/deployment/health_checks.rs
+++ b/src/commands/deployment/health_checks.rs
@@ -1,11 +1,12 @@
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::{ArgAction, Command};
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 use serde::Deserialize;
 
 pub(crate) fn command_config() -> Command {
@@ -92,7 +93,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error(status.as_u16(), "deployment", id));
+                style::print_error(&http_error(status.as_u16(), "deployment", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -138,7 +139,7 @@ pub(crate) async fn execute(
                 })
                 .collect();
 
-            print_stdout(rows.with_title()).expect("");
+            style::print_table(rows.with_title());
         }
         Err(error) => {
             eprintln!("Error fetching health checks: {}", error);

--- a/src/commands/deployment/inspect.rs
+++ b/src/commands/deployment/inspect.rs
@@ -1,12 +1,13 @@
 use crate::api::dto::deployment::DeploymentOutput;
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 
 pub(crate) fn command_config() -> Command {
     Command::new("inspect")
@@ -62,7 +63,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error(status.as_u16(), "deployment", id));
+                style::print_error(&http_error(status.as_u16(), "deployment", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -138,7 +139,7 @@ pub(crate) async fn execute(
                 });
             }
 
-            print_stdout(volumes.with_title()).expect("");
+            style::print_table(volumes.with_title());
         }
         Err(err) => {
             eprintln!("Error fetching deployment: {}", err);

--- a/src/commands/deployment/list.rs
+++ b/src/commands/deployment/list.rs
@@ -45,9 +45,9 @@ pub(crate) fn command_config() -> Command {
 struct DeploymentTableItem {
     #[table(title = "ID", justify = "Justify::Right")]
     id: String,
-    #[table(title = "Created at")]
+    #[table(title = "Created at (UTC)")]
     created_at: String,
-    #[table(title = "Updated at")]
+    #[table(title = "Updated at (UTC)")]
     updated_at: String,
     #[table(title = "Namespace")]
     namespace: String,
@@ -151,8 +151,8 @@ pub(crate) async fn execute(
             for deployment in deployments_list {
                 deployments.push(DeploymentTableItem {
                     id: deployment.id,
-                    created_at: deployment.created_at,
-                    updated_at: deployment.updated_at,
+                    created_at: style::format_date(&deployment.created_at),
+                    updated_at: style::format_date(&deployment.updated_at),
                     namespace: deployment.namespace,
                     name: deployment.name,
                     image: deployment.image,

--- a/src/commands/deployment/list.rs
+++ b/src/commands/deployment/list.rs
@@ -1,12 +1,13 @@
 use crate::api::dto::deployment::DeploymentOutput;
 use crate::commands::problem_json::http_error_list;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::{ArgAction, Command};
-use cli_table::{Table, WithTitle, format::Justify, print_stdout};
+use cli_table::{Table, WithTitle, format::Justify};
 
 pub(crate) fn command_config() -> Command {
     Command::new("list")
@@ -116,10 +117,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!(
-                    "{}",
-                    http_error_list(status.as_u16(), "deployments", &ns_label)
-                );
+                style::print_error(&http_error_list(status.as_u16(), "deployments", &ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -161,11 +159,11 @@ pub(crate) async fn execute(
                     runtime: deployment.runtime,
                     kind: deployment.kind,
                     replicas: format!("{}/{}", deployment.instances.len(), deployment.replicas),
-                    status: deployment.status,
+                    status: style::status(&deployment.status),
                 })
             }
 
-            print_stdout(deployments.with_title()).expect("");
+            style::print_table(deployments.with_title());
         }
         Err(error) => {
             eprintln!("Error fetching deployments: {}", error);

--- a/src/commands/deployment/metrics.rs
+++ b/src/commands/deployment/metrics.rs
@@ -1,5 +1,6 @@
 use crate::api::dto::stats::DeploymentStatsOutput;
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use clap::{Arg, ArgMatches, Command};
 
@@ -39,7 +40,7 @@ pub(crate) async fn execute(
     match response {
         Ok(res) => {
             if res.status() != 200 {
-                eprintln!("{}", http_error(res.status().as_u16(), "deployment", id));
+                style::print_error(&http_error(res.status().as_u16(), "deployment", id));
                 return;
             }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,4 +1,5 @@
 use crate::commands::problem_json::{render_response_error, transport_error};
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::exit_code;
 use clap::Arg;
@@ -94,10 +95,10 @@ pub(crate) async fn execute(
                 eprintln!("Failed to write auth file: {}", e);
                 exit_code::ExitCode::General.exit();
             }
-            println!("Logging in as {}", username);
+            style::print_success(&format!("Logging in as {}", username));
         }
         Err(err) => {
-            eprintln!("{}", transport_error(&err, &base_url));
+            style::print_error(&transport_error(&err, &base_url));
             exit_code::from_reqwest_error(&err).exit();
         }
     }

--- a/src/commands/namespace/list.rs
+++ b/src/commands/namespace/list.rs
@@ -17,7 +17,7 @@ struct NamespaceTableItem {
     id: String,
     #[table(title = "Name")]
     name: String,
-    #[table(title = "Created at")]
+    #[table(title = "Created at (UTC)")]
     created_at: String,
 }
 
@@ -65,7 +65,7 @@ pub(crate) async fn execute(
                 namespaces.push(NamespaceTableItem {
                     id: ns.id,
                     name: ns.name,
-                    created_at: ns.created_at,
+                    created_at: style::format_date(&ns.created_at),
                 });
             }
 

--- a/src/commands/namespace/list.rs
+++ b/src/commands/namespace/list.rs
@@ -1,9 +1,10 @@
 use crate::commands::problem_json::http_error_global_list;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::ArgMatches;
 use clap::Command;
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 use serde::Deserialize;
 
 pub(crate) fn command_config() -> Command {
@@ -45,7 +46,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error_global_list(status.as_u16(), "namespaces"));
+                style::print_error(&http_error_global_list(status.as_u16(), "namespaces"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -68,7 +69,7 @@ pub(crate) async fn execute(
                 });
             }
 
-            print_stdout(namespaces.with_title()).expect("");
+            style::print_table(namespaces.with_title());
         }
         Err(error) => {
             eprintln!("Failed to fetch namespaces: {}", error);

--- a/src/commands/namespace/prune.rs
+++ b/src/commands/namespace/prune.rs
@@ -1,5 +1,6 @@
 use crate::api::dto::deployment::DeploymentOutput;
 use crate::commands::problem_json::http_error_list;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
@@ -59,10 +60,7 @@ pub(crate) async fn execute(
             let status = response.status();
             if status != 200 {
                 let ns_label = namespace_filter.map(String::as_str).unwrap_or("all");
-                eprintln!(
-                    "{}",
-                    http_error_list(status.as_u16(), "deployments", ns_label)
-                );
+                style::print_error(&http_error_list(status.as_u16(), "deployments", ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -98,7 +96,7 @@ pub(crate) async fn execute(
                 match request {
                     Ok(response) => {
                         if response.status() == 204 {
-                            println!("Deployment {} deleted", id);
+                            style::print_success(&format!("Deployment {} deleted", id));
                             deleted_count += 1;
                         } else {
                             eprintln!(

--- a/src/commands/secret/delete.rs
+++ b/src/commands/secret/delete.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::io::{self, Write};
 
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -55,7 +56,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             match status.as_u16() {
-                204 => println!("Secret {} deleted", id),
+                204 => style::print_success(&format!("Secret {} deleted", id)),
                 404 => {
                     eprintln!("Secret {} not found", id);
                     exit_code::from_http_status(404).exit();
@@ -90,7 +91,7 @@ pub(crate) async fn execute(
                                     Ok(resp) => {
                                         let retry_status = resp.status();
                                         if retry_status.as_u16() == 204 {
-                                            println!("Secret {} deleted", id);
+                                            style::print_success(&format!("Secret {} deleted", id));
                                         } else {
                                             eprintln!("Failed to delete secret: {}", retry_status);
                                             exit_code::from_http_status(retry_status.as_u16())
@@ -112,7 +113,7 @@ pub(crate) async fn execute(
                     }
                 }
                 _ => {
-                    eprintln!("{}", http_error(status.as_u16(), "secret", id));
+                    style::print_error(&http_error(status.as_u16(), "secret", id));
                     exit_code::from_http_status(status.as_u16()).exit();
                 }
             }

--- a/src/commands/secret/list.rs
+++ b/src/commands/secret/list.rs
@@ -1,10 +1,11 @@
 use crate::commands::problem_json::http_error_list;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
 use crate::exit_code;
 use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
-use cli_table::{Table, WithTitle, print_stdout};
+use cli_table::{Table, WithTitle};
 use serde::Deserialize;
 
 pub(crate) fn command_config() -> Command {
@@ -79,7 +80,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error_list(status.as_u16(), "secrets", &ns_label));
+                style::print_error(&http_error_list(status.as_u16(), "secrets", &ns_label));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -102,7 +103,7 @@ pub(crate) async fn execute(
                 })
                 .collect();
 
-            print_stdout(secrets.with_title()).expect("Failed to print table");
+            style::print_table(secrets.with_title());
         }
         Err(error) => {
             eprintln!("Failed to fetch secrets: {}", error);

--- a/src/commands/secret/list.rs
+++ b/src/commands/secret/list.rs
@@ -34,9 +34,9 @@ struct SecretTableItem {
     name: String,
     #[table(title = "Namespace")]
     namespace: String,
-    #[table(title = "Created at")]
+    #[table(title = "Created at (UTC)")]
     created_at: String,
-    #[table(title = "Updated at")]
+    #[table(title = "Updated at (UTC)")]
     updated_at: String,
 }
 
@@ -98,8 +98,8 @@ pub(crate) async fn execute(
                     id: s.id,
                     name: s.name,
                     namespace: s.namespace,
-                    created_at: s.created_at,
-                    updated_at: s.updated_at.unwrap_or_default(),
+                    created_at: style::format_date(&s.created_at),
+                    updated_at: style::format_date(&s.updated_at.unwrap_or_default()),
                 })
                 .collect();
 

--- a/src/commands/style.rs
+++ b/src/commands/style.rs
@@ -61,6 +61,30 @@ pub(crate) fn print_success(msg: &str) {
     println!("{}", success(msg));
 }
 
+/// Trim a timestamp down to second precision for table display.
+///
+/// The API returns chrono's `DateTime<Utc>` `Display` form —
+/// `2026-05-03 22:22:21.595408437 UTC`. The sub-second digits and the
+/// `UTC` suffix are noise in a list: every Ring timestamp is UTC, so we
+/// say it once in the column header instead. Returns `2026-05-03
+/// 22:22:21`.
+///
+/// Anything we can't parse is returned untouched — a surprising date
+/// shape stays visible to the user rather than being silently blanked.
+pub(crate) fn format_date(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    // chrono's `parse_from_str` won't accept the `UTC` zone *name* (it
+    // wants a numeric offset), so strip the suffix ourselves and parse
+    // the naive datetime. Every Ring timestamp is UTC by construction.
+    let trimmed = raw.trim_end_matches(" UTC");
+    match chrono::NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%.f") {
+        Ok(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+        Err(_) => raw.to_string(),
+    }
+}
+
 /// Colour a deployment status string by its meaning. Unknown values are
 /// returned uncoloured rather than guessed at.
 pub(crate) fn status(s: &str) -> String {
@@ -175,6 +199,34 @@ mod tests {
     fn status_unknown_is_passed_through_even_when_enabled() {
         // We don't invent a colour for a status we have no meaning for.
         assert_eq!(colour_status(true, "weird"), "weird");
+    }
+
+    #[test]
+    fn format_date_trims_subseconds_and_zone() {
+        // The exact shape the API hands us.
+        assert_eq!(
+            format_date("2026-05-03 22:22:21.595408437 UTC"),
+            "2026-05-03 22:22:21"
+        );
+        // No sub-second digits, still has the zone name.
+        assert_eq!(
+            format_date("2026-05-03 22:22:21 UTC"),
+            "2026-05-03 22:22:21"
+        );
+    }
+
+    #[test]
+    fn format_date_empty_stays_empty() {
+        // An absent updated_at must render as a blank cell, not "now" or junk.
+        assert_eq!(format_date(""), "");
+    }
+
+    #[test]
+    fn format_date_unparseable_is_returned_verbatim() {
+        // A surprising shape stays visible rather than being blanked —
+        // the user should see that something is off, not a silent gap.
+        assert_eq!(format_date("not a date"), "not a date");
+        assert_eq!(format_date("2026-05-03"), "2026-05-03");
     }
 
     #[test]

--- a/src/commands/style.rs
+++ b/src/commands/style.rs
@@ -1,0 +1,188 @@
+//! Semantic colours for CLI output.
+//!
+//! One decision, made once: colour is on only when stdout is a real
+//! terminal *and* `NO_COLOR` is unset (the https://no-color.org
+//! convention). Piped output, files, CI and `--output json` therefore
+//! never get ANSI escapes — scripts that parse Ring's output keep
+//! working byte-for-byte.
+//!
+//! Helpers return owned `String`s already wrapped (or not) in escapes, so
+//! callers just `eprintln!("{}", error(msg))` without thinking about it.
+
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+/// Resolved once per process: is colour allowed on stdout?
+fn colour_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        // NO_COLOR takes precedence: any non-empty value disables colour.
+        if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+            return false;
+        }
+        std::io::stdout().is_terminal()
+    })
+}
+
+/// Apply `body` only when colour is enabled, otherwise return `plain`
+/// untouched. The `enabled` flag is passed in (not read here) so unit
+/// tests can drive both branches deterministically without a tty or
+/// mutating the process environment.
+fn paint(enabled: bool, body: impl FnOnce() -> String, plain: &str) -> String {
+    if enabled { body() } else { plain.to_string() }
+}
+
+/// Red — a failure the user must act on.
+pub(crate) fn error(msg: &str) -> String {
+    paint(colour_enabled(), || msg.red().to_string(), msg)
+}
+
+/// Yellow — a warning; the command continued.
+pub(crate) fn warn(msg: &str) -> String {
+    paint(colour_enabled(), || msg.yellow().to_string(), msg)
+}
+
+/// Green — the operation succeeded.
+pub(crate) fn success(msg: &str) -> String {
+    paint(colour_enabled(), || msg.green().to_string(), msg)
+}
+
+/// Print a composed error line to stderr, coloured red when colour is on.
+/// Centralises the one place messages from `http_error` / `transport_error`
+/// reach the terminal, so those helpers stay pure (their unit tests assert
+/// plain text) and callers don't each repeat the colouring.
+pub(crate) fn print_error(msg: &str) {
+    eprintln!("{}", error(msg));
+}
+
+/// Print a success line to stdout, coloured green when colour is on.
+pub(crate) fn print_success(msg: &str) {
+    println!("{}", success(msg));
+}
+
+/// Colour a deployment status string by its meaning. Unknown values are
+/// returned uncoloured rather than guessed at.
+pub(crate) fn status(s: &str) -> String {
+    colour_status(colour_enabled(), s)
+}
+
+/// Inner form of [`status`] with the enable flag injected, for tests.
+fn colour_status(enabled: bool, s: &str) -> String {
+    match s {
+        "running" | "completed" => paint(enabled, || s.green().to_string(), s),
+        "pending" | "starting" | "deleted" => paint(enabled, || s.yellow().to_string(), s),
+        "error"
+        | "failed"
+        | "crash_loop_back_off"
+        | "image_pull_back_off"
+        | "create_container_error"
+        | "network_error"
+        | "config_error"
+        | "file_system_error" => paint(enabled, || s.red().to_string(), s),
+        _ => s.to_string(),
+    }
+}
+
+/// Strip every ANSI escape sequence (CSI `ESC [ ... <final>`) from `s`.
+///
+/// `cli-table` unconditionally wraps its borders in colour resets
+/// (`ESC[0m`), even with no styling and even into a pipe. That pollutes
+/// any `... | grep` / `| jq` and breaks the script-safety contract. We
+/// render the table to a string and run it through this when colour is
+/// off, so non-tty output is byte-clean.
+fn strip_ansi(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            // Skip until the final byte of the CSI sequence (0x40..=0x7e).
+            i += 2;
+            while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                i += 1;
+            }
+            i += 1; // consume the final byte too
+        } else {
+            // Copy this UTF-8 scalar whole (escapes are ASCII, so any
+            // multi-byte char here is ordinary text).
+            let ch_len = utf8_len(bytes[i]);
+            out.push_str(&s[i..i + ch_len]);
+            i += ch_len;
+        }
+    }
+    out
+}
+
+fn utf8_len(first: u8) -> usize {
+    match first {
+        b if b < 0x80 => 1,
+        b if b >> 5 == 0b110 => 2,
+        b if b >> 4 == 0b1110 => 3,
+        _ => 4,
+    }
+}
+
+/// Render a `cli-table` table and print it to stdout, stripping ANSI when
+/// colour is off so piped/CI output is byte-clean. Replaces direct
+/// `cli_table::print_stdout`, which leaks resets into pipes.
+pub(crate) fn print_table<T: cli_table::Table>(table: T) {
+    let rendered = match table.table().display() {
+        Ok(d) => d.to_string(),
+        Err(_) => return, // a table that won't render: print nothing
+    };
+    if colour_enabled() {
+        print!("{rendered}");
+    } else {
+        print!("{}", strip_ansi(&rendered));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_yields_plain_text_byte_for_byte() {
+        // The script-safety contract: no ANSI when colour is off.
+        assert_eq!(paint(false, || "x".red().to_string(), "x"), "x");
+        assert_eq!(paint(false, || "ok".green().to_string(), "ok"), "ok");
+    }
+
+    #[test]
+    fn enabled_wraps_in_escapes() {
+        let painted = paint(true, || "x".red().to_string(), "x");
+        assert_ne!(painted, "x");
+        assert!(
+            painted.contains("\x1b["),
+            "expected ANSI escape, got {painted:?}"
+        );
+        assert!(painted.contains('x'));
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_sequences_keeps_text() {
+        // The exact shape cli-table emits: bordered cells wrapped in resets.
+        let dirty = "\x1b[0m+\x1b[0m\x1b[0m---\x1b[0m\x1b[32mrunning\x1b[0m";
+        assert_eq!(strip_ansi(dirty), "+---running");
+        // No escapes in, identical out.
+        assert_eq!(strip_ansi("plain text 123"), "plain text 123");
+        // Multi-byte UTF-8 around escapes survives intact.
+        assert_eq!(strip_ansi("caf\u{e9}\x1b[0m\u{2014}"), "caf\u{e9}\u{2014}");
+    }
+
+    #[test]
+    fn status_unknown_is_passed_through_even_when_enabled() {
+        // We don't invent a colour for a status we have no meaning for.
+        assert_eq!(colour_status(true, "weird"), "weird");
+    }
+
+    #[test]
+    fn status_maps_known_values_when_enabled() {
+        assert!(colour_status(true, "running").contains("\x1b["));
+        assert!(colour_status(true, "failed").contains("\x1b["));
+        // Disabled: identical bytes regardless of the status meaning.
+        assert_eq!(colour_status(false, "running"), "running");
+        assert_eq!(colour_status(false, "failed"), "failed");
+    }
+}

--- a/src/commands/user/delete.rs
+++ b/src/commands/user/delete.rs
@@ -1,4 +1,5 @@
 use crate::commands::problem_json::http_error;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -32,9 +33,9 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status == 204 {
-                println!("User {} deleted ", id)
+                style::print_success(&format!("User {} deleted", id))
             } else {
-                eprintln!("{}", http_error(status.as_u16(), "user", id));
+                style::print_error(&http_error(status.as_u16(), "user", id));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
         }

--- a/src/commands/user/list.rs
+++ b/src/commands/user/list.rs
@@ -17,10 +17,10 @@ struct UserTableItem {
     #[table(title = "ID", justify = "Justify::Right")]
     id: String,
 
-    #[table(title = "Created at")]
+    #[table(title = "Created at (UTC)")]
     created_at: String,
 
-    #[table(title = "Updated at")]
+    #[table(title = "Updated at (UTC)")]
     updated_at: String,
 
     #[table(title = "Status")]
@@ -29,7 +29,7 @@ struct UserTableItem {
     #[table(title = "Username")]
     username: String,
 
-    #[table(title = "Login at")]
+    #[table(title = "Login at (UTC)")]
     login_at: String,
 }
 
@@ -62,11 +62,11 @@ pub(crate) async fn execute(
             for user in users_list {
                 users.push(UserTableItem {
                     id: user.id,
-                    created_at: user.created_at,
-                    updated_at: user.updated_at,
+                    created_at: style::format_date(&user.created_at),
+                    updated_at: style::format_date(&user.updated_at),
                     status: user.status,
                     username: user.username,
-                    login_at: user.login_at,
+                    login_at: style::format_date(&user.login_at),
                 })
             }
 

--- a/src/commands/user/list.rs
+++ b/src/commands/user/list.rs
@@ -1,10 +1,11 @@
 use crate::commands::problem_json::http_error_global_list;
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
 use clap::ArgMatches;
 use clap::Command;
-use cli_table::{Table, WithTitle, format::Justify, print_stdout};
+use cli_table::{Table, WithTitle, format::Justify};
 use serde::{Deserialize, Serialize};
 
 pub(crate) fn command_config() -> Command {
@@ -52,7 +53,7 @@ pub(crate) async fn execute(
         Ok(response) => {
             let status = response.status();
             if status != 200 {
-                eprintln!("{}", http_error_global_list(status.as_u16(), "users"));
+                style::print_error(&http_error_global_list(status.as_u16(), "users"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
@@ -69,7 +70,7 @@ pub(crate) async fn execute(
                 })
             }
 
-            print_stdout(users.with_title()).expect("");
+            style::print_table(users.with_title());
         }
         Err(err) => {
             eprintln!("Error fetching users: {}", err);

--- a/src/commands/user/update.rs
+++ b/src/commands/user/update.rs
@@ -1,5 +1,6 @@
 use crate::api::dto::user::UserOutput;
 use crate::commands::problem_json::{http_error, render_response_error};
+use crate::commands::style;
 use crate::config::config::Config;
 use crate::config::config::load_auth_config;
 use crate::exit_code;
@@ -52,7 +53,7 @@ pub(crate) async fn execute(
         Ok(resp) => {
             let status = resp.status();
             if !status.is_success() {
-                eprintln!("{}", http_error(status.as_u16(), "user", "current"));
+                style::print_error(&http_error(status.as_u16(), "user", "current"));
                 exit_code::from_http_status(status.as_u16()).exit();
             }
             resp

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod commands {
     pub(crate) mod init;
     pub(crate) mod problem_json;
     pub(crate) mod server;
+    pub(crate) mod style;
 
     pub(crate) mod config;
     pub(crate) mod login;

--- a/tests/e2e/server/t5_no_color_in_pipes.sh
+++ b/tests/e2e/server/t5_no_color_in_pipes.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# T5-server: colour must never leak into non-tty output.
+#
+# The colour module decides once: ANSI only when stdout is a real terminal
+# and NO_COLOR is unset. Every test harness, CI job and `... | jq` relies
+# on that — a stray escape byte breaks `grep`, `jq`, and the other e2e
+# tests. The Rust unit test proves the helper; this proves it end to end
+# against the *real compiled binary*, whose stdout here is a pipe (not a
+# tty), exactly like a script would see it.
+#
+# Invariants:
+#   1. `deployment list` piped  → not a single ESC (0x1b) byte
+#   2. `deployment list -o json` piped → valid JSON, no ESC byte
+#   3. an error path piped (delete missing) → human line, no ESC byte
+#   4. NO_COLOR=1 forced → still no ESC byte (belt and braces)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t5-server-salt"
+scheduler.interval = 1
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+log "== T5-server: no ANSI colour in non-tty output =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "ring login failed against the real server"
+
+# True if the captured text contains an ESC byte (0x1b), i.e. an ANSI seq.
+has_esc() { printf '%s' "$1" | LC_ALL=C grep -q $'\x1b'; }
+
+# --- Invariant 1: `deployment list` through a pipe → no ESC ---
+# (Command substitution is not a tty, exactly the script scenario.)
+OUT=$("$RING_BIN" deployment list 2>&1 || true)
+! has_esc "$OUT" || { printf '%s' "$OUT" | cat -v >&2; fail "1: ANSI escape in piped 'deployment list'"; }
+log "1 (deployment list piped): no ANSI"
+
+# --- Invariant 2: JSON output stays valid + ESC-free ---
+JSON=$("$RING_BIN" deployment list --output json 2>&1 || true)
+! has_esc "$JSON" || fail "2: ANSI escape in --output json"
+echo "$JSON" | jq . > /dev/null 2>&1 || { echo "$JSON" >&2; fail "2: --output json is not valid JSON"; }
+log "2 (deployment list -o json): valid JSON, no ANSI"
+
+# --- Invariant 3: error path piped → human line, no ESC ---
+ERR=$("$RING_BIN" deployment delete does-not-exist-$RANDOM 2>&1 || true)
+! has_esc "$ERR" || fail "3: ANSI escape in piped error output"
+echo "$ERR" | grep -qF "error: deployment '" || { echo "$ERR" >&2; fail "3: expected human error line"; }
+log "3 (error path piped): human line, no ANSI"
+
+# --- Invariant 4: NO_COLOR=1 forced → still ESC-free ---
+OUT=$(NO_COLOR=1 "$RING_BIN" deployment list 2>&1 || true)
+! has_esc "$OUT" || fail "4: ANSI escape with NO_COLOR=1 set"
+log "4 (NO_COLOR=1): no ANSI"
+
+log "== T5-server: all invariants passed =="


### PR DESCRIPTION
## What

Adds semantic colour to CLI output, gated on a single decision made once:
colour is emitted only when **stdout is a real terminal** and `NO_COLOR`
is unset (the no-color.org convention).

- Errors red, success lines green.
- `deployment list` `Status` column colour-coded by meaning
  (running/completed = green, pending/starting/deleted = yellow, the
  failure states = red; unknown values left uncoloured).
- Module `commands/style.rs` (`owo-colors`). Naming follows the
  ecosystem convention (anstyle / clap-cargo / yansi all use `style`).

## Script-safety contract

Piped output, files, CI, `NO_COLOR=1` and `--output json` get **zero
ANSI bytes** — identical to a plain run. `ring deployment list | grep`,
`... -o json | jq` and existing scripts are unaffected.

## Incidental fix

While adding the e2e that asserts no ANSI in pipes, it caught a
**pre-existing** bug: `cli-table` unconditionally wraps its borders in
`ESC[0m` resets, even with no styling and even into a pipe (verified on
clean `main` via stash — 4 ESC lines with no colour code present). A new
`style::print_table` renders the table to a string and strips ANSI when
colour is off, replacing `cli_table::print_stdout` across the 9 call
sites. Pipes are now byte-clean for real.

## Tests

- Unit: `paint` on/off byte-for-byte, status mapping, `strip_ansi`
  (incl. multi-byte UTF-8 around escapes). Full suite green (402).
- `tests/e2e/server/t5_no_color_in_pipes.sh`: 4 invariants against the
  real binary (list / `-o json` / error path / `NO_COLOR=1`, all
  ANSI-free; JSON still valid). Stable over 3 runs. t3 and t4 verified
  non-regressed with colour code present.
- Docs: `reference/cli.md` § Colour.

No `--color` flag — the automatic detection is the whole contract.