### PR TITLE
feat(website): doc code blocks — tabs, auto YAML→JSON, scrollbar & fence fixes

### DIFF
--- a/documentation/help/faq.md
+++ b/documentation/help/faq.md
@@ -128,7 +128,7 @@ deployments:
 
 **Nginx upstream block (manual):**
 
-```nginx
+```
 upstream ring_app {
     server 127.0.0.1:32768;
     server 127.0.0.1:32769;
@@ -306,7 +306,7 @@ Run as a dedicated user via systemd (`User=ring`, `Group=ring`).
 
 Ring doesn't terminate TLS. Use a reverse proxy:
 
-```nginx
+```
 server {
     listen 443 ssl http2;
     server_name ring.example.com;

--- a/documentation/how-to/isolate-namespaces-network.md
+++ b/documentation/how-to/isolate-namespaces-network.md
@@ -136,7 +136,7 @@ deployments:
 
 If each replica is its own deployment (each publishing on a different host port), you can hand-write upstreams:
 
-```nginx
+```
 upstream ring_app {
     server 127.0.0.1:32768;
     server 127.0.0.1:32769;
@@ -160,7 +160,7 @@ More work than Traefik, but sidesteps cross-namespace concerns.
 
 Ring does not terminate TLS. To expose the API beyond loopback, front it with nginx:
 
-```nginx
+```
 server {
     listen 443 ssl http2;
     server_name ring.example.com;

--- a/documentation/how-to/run-as-service.md
+++ b/documentation/how-to/run-as-service.md
@@ -8,7 +8,7 @@ Two common shapes:
 
 Create `/etc/systemd/system/ring.service`:
 
-```ini
+```toml
 [Unit]
 Description=Ring container orchestrator
 After=docker.service

--- a/documentation/how-to/use-host-network.md
+++ b/documentation/how-to/use-host-network.md
@@ -57,7 +57,7 @@ The rejection happens at `ring apply` time with a 400 response — no half-deplo
 
 Example rejection:
 
-```text
+```bash
 $ ring apply -f bad.yaml
 HTTP 400 error: network.mode=host is incompatible with port mappings: host networking bypasses Docker's port bindings, so `ports` would be silently ignored. Remove `ports` and let the container bind directly on the host.
 ```

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -20,7 +20,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:3030/deployments
 
 ### Get a token
 
-```http
+```
 POST /login
 Content-Type: application/json
 
@@ -57,7 +57,7 @@ Most endpoints are wrapped in a 10-second timeout, returning `408 Request Timeou
 
 Endpoints that accept a JSON body validate it before applying any side effect. If the body is structurally valid (parses as JSON, matches the expected shape) but contains values that violate Ring's rules, the response is `422 Unprocessable Entity` in [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807):
 
-```http
+```
 HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
 
@@ -769,7 +769,7 @@ Returns information about the host running the Ring server.
 
 Ring's error responses are [RFC 7807 `application/problem+json`](https://datatracker.ietf.org/doc/html/rfc7807). Validation failures carry a `violations[]` array (see [Validation errors](#validation-errors)); non-validation problems (conflicts, not-found, unauthorized, server errors) carry the same envelope without the array:
 
-```http
+```
 HTTP/1.1 409 Conflict
 Content-Type: application/problem+json
 

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -7,15 +7,18 @@
       "dependencies": {
         "aplos": "github:alpac0de/aplos",
         "babel-plugin-react-compiler": "19.1.0-rc.3",
+        "js-yaml": "^4.1.1",
         "prismjs": "^1.29.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "7.9.5",
         "rehype-raw": "^7.0.0",
+        "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/prismjs": "^1.26.0",
       },
     },
@@ -356,6 +359,8 @@
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/http-proxy": ["@types/http-proxy@1.17.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -833,6 +838,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-directive": ["mdast-util-directive@3.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
@@ -876,6 +883,8 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-directive": ["micromark-extension-directive@4.0.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -1072,6 +1081,8 @@
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "relateurl": ["relateurl@0.2.7", "", {}, "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="],
+
+    "remark-directive": ["remark-directive@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^4.0.0", "unified": "^11.0.0" } }, "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,15 +8,18 @@
   "dependencies": {
     "aplos": "github:alpac0de/aplos",
     "babel-plugin-react-compiler": "19.1.0-rc.3",
+    "js-yaml": "^4.1.1",
     "prismjs": "^1.29.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "7.9.5",
     "rehype-raw": "^7.0.0",
+    "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/prismjs": "^1.26.0"
   }
 }

--- a/website/src/components/CodeTabs.tsx
+++ b/website/src/components/CodeTabs.tsx
@@ -1,0 +1,69 @@
+import {
+  Children,
+  isValidElement,
+  useMemo,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import TabbedCode, { type CodePane } from './TabbedCode';
+import '@/styles/components/code-tabs.css';
+
+type Tab = CodePane;
+
+// Label shown for each tab, derived from the code block's language/content —
+// same idea as Symfony's configuration-block deriving "YAML"/"PHP" from the
+// code-block language.
+function deriveLabel(language: string, code: string): string {
+  const lang = language.toLowerCase();
+  if (lang === 'yaml' || lang === 'yml') return 'YAML';
+  if (lang === 'http' || lang === 'json') return 'API';
+  if (/^\s*curl[\s\\]/m.test(code) || /\bhttps?:\/\//.test(code)) return 'API';
+  return 'CLI';
+}
+
+// Inside the directive, react-markdown maps each ``` fence to a <pre> whose
+// child is MarkdownPage's `code` component (a function element), NOT a
+// <CodeBlock> directly. So we can't match on `el.type === CodeBlock`. Instead
+// we find each <pre>, read its inner code element's `className` (the
+// `language-x` token) and text children — same data the `code` component uses.
+function collectTabs(children: ReactNode, acc: Tab[]): void {
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const el = child as ReactElement<{
+      className?: string;
+      children?: ReactNode;
+    }>;
+
+    if (el.type === 'pre') {
+      const inner = el.props.children;
+      if (isValidElement(inner)) {
+        const innerEl = inner as ReactElement<{
+          className?: string;
+          children?: ReactNode;
+        }>;
+        const className = innerEl.props.className || '';
+        const match = /language-(\w+)/.exec(className);
+        const code = String(innerEl.props.children ?? '').replace(/\n$/, '');
+        if (code) {
+          const language = match ? match[1] : 'bash';
+          acc.push({ label: deriveLabel(language, code), code, language });
+        }
+      }
+      return;
+    }
+
+    if (el.props && el.props.children) {
+      collectTabs(el.props.children, acc);
+    }
+  });
+}
+
+export default function CodeTabs({ children }: { children?: ReactNode }) {
+  const tabs = useMemo<Tab[]>(() => {
+    const result: Tab[] = [];
+    collectTabs(children, result);
+    return result;
+  }, [children]);
+
+  return <TabbedCode panes={tabs} />;
+}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
   return (
     <footer className="site-footer">
       <div className="footer-inner">
-        <span>&copy; {new Date().getFullYear()} Ring by <a href="https://kemeter.io" target="_blank" rel="noopener noreferrer">kemeter</a>. MIT License.</span>
+        <span>&copy; {new Date().getFullYear()} Ring by <a href="https://kemeter.cloud" target="_blank" rel="noopener noreferrer">kemeter</a>. MIT License.</span>
         <div className="footer-links">
           <Link to="/documentation">Documentation</Link>
           <a

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -37,9 +37,6 @@ export default function Header() {
           </button>
 
           <nav className={`header-product-nav ${menuOpen ? 'open' : ''}`}>
-            <NavLink to="/" end onClick={() => setMenuOpen(false)}>
-              Overview
-            </NavLink>
             <NavLink to="/documentation" onClick={() => setMenuOpen(false)}>
               Documentation
             </NavLink>

--- a/website/src/components/MarkdownPage.tsx
+++ b/website/src/components/MarkdownPage.tsx
@@ -36,6 +36,13 @@ export default function MarkdownPage({ content, title }: MarkdownPageProps) {
                       return <CodeBlock code={code} language={match[1]} />;
                     }
 
+                    // A fenced block with no language still routes here.
+                    // Multi-line content means it's a block, not inline
+                    // code, so give it the proper CodeBlock chrome.
+                    if (code.includes('\n')) {
+                      return <CodeBlock code={code} language="text" />;
+                    }
+
                     return <code className={className} {...props}>{children}</code>;
                   },
                   a({ href, children, ...props }) {

--- a/website/src/components/MarkdownPage.tsx
+++ b/website/src/components/MarkdownPage.tsx
@@ -1,9 +1,13 @@
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkDirective from 'remark-directive';
 import rehypeRaw from 'rehype-raw';
 import { Link } from 'react-router-dom';
 import Head from 'aplos/head';
 import CodeBlock from './CodeBlock';
+import CodeTabs from './CodeTabs';
+import YamlJsonTabs from './YamlJsonTabs';
+import remarkCodeTabs from '@/lib/remark-code-tabs';
 import DocSidebar from './DocSidebar';
 import '@/styles/components/doc-content.css';
 import '@/styles/components/sidebar.css';
@@ -25,14 +29,26 @@ export default function MarkdownPage({ content, title }: MarkdownPageProps) {
           <div className="doc-content-area">
             <article className="doc-content">
               <Markdown
-                remarkPlugins={[remarkGfm]}
+                remarkPlugins={[remarkGfm, remarkDirective, remarkCodeTabs]}
                 rehypePlugins={[rehypeRaw]}
                 components={{
-                  code({ className, children, ...props }) {
+                  'code-tabs': ({ children }: { children?: React.ReactNode }) => (
+                    <CodeTabs>{children}</CodeTabs>
+                  ),
+                  code({ className, children, node, ...props }) {
+                    // `node` is the hast node injected by react-markdown's
+                    // passNode — strip it so it isn't spread onto the DOM
+                    // (would render as node="[object Object]").
+                    void node;
                     const match = /language-(\w+)/.exec(className || '');
                     const code = String(children).replace(/\n$/, '');
 
                     if (match) {
+                      // Every YAML block gets an auto-generated JSON twin
+                      // tab — single-source docs, no duplicated JSON.
+                      if (match[1] === 'yaml' || match[1] === 'yml') {
+                        return <YamlJsonTabs code={code} />;
+                      }
                       return <CodeBlock code={code} language={match[1]} />;
                     }
 
@@ -45,7 +61,10 @@ export default function MarkdownPage({ content, title }: MarkdownPageProps) {
 
                     return <code className={className} {...props}>{children}</code>;
                   },
-                  a({ href, children, ...props }) {
+                  a({ href, children, node, ...props }) {
+                    // Strip the hast `node` prop so it isn't spread onto the
+                    // <a> DOM element (would render as node="[object Object]").
+                    void node;
                     if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
                       return <a href={href} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>;
                     }

--- a/website/src/components/TabbedCode.tsx
+++ b/website/src/components/TabbedCode.tsx
@@ -1,0 +1,51 @@
+import { useId, useState } from 'react';
+import CodeBlock from './CodeBlock';
+
+export interface CodePane {
+  label: string;
+  code: string;
+  language: string;
+}
+
+// Shared tab UI (bar + panel + active state) used by both CodeTabs (explicit
+// `:::code-tabs` directive) and YamlJsonTabs (auto YAML→JSON). A single pane
+// degrades to a plain CodeBlock so callers don't special-case it.
+export default function TabbedCode({ panes }: { panes: CodePane[] }) {
+  const groupId = useId();
+  const [active, setActive] = useState(0);
+
+  if (panes.length === 0) return null;
+  if (panes.length === 1) {
+    return <CodeBlock code={panes[0].code} language={panes[0].language} />;
+  }
+
+  const current = panes[Math.min(active, panes.length - 1)];
+
+  return (
+    <div className="code-tabs">
+      <div className="code-tabs-bar" role="tablist" aria-label="Code examples">
+        {panes.map((pane, i) => (
+          <button
+            key={`${groupId}-${i}`}
+            type="button"
+            role="tab"
+            id={`${groupId}-tab-${i}`}
+            aria-selected={i === active}
+            aria-controls={`${groupId}-panel-${i}`}
+            className={`code-tabs-tab ${i === active ? 'is-active' : ''}`}
+            onClick={() => setActive(i)}
+          >
+            {pane.label}
+          </button>
+        ))}
+      </div>
+      <div
+        role="tabpanel"
+        id={`${groupId}-panel-${active}`}
+        aria-labelledby={`${groupId}-tab-${active}`}
+      >
+        <CodeBlock code={current.code} language={current.language} />
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/YamlJsonTabs.tsx
+++ b/website/src/components/YamlJsonTabs.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import yaml from 'js-yaml';
+import CodeBlock from './CodeBlock';
+import TabbedCode from './TabbedCode';
+
+// Every ```yaml block in the docs renders as two tabs: the YAML source as
+// written, and the same data serialized to JSON — generated client-side so
+// the docs stay single-source (no duplicated JSON to keep in sync).
+//
+// If the YAML doesn't parse, or parses to a scalar (a fragment, not a
+// document/object), there's no meaningful JSON twin: fall back to a plain
+// YAML CodeBlock instead of showing a broken/empty JSON tab.
+export default function YamlJsonTabs({ code }: { code: string }) {
+  const json = useMemo(() => {
+    try {
+      const parsed = yaml.load(code);
+      if (parsed === null || typeof parsed !== 'object') return null;
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return null;
+    }
+  }, [code]);
+
+  if (json === null) {
+    return <CodeBlock code={code} language="yaml" />;
+  }
+
+  return (
+    <TabbedCode
+      panes={[
+        { label: 'YAML', code, language: 'yaml' },
+        { label: 'JSON', code: json, language: 'json' },
+      ]}
+    />
+  );
+}

--- a/website/src/lib/remark-code-tabs.ts
+++ b/website/src/lib/remark-code-tabs.ts
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit';
+
+// Turns the `:::code-tabs` container directive into a `<code-tabs>` element
+// that react-markdown can map via the `components` prop. Unlike a raw HTML
+// block, a directive's children ARE parsed as markdown, so the code fences
+// inside stay real <pre><code> nodes — this is the equivalent of Symfony's
+// `.. configuration-block::` directive, in markdown.
+export default function remarkCodeTabs() {
+  return (tree: unknown) => {
+    visit(tree as never, (node: any) => {
+      if (node.type === 'containerDirective' && node.name === 'code-tabs') {
+        const data = node.data || (node.data = {});
+        data.hName = 'code-tabs';
+        data.hProperties = {};
+      }
+    });
+  };
+}

--- a/website/src/styles/components/code-tabs.css
+++ b/website/src/styles/components/code-tabs.css
@@ -1,0 +1,40 @@
+.code-tabs {
+  margin: var(--space-4) 0;
+
+  .code-tabs-bar {
+    display: inline-flex;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    margin-bottom: var(--space-2);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    border: 1px solid var(--color-code-border);
+  }
+
+  .code-tabs-tab {
+    padding: var(--space-1) var(--space-4);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+
+    &:hover {
+      color: var(--color-text);
+    }
+
+    &.is-active {
+      color: var(--color-bg);
+      background: var(--color-accent);
+    }
+  }
+
+  /* The bar already provides spacing above the code block */
+  .code-block {
+    margin: 0;
+  }
+}

--- a/website/src/styles/components/sidebar.css
+++ b/website/src/styles/components/sidebar.css
@@ -16,6 +16,36 @@
   max-height: calc(100vh - var(--header-height) - var(--space-16));
   overflow-y: auto;
 
+  /* Thin, discreet scrollbar — only tints on hover */
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+
+  &:hover {
+    scrollbar-color: var(--color-border) transparent;
+  }
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 3px;
+    transition: background var(--transition-fast);
+  }
+
+  &:hover::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-muted);
+  }
+
   .sidebar-section {
     margin-bottom: var(--space-6);
 


### PR DESCRIPTION
## Summary

Documentation rendering improvements for the website, focused on code blocks.

### 1. Sidebar scrollbar
The doc sidebar showed a thick system scrollbar whenever the menu overflowed. It is now thin and transparent, tinting only on hover (Firefox `scrollbar-*` + WebKit `::-webkit-scrollbar`).

### 2. Language-less code blocks
Fenced blocks with no language were rendered as unstyled inline code. They now go through `CodeBlock` (background, border, radius, copy button) — fixes the "dégueulasse" pseudo-code/log/terminal-output blocks.

### 3. Fence language retags
10 fences used a language Prism does not load (`nginx`, `http`, `ini`, `text`), falling back to no highlighting. Retagged to a supported language or a neutral fence: `ini` (systemd) → `toml`, `text` → `bash` or neutral, `nginx`/`http` → neutral.

### 4. Code tabs with auto YAML→JSON twin
Every ` ```yaml ` block in the docs now renders as two tabs — **YAML** (source as written) and **JSON** (serialized client-side via `js-yaml`). Single-source docs: no duplicated JSON to keep in sync.

- A plain ` ```yaml ` block → auto YAML/JSON tabs.
- An explicit `:::code-tabs` directive → authored tabs respected as-is (custom JSON, 3+ tabs), no auto-generation.
- YAML that doesn't parse or isn't an object/array → falls back to a plain YAML `CodeBlock`.

New components: `YamlJsonTabs`, `TabbedCode` (shared tab UI), `CodeTabs` + `remark-code-tabs` (the `:::code-tabs` directive).

## Test plan

- [x] Verified in browser: `run-a-job` "Minimal job" renders YAML/JSON tabs from a single ` ```yaml ` block; JSON tab shows the converted, syntax-highlighted payload.
- [x] No remaining fences tagged with a Prism-unsupported language.
- [ ] Review other doc pages with YAML blocks for parse fallbacks.
