### PR TITLE
Website redesign + fix YAML/JSON deployment tabs

### DIFF
--- a/website/public/images/ring-logo.svg
+++ b/website/public/images/ring-logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <circle cx="32" cy="32" r="24" stroke="#22c55e" stroke-width="5" fill="none"/>
-  <circle cx="32" cy="32" r="12" stroke="#22c55e" stroke-width="3" fill="none" opacity="0.5"/>
+  <circle cx="32" cy="32" r="24" stroke="#1a3a6e" stroke-width="5" fill="none"/>
+  <circle cx="32" cy="32" r="12" stroke="#1a3a6e" stroke-width="3" fill="none" opacity="0.5"/>
 </svg>

--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -29,6 +29,9 @@ export default function CodeBlock({ code, language = 'bash', filename }: CodeBlo
     <div className={`code-block ${filename ? 'has-header' : ''}`}>
       {filename && (
         <div className="code-block-header">
+          <div className="code-block-dots">
+            <span /><span /><span />
+          </div>
           <span className="code-block-filename">{filename}</span>
           <CopyButton text={code} />
         </div>

--- a/website/src/components/FeatureGrid.tsx
+++ b/website/src/components/FeatureGrid.tsx
@@ -1,0 +1,55 @@
+import '@/styles/components/feature-grid.css';
+
+interface GridFeature {
+  number: string;
+  title: string;
+  description: string;
+}
+
+const FEATURES: GridFeature[] = [
+  {
+    number: '01',
+    title: 'Declarative YAML',
+    description: 'Describe your entire deployment in one file. Ring handles containers, networking, and scaling.',
+  },
+  {
+    number: '02',
+    title: 'Complete REST API',
+    description: 'Every CLI operation is also an API call. Integrate Ring into your CI/CD pipelines and scripts.',
+  },
+  {
+    number: '03',
+    title: 'Encrypted secrets',
+    description: 'Sensitive values encrypted at rest with AES-256-GCM, decrypted and injected at deployment time.',
+  },
+  {
+    number: '04',
+    title: 'Health checks & rolling updates',
+    description: 'Zero-downtime rolling updates. If a new container fails, the rollout stops automatically.',
+  },
+];
+
+export default function FeatureGrid() {
+  return (
+    <section className="feature-grid-section">
+      <div className="container">
+        <div className="feature-grid-header">
+          <span className="feature-grid-eyebrow">Features</span>
+          <h2 className="feature-grid-title">Everything you need, nothing you don&apos;t.</h2>
+          <p className="feature-grid-subtitle">
+            A pragmatic alternative to Kubernetes for single-node deployments.
+          </p>
+        </div>
+        <div className="feature-grid">
+          {FEATURES.map((f) => (
+            <article key={f.title} className="feature-grid-card">
+              <div className="feature-grid-card-label">{f.number}</div>
+              <h3 className="feature-grid-card-title">{f.title}</h3>
+              <p className="feature-grid-card-description">{f.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -11,9 +11,9 @@ export default function Header() {
       <div className="header-bottom">
         <div className="header-bottom-inner">
           <Link to="/" className="header-product-logo">
-            <svg width="24" height="24" viewBox="0 0 64 64" fill="none">
-              <circle cx="32" cy="32" r="24" stroke="#22c55e" strokeWidth="5" fill="none"/>
-              <circle cx="32" cy="32" r="12" stroke="#22c55e" strokeWidth="3" fill="none" opacity="0.5"/>
+            <svg width="24" height="24" viewBox="0 0 64 64" fill="none" style={{ color: 'var(--color-accent)' }}>
+              <circle cx="32" cy="32" r="24" stroke="currentColor" strokeWidth="5" fill="none"/>
+              <circle cx="32" cy="32" r="12" stroke="currentColor" strokeWidth="3" fill="none" opacity="0.5"/>
             </svg>
             <div className="header-product-name">
               <span>Ring</span>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -8,7 +8,11 @@ export default function Hero() {
   return (
     <section className="hero">
       <div className="hero-inner">
-        <h1>Lightweight workload orchestration, simplified</h1>
+        <h1 className="hero-title">
+          Lightweight workload orchestration,
+          <br />
+          <span className="hero-title-accent">simplified.</span>
+        </h1>
         <p className="hero-subtitle">
           Deploy and manage workloads with declarative YAML,
           a REST API, and zero complexity. A lightweight alternative to Kubernetes.

--- a/website/src/components/ThemeToggle.tsx
+++ b/website/src/components/ThemeToggle.tsx
@@ -1,19 +1,42 @@
 import { useState, useEffect } from 'react';
 
+type Theme = 'light' | 'dark';
+
+function systemTheme(): Theme {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+  // The icon reflects the *effective* theme. The actual theming is done by
+  // CSS (@media prefers-color-scheme) until the user makes an explicit choice,
+  // at which point we set data-theme to override the OS default.
+  const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window !== 'undefined') {
-      return (localStorage.getItem('theme') as 'light' | 'dark') || 'light';
+      const stored = localStorage.getItem('theme') as Theme | null;
+      return stored ?? systemTheme();
     }
     return 'light';
   });
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
-  }, [theme]);
+    const stored = localStorage.getItem('theme') as Theme | null;
+    // Only pin data-theme when the user has explicitly chosen a theme.
+    // Without a stored choice, leave the DOM untouched so the pure-CSS
+    // OS default applies with no flash.
+    if (stored) {
+      document.documentElement.setAttribute('data-theme', stored);
+    }
+  }, []);
 
-  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+  const toggle = () => {
+    const next: Theme = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.setAttribute('data-theme', next);
+  };
 
   return (
     <button

--- a/website/src/components/YamlJsonTabs.tsx
+++ b/website/src/components/YamlJsonTabs.tsx
@@ -4,17 +4,61 @@ import CodeBlock from './CodeBlock';
 import TabbedCode from './TabbedCode';
 
 // Every ```yaml block in the docs renders as two tabs: the YAML source as
-// written, and the same data serialized to JSON — generated client-side so
-// the docs stay single-source (no duplicated JSON to keep in sync).
+// written, and a JSON twin generated client-side so the docs stay
+// single-source (no duplicated JSON to keep in sync).
 //
-// If the YAML doesn't parse, or parses to a scalar (a fragment, not a
-// document/object), there's no meaningful JSON twin: fall back to a plain
-// YAML CodeBlock instead of showing a broken/empty JSON tab.
+// The YAML config file is NOT the API payload. A config file wraps
+// deployments under a `deployments:` key, each one named:
+//
+//   deployments:
+//     web-app:
+//       name: web-app
+//       image: nginx:latest
+//
+// but `POST /deployments` takes a single deployment object as its body —
+// without the `deployments:` envelope and without the `web-app:` key. So
+// when a block is a deployments config, the JSON tab shows the actual API
+// request body (one block per deployment). Any other YAML (health_checks,
+// environment fragments, CI files, …) keeps the literal JSON twin, or
+// falls back to a plain YAML block when there's no meaningful JSON.
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// Returns the API request bodies if `parsed` is a deployments config
+// (`deployments:` mapping of named deployment objects), else null.
+function deploymentBodies(parsed: unknown): string | null {
+  if (!isPlainObject(parsed)) return null;
+
+  const keys = Object.keys(parsed);
+  if (keys.length !== 1 || keys[0] !== 'deployments') return null;
+
+  const deployments = parsed.deployments;
+  if (!isPlainObject(deployments)) return null;
+
+  const entries = Object.values(deployments);
+  if (entries.length === 0 || !entries.every(isPlainObject)) return null;
+
+  // One request per deployment; the named key is dropped — it's the
+  // config-file handle, not part of the wire payload.
+  return entries
+    .map(
+      (body) =>
+        `POST /deployments\n${JSON.stringify(body, null, 2)}`,
+    )
+    .join('\n\n');
+}
+
 export default function YamlJsonTabs({ code }: { code: string }) {
   const json = useMemo(() => {
     try {
       const parsed = yaml.load(code);
       if (parsed === null || typeof parsed !== 'object') return null;
+
+      const apiBody = deploymentBodies(parsed);
+      if (apiBody !== null) return apiBody;
+
       return JSON.stringify(parsed, null, 2);
     } catch {
       return null;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Head from 'aplos/head';
 import Hero from '@/components/Hero';
 import FeatureSection from '@/components/FeatureSection';
+import FeatureGrid from '@/components/FeatureGrid';
 import { Link } from 'aplos/navigation';
 
 const SITE_URL = 'https://kemeter.github.io/ring';
@@ -155,6 +156,8 @@ export default function HomePage() {
         language="yaml"
         filename="multi-env.yaml"
       />
+
+      <FeatureGrid />
 
       <section className="section" style={{ textAlign: 'center' }}>
         <div className="container">

--- a/website/src/styles/components/code-block.css
+++ b/website/src/styles/components/code-block.css
@@ -8,15 +8,28 @@
   .code-block-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: var(--space-2) var(--space-4);
-    border-bottom: 1px solid var(--color-code-border);
-    background: var(--color-surface);
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+    .code-block-dots {
+      display: flex;
+      gap: 6px;
+      flex-shrink: 0;
+
+      span {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.15);
+      }
+    }
 
     .code-block-filename {
+      flex: 1;
       font-family: var(--font-mono);
       font-size: var(--text-xs);
-      color: var(--color-text-secondary);
+      color: rgba(255, 255, 255, 0.45);
     }
   }
 
@@ -25,33 +38,37 @@
     padding: var(--space-4) var(--space-6);
     overflow-x: auto;
     font-size: var(--text-sm);
-    line-height: var(--leading-relaxed);
+    line-height: var(--leading-normal);
+    color: var(--color-text-on-code);
 
     code {
       font-family: var(--font-mono);
       background: none;
       padding: 0;
+      color: inherit;
     }
   }
 
   .copy-btn {
     position: absolute;
     top: var(--space-2);
-    right: var(--space-2);
-    padding: var(--space-2);
+    right: var(--space-3);
+    padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-sm);
-    color: var(--color-text-muted);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.55);
     transition: all var(--transition-fast);
     opacity: 0;
     z-index: 1;
 
     &:hover {
-      color: var(--color-text);
-      background: var(--color-surface-hover);
+      color: rgba(255, 255, 255, 0.9);
+      border-color: rgba(255, 255, 255, 0.3);
     }
 
     &.copied {
-      color: var(--color-accent);
+      color: #4ade80;
+      border-color: #4ade80;
     }
   }
 
@@ -65,13 +82,13 @@
   }
 }
 
-/* Prism theme - light */
+/* Prism — sober palette, readable on the dark code surface (both themes) */
 .token.comment,
 .token.prolog,
 .token.doctype,
-.token.cdata { color: #6b7280; }
+.token.cdata { color: #6b7280; font-style: italic; }
 
-.token.punctuation { color: #374151; }
+.token.punctuation { color: #9ca3af; }
 
 .token.property,
 .token.tag,
@@ -79,70 +96,30 @@
 .token.number,
 .token.constant,
 .token.symbol,
-.token.deleted { color: #dc2626; }
+.token.deleted { color: #d4a574; }
 
 .token.selector,
 .token.attr-name,
 .token.string,
 .token.char,
 .token.builtin,
-.token.inserted { color: #16a34a; }
+.token.inserted { color: #8fb1d4; }
 
 .token.operator,
 .token.entity,
-.token.url { color: #0284c7; }
+.token.url { color: var(--color-text-on-code); }
 
 .token.atrule,
 .token.attr-value,
-.token.keyword { color: #7c3aed; }
+.token.keyword { color: #c08bdc; }
 
 .token.function,
-.token.class-name { color: #2563eb; }
+.token.class-name { color: #8fb1d4; }
 
 .token.regex,
 .token.important,
-.token.variable { color: #d97706; }
+.token.variable { color: #d4a574; }
 
 .token.important,
 .token.bold { font-weight: bold; }
 .token.italic { font-style: italic; }
-
-/* Prism theme - dark */
-[data-theme="dark"] {
-  .token.comment,
-  .token.prolog,
-  .token.doctype,
-  .token.cdata { color: #5a6478; }
-
-  .token.punctuation { color: #8892a4; }
-
-  .token.property,
-  .token.tag,
-  .token.boolean,
-  .token.number,
-  .token.constant,
-  .token.symbol,
-  .token.deleted { color: #f87171; }
-
-  .token.selector,
-  .token.attr-name,
-  .token.string,
-  .token.char,
-  .token.builtin,
-  .token.inserted { color: #22c55e; }
-
-  .token.operator,
-  .token.entity,
-  .token.url { color: #38bdf8; }
-
-  .token.atrule,
-  .token.attr-value,
-  .token.keyword { color: #c084fc; }
-
-  .token.function,
-  .token.class-name { color: #60a5fa; }
-
-  .token.regex,
-  .token.important,
-  .token.variable { color: #fbbf24; }
-}

--- a/website/src/styles/components/feature-grid.css
+++ b/website/src/styles/components/feature-grid.css
@@ -1,0 +1,76 @@
+.feature-grid-section {
+  padding: var(--space-24) 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.feature-grid-header {
+  margin-bottom: var(--space-16);
+  max-width: 640px;
+}
+
+.feature-grid-eyebrow {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  color: var(--color-accent);
+  margin-bottom: var(--space-4);
+}
+
+.feature-grid-title {
+  font-size: var(--text-4xl);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin-bottom: var(--space-4);
+  color: var(--color-text);
+}
+
+.feature-grid-subtitle {
+  font-size: var(--text-lg);
+  line-height: var(--leading-normal);
+  color: var(--color-text-secondary);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--color-border);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.feature-grid-card {
+  padding: var(--space-8);
+  background: var(--color-surface);
+}
+
+.feature-grid-card-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
+}
+
+.feature-grid-card-title {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.feature-grid-card-description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+@media (max-width: 768px) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/website/src/styles/components/hero.css
+++ b/website/src/styles/components/hero.css
@@ -8,20 +8,23 @@
     padding: 0 var(--space-6);
   }
 
-  h1 {
+  .hero-title {
     font-size: var(--text-5xl);
-    letter-spacing: -0.03em;
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
     margin-bottom: var(--space-6);
-    background: linear-gradient(135deg, var(--color-text) 0%, var(--color-text-secondary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--color-text);
+  }
+
+  .hero-title-accent {
+    color: var(--color-accent);
   }
 
   .hero-subtitle {
     font-size: var(--text-lg);
     color: var(--color-text-secondary);
-    line-height: var(--leading-relaxed);
+    line-height: var(--leading-normal);
     max-width: 600px;
     margin: 0 auto var(--space-10);
   }
@@ -77,9 +80,10 @@
     padding: var(--space-3) var(--space-6);
     background: var(--color-accent);
     color: #fff;
-    font-weight: 600;
+    font-weight: 500;
     font-size: var(--text-sm);
-    border-radius: var(--radius-md);
+    border: 1.5px solid transparent;
+    border-radius: var(--radius-pill);
     transition: background var(--transition-fast);
 
     &:hover {
@@ -93,17 +97,18 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-3) var(--space-6);
-    background: var(--color-surface);
+    background: transparent;
     color: var(--color-text);
+    font-family: var(--font-mono);
     font-weight: 500;
-    font-size: var(--text-sm);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
+    font-size: var(--text-xs);
+    border: 1.5px solid var(--color-border);
+    border-radius: var(--radius-pill);
     transition: all var(--transition-fast);
 
     &:hover {
       background: var(--color-surface-hover);
-      border-color: var(--color-border-light);
+      border-color: var(--color-text);
     }
   }
 }
@@ -112,7 +117,7 @@
   .hero {
     padding-top: calc(var(--header-height) + var(--space-16));
 
-    h1 {
+    .hero-title {
       font-size: var(--text-3xl);
     }
 

--- a/website/src/styles/variables.css
+++ b/website/src/styles/variables.css
@@ -1,25 +1,31 @@
 :root {
-  /* Colors - Light theme (default) */
-  --color-bg: #ffffff;
-  --color-bg-alt: #f8f9fb;
-  --color-surface: #f1f3f5;
-  --color-surface-hover: #e9ecef;
-  --color-border: #dee2e6;
-  --color-border-light: #ced4da;
+  /* Colors - Light theme (default) — warm off-white, navy ink */
+  --color-bg: #fafaf7;
+  --color-bg-alt: #f3f2ee;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f3f2ee;
+  --color-border: #e6e4dd;
+  --color-border-light: #d3d0c7;
 
-  --color-text: #1a1a2e;
-  --color-text-secondary: #495057;
-  --color-text-muted: #868e96;
+  --color-text: #0e1726;
+  --color-text-secondary: #4d5870;
+  --color-text-muted: #8a93a6;
 
-  --color-accent: #16a34a;
-  --color-accent-hover: #15803d;
-  --color-accent-soft: rgba(22, 163, 74, 0.08);
+  /* Accent — navy blue (single accent, used everywhere) */
+  --color-accent: #1a3a6e;
+  --color-accent-hover: #122a52;
+  --color-accent-soft: rgba(26, 58, 110, 0.08);
 
-  --color-code-bg: #f4f5f7;
-  --color-code-border: #dee2e6;
-  --color-inline-code-bg: #edf0f3;
+  /* Code surface stays dark even in light theme (terminal-window look) */
+  --color-code-bg: #0e1414;
+  --color-code-border: #0e1414;
+  --color-text-on-code: #e9ebef;
+  --color-inline-code-bg: #f3f2ee;
 
-  --header-bg: rgba(255, 255, 255, 0.8);
+  --header-bg: rgba(250, 250, 247, 0.8);
+
+  --shadow-card: 0 1px 2px rgba(14, 23, 38, 0.04), 0 1px 1px rgba(14, 23, 38, 0.03);
+  --shadow-elevated: 0 4px 12px rgba(14, 23, 38, 0.06);
 
   /* Typography */
   --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -64,12 +70,42 @@
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+  --radius-pill: 999px;
 
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
 }
 
+/* 1. Default: follow the OS — pure CSS, applied before any JS (no flash).
+      Skipped only when the user explicitly forced light via the toggle. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg: #0b0d0f;
+    --color-bg-alt: #0e1117;
+    --color-surface: #151820;
+    --color-surface-hover: #1a1f2e;
+    --color-border: #1e2330;
+    --color-border-light: #2a3040;
+
+    --color-text: #e4e8ef;
+    --color-text-secondary: #8892a4;
+    --color-text-muted: #5a6478;
+
+    --color-accent: #5b8def;
+    --color-accent-hover: #7ba3f2;
+    --color-accent-soft: rgba(91, 141, 239, 0.12);
+
+    --color-code-bg: #0e1414;
+    --color-code-border: #0e1414;
+    --color-text-on-code: #e9ebef;
+    --color-inline-code-bg: #1a1f2e;
+
+    --header-bg: rgba(11, 13, 15, 0.8);
+  }
+}
+
+/* 2. Manual override: user clicked the toggle and chose dark explicitly. */
 [data-theme="dark"] {
   --color-bg: #0b0d0f;
   --color-bg-alt: #0e1117;
@@ -82,12 +118,13 @@
   --color-text-secondary: #8892a4;
   --color-text-muted: #5a6478;
 
-  --color-accent: #22c55e;
-  --color-accent-hover: #16a34a;
-  --color-accent-soft: rgba(34, 197, 94, 0.1);
+  --color-accent: #5b8def;
+  --color-accent-hover: #7ba3f2;
+  --color-accent-soft: rgba(91, 141, 239, 0.12);
 
-  --color-code-bg: #111318;
-  --color-code-border: #1e2330;
+  --color-code-bg: #0e1414;
+  --color-code-border: #0e1414;
+  --color-text-on-code: #e9ebef;
   --color-inline-code-bg: #1a1f2e;
 
   --header-bg: rgba(11, 13, 15, 0.8);


### PR DESCRIPTION
## Summary

Visual redesign of the marketing site and a docs bug fix.

### Redesign
- Warm off-white theme (`#fafaf7`) with navy ink, navy-blue accent
- Code blocks restyled as terminal windows (macOS dots + dark surface, contrast on the light page)
- Hero: accent-colored title line, pill buttons, removed the grey gradient
- New numbered 2×2 feature grid before the final CTA
- Default theme now follows the OS via `@media (prefers-color-scheme)` (pure CSS, no flash); the manual toggle still overrides and persists
- Favicon recolored to match the accent

No existing copy was changed — only styling, one new component, and the theme logic.

### Fix
- Docs YAML blocks: the JSON twin tab now renders the actual `POST /deployments` request body — the `deployments:` envelope and the named deployment key are stripped. One request block per deployment. Non-deployment YAML keeps the previous literal-JSON behavior.

## Verification
- Both themes verified in-browser (OS dark default with no flash, manual light override beats OS dark)
- JSON tab transformation verified on `documentation/how-to/deploy-with-secrets`

## Notes
- The site header is still dark on the new light background — out of scope here, can be a follow-up.