### PR TITLE
fix(secret): accept env-style names (uppercase, underscore)

### DIFF
--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -468,7 +468,7 @@ Secrets are AES-256-GCM-encrypted values stored per-namespace. The API never exp
 | Field | Rule | Code |
 | --- | --- | --- |
 | `namespace` | 2-63 lowercase DNS-label characters | `secret.namespace.length`, `secret.namespace.format` |
-| `name` | 2-253 lowercase DNS-subdomain characters | `secret.name.length`, `secret.name.format` |
+| `name` | 2-253 characters: letters (any case), digits, `_`, `.`, `-`; must start and end with an alphanumeric character | `secret.name.length`, `secret.name.format` |
 | `value` | 1 byte to 1 MiB | `secret.value.length` |
 
 **Errors** (all in `application/problem+json`):

--- a/src/api/action/secret/create.rs
+++ b/src/api/action/secret/create.rs
@@ -45,7 +45,7 @@ pub(crate) struct SecretInput {
         regex(
             path = *SECRET_NAME_PATTERN,
             code = "secret.name.format",
-            message = "must contain only lowercase letters, digits, '.' and '-', and start and end with an alphanumeric character"
+            message = "must contain only letters, digits, '_', '.' and '-', and start and end with an alphanumeric character"
         )
     )]
     name: String,
@@ -189,6 +189,77 @@ mod tests {
         let body: serde_json::Value = response.json();
         assert_eq!(body["name"], "db-password");
         assert_eq!(body["namespace"], "production");
+    }
+
+    #[tokio::test]
+    async fn create_secret_with_uppercase_env_style_name() {
+        // Secret names mirror the env-variable keys consumers inject
+        // (SCREAMING_SNAKE_CASE), so uppercase and underscore must be
+        // accepted, otherwise such pushes 422 and namespaces stay empty.
+        set_test_key();
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        create_namespace(&server, &token, "alpacode").await;
+
+        let response = server
+            .post("/secrets")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({
+                "namespace": "alpacode",
+                "name": "POSTGRESQL_ADDON_PASSWORD",
+                "value": "s3cret"
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["name"], "POSTGRESQL_ADDON_PASSWORD");
+        assert_eq!(body["namespace"], "alpacode");
+    }
+
+    #[tokio::test]
+    async fn create_secret_with_underscore_boundary_is_rejected() {
+        // Underscore is allowed *inside* the name but the value must still
+        // start and end with an alphanumeric character: `_FOO` and `FOO_`
+        // must 422 so the regex anchors can't silently regress.
+        set_test_key();
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        create_namespace(&server, &token, "alpacode").await;
+
+        for invalid_name in ["_LEADING_UNDERSCORE", "TRAILING_UNDERSCORE_"] {
+            let response = server
+                .post("/secrets")
+                .add_header("Authorization", format!("Bearer {}", token))
+                .json(&serde_json::json!({
+                    "namespace": "alpacode",
+                    "name": invalid_name,
+                    "value": "s3cret"
+                }))
+                .await;
+
+            assert_eq!(
+                response.status_code(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "expected `{}` to be rejected",
+                invalid_name
+            );
+            let body: serde_json::Value = response.json();
+            assert!(
+                body["violations"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|v| v["code"] == "secret.name.format"),
+                "expected a secret.name.format violation for `{}`, got {}",
+                invalid_name,
+                body
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/api/action/secret/validation.rs
+++ b/src/api/action/secret/validation.rs
@@ -6,10 +6,12 @@ use regex::Regex;
 pub(crate) const SECRET_NAME_MIN: u64 = 2;
 pub(crate) const SECRET_NAME_MAX: u64 = 253;
 
-/// Kubernetes secret-name convention: lowercase DNS subdomain. Letters,
-/// digits, dot and dash, must start and end with an alphanumeric.
+/// Environment-variable naming: secret names mirror the env keys consumers
+/// inject (e.g. `DATABASE_PASSWORD`), so uppercase and underscore are
+/// allowed alongside digits, dot and dash. Must start and end with an
+/// alphanumeric character.
 pub(crate) static SECRET_NAME_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$").unwrap());
+    Lazy::new(|| Regex::new(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$").unwrap());
 
 /// Hard upper bound on the plaintext value. Anything bigger should live in
 /// a config or an external secret store. 1 MiB matches Kubernetes' Secret

--- a/tests/e2e/docker/t27_secret_validation_problem_json.sh
+++ b/tests/e2e/docker/t27_secret_validation_problem_json.sh
@@ -18,9 +18,12 @@ ring_login
 OUTPUT_FILE=$(mktemp -t ring-e2e-t27-XXXXXX)
 trap 'rm -f "$OUTPUT_FILE"' EXIT
 
-# Case 1: invalid name → 422 with violations.
+# Case 1: invalid name → 422 with violations. `!` is outside the allowed
+# character set; uppercase + underscore are now valid, so they no longer
+# serve as the invalid example. (A leading dash would trip CLI arg parsing
+# instead of the validator, so it can't be used here.)
 set +e
-"$RING_BIN" secret create "BAD_NAME" --namespace ring-e2e --value "x" \
+"$RING_BIN" secret create "bad!name" --namespace ring-e2e --value "x" \
   > "$OUTPUT_FILE" 2>&1
 EXIT_CODE=$?
 set -e
@@ -32,7 +35,7 @@ sed 's/^/  | /' "$OUTPUT_FILE"
 if [ "$EXIT_CODE" -eq 0 ]; then
   fail "expected secret create to fail on invalid name"
 fi
-if ! grep -q "Failed to create secret 'BAD_NAME'" "$OUTPUT_FILE"; then
+if ! grep -q "Failed to create secret 'bad!name'" "$OUTPUT_FILE"; then
   fail "missing context line with the secret name"
 fi
 if ! grep -q "(422)" "$OUTPUT_FILE"; then


### PR DESCRIPTION
## Problem

Secret name validation only accepted lowercase Kubernetes DNS-subdomain names (`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`). Secret names that mirror the env-variable keys consumers inject (e.g. `POSTGRESQL_ADDON_PASSWORD`, SCREAMING_SNAKE_CASE) were rejected with a 422.

## Change

- Widen `SECRET_NAME_PATTERN` to allow uppercase letters and underscore alongside digits, dot and dash, keeping the alphanumeric start/end anchors: `^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$`.
- Fix the validation error message, which still claimed "only lowercase letters" and was now misleading.
- Update the API reference doc (`secret.name` validation rule).

This only widens the accepted set, so it is backward-compatible — every previously valid name still validates.

## Tests

- Added unit test: env-style name (`POSTGRESQL_ADDON_PASSWORD`) is accepted (201).
- Added negative unit test: leading/trailing underscore (`_FOO`, `FOO_`) is still rejected (422), locking the regex anchors.
- Updated e2e `t27` to use a character-class-invalid name (`bad!name`), since uppercase+underscore is no longer an invalid example.

Verified green:
- `cargo test --bin ring secret::create` — 6/6 pass
- `tests/e2e/docker/t27_secret_validation_problem_json.sh` — PASS