### PR TITLE
Honor top-level configs: block in ring apply

### DIFF
--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -2,7 +2,7 @@
 
 The complete schema for the YAML / JSON files you pass to `ring apply -f`. Every field, what Ring expects in it, and what happens if you omit it.
 
-A manifest has two top-level keys: `namespaces:` (optional) and `deployments:` (required).
+A manifest has three top-level keys: `namespaces:` (optional), `configs:` (optional) and `deployments:` (required).
 
 > **Runtime parity.** Most fields below are honored by both runtimes. A handful are Docker-only — they are declared in the manifest, accepted by the API, and either silently ignored or rejected by the Cloud Hypervisor runtime. Each affected section flags this inline; the cross-cutting list lives on [How-to: deploy on Cloud Hypervisor → Limitations](/documentation/how-to/deploy-on-cloud-hypervisor#limitations-parity-with-docker).
 
@@ -33,6 +33,28 @@ namespaces:
   staging:
     name: staging
 ```
+
+### `configs:` (optional)
+
+A map of config declarations. When present, Ring creates them after namespaces and before deployments, so a deployment that mounts one via a [`type: config` volume](#volumes) can resolve it on first apply. Already-existing configs (same `name` + `namespace`) are reported as "already exists, skipping" — re-applying an unchanged manifest is idempotent and never errors. The map key is internal; Ring keys the config by its `name` + `namespace`.
+
+```yaml
+configs:
+  nginx-config:
+    namespace: production
+    name: "nginx-config"
+    data: '{"site.conf":"server { listen 80; }"}'
+    # labels: "tier=frontend"   # optional
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `namespace` | string | yes | Namespace the config lives in. Must match the namespace of any deployment mounting it. |
+| `name` | string | yes | Config name. This is what a `type: config` volume's `source` references. |
+| `data` | string | yes | JSON object mapping keys to payloads, e.g. `{"site.conf":"..."}`. A `type: config` volume's `key` selects which entry to mount. Subject to `$VAR` interpolation like deployment fields. |
+| `labels` | string | no | Free-form labels. |
+
+> A manifest carrying its own `configs:` is self-sufficient: `ring apply -f manifest.yaml` creates the configs and the deployments that reference them in one pass — no out-of-band `ring config create` needed.
 
 ### `deployments:` (required)
 

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -40,8 +40,8 @@ deployments:
               source: test-config2
               key: "test.conf"
               destination: /var/config/test.conf
-              driver: local
-              permission: rw
+              # config volumes are always mounted read-only; `ring apply`
+              # forces `ro` regardless of what is written here.
 
         labels:
             - sozune.host: "nginx.localhost"

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -208,10 +208,21 @@ struct NamespaceDefinition {
     name: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct ConfigDefinition {
+    namespace: String,
+    name: String,
+    data: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    labels: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
     #[serde(default)]
     namespaces: HashMap<String, NamespaceDefinition>,
+    #[serde(default)]
+    configs: HashMap<String, ConfigDefinition>,
     deployments: HashMap<String, Deployment>,
 }
 
@@ -263,6 +274,16 @@ impl Deployment {
 
         for arg in self.command.iter_mut() {
             *arg = env_resolver(arg, env_vars);
+        }
+
+        // The API rejects a `config` volume whose permission is not `ro`. The
+        // CLI default is `rw`, so force `ro` here — a manifest carrying a
+        // `type: config` volume must apply without the user spelling out the
+        // permission the server is going to require anyway.
+        for volume in self.volumes.iter_mut() {
+            if volume.volume_type == "config" {
+                volume.permission = "ro".to_string();
+            }
         }
     }
 }
@@ -384,6 +405,51 @@ async fn create_namespace_on_server(
     }
 }
 
+async fn create_config_on_server(
+    config: &ConfigDefinition,
+    api_url: &str,
+    auth_token: &str,
+    client: &reqwest::Client,
+) -> Result<(), ApplyError> {
+    let url = format!("{}/configs", api_url);
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", auth_token))
+        .json(&json!(config))
+        .send()
+        .await
+        .map_err(ApplyError::Http)?;
+
+    let status = response.status();
+
+    if status.is_success() {
+        info!(
+            "Config '{}' created successfully in namespace '{}'",
+            config.name, config.namespace
+        );
+        println!(
+            "Config '{}' created in namespace '{}'",
+            config.name, config.namespace
+        );
+        Ok(())
+    } else if status == reqwest::StatusCode::CONFLICT {
+        info!(
+            "Config '{}' already exists in namespace '{}', skipping",
+            config.name, config.namespace
+        );
+        println!(
+            "Config '{}' already exists in namespace '{}', skipping",
+            config.name, config.namespace
+        );
+        Ok(())
+    } else {
+        let context = format!("Failed to create config '{}'", config.name);
+        let code = render_response_error(&context, response).await;
+        Err(ApplyError::Reported(code))
+    }
+}
+
 async fn deploy_to_server(
     deployment: &Deployment,
     api_url: &str,
@@ -477,6 +543,30 @@ async fn apply_internal(
         {
             if !matches!(e, ApplyError::Reported(_)) {
                 eprintln!("Failed to create namespace '{}': {}", key, e);
+            }
+            if first_error.is_none() {
+                first_error = Some(e);
+            }
+        }
+    }
+
+    // Create configs after namespaces, before deployments: a deployment with a
+    // `type: config` volume can only resolve once the config exists.
+    for (key, mut config) in config_file.configs {
+        config.namespace = env_resolver(&config.namespace, &env_vars);
+        config.name = env_resolver(&config.name, &env_vars);
+        config.data = env_resolver(&config.data, &env_vars);
+
+        if is_dry_run {
+            println!(
+                "DRY RUN - Would create config '{}' in namespace '{}'",
+                config.name, config.namespace
+            );
+        } else if let Err(e) =
+            create_config_on_server(&config, &api_url, &auth_config.token, client).await
+        {
+            if !matches!(e, ApplyError::Reported(_)) {
+                eprintln!("Failed to create config '{}': {}", key, e);
             }
             if first_error.is_none() {
                 first_error = Some(e);
@@ -881,6 +971,82 @@ deployments:
         deployment.resolve_env_vars(&env_vars);
 
         assert_eq!(deployment.command[2], "serve --port 8080");
+    }
+
+    #[test]
+    fn test_config_volume_permission_forced_to_ro() {
+        let yaml_content = r#"
+deployments:
+  nginx:
+    name: nginx
+    image: nginx:1.19.5
+    volumes:
+      - type: config
+        source: test-config2
+        key: "test.conf"
+        destination: /var/config/test.conf
+        permission: rw
+      - type: bind
+        source: /tmp/data
+        destination: /data
+        permission: rw
+"#;
+        let config: ConfigFile = serde_yaml::from_str(yaml_content).unwrap();
+        let mut nginx = config.deployments["nginx"].clone();
+        nginx.resolve_env_vars(&HashMap::new());
+
+        // The config volume is forced to `ro` (the API rejects anything else);
+        // the bind volume keeps its declared `rw`.
+        assert_eq!(nginx.volumes[0].volume_type, "config");
+        assert_eq!(nginx.volumes[0].permission, "ro");
+        assert_eq!(nginx.volumes[1].volume_type, "bind");
+        assert_eq!(nginx.volumes[1].permission, "rw");
+    }
+
+    #[test]
+    fn test_config_file_with_configs() {
+        let yaml_content = r#"
+configs:
+  entrypoints:
+    namespace: ring
+    name: "test-config2"
+    data: '{"test.conf":"server {}"}'
+
+deployments:
+  nginx:
+    name: nginx
+    namespace: ring
+    image: nginx:1.19.5
+    volumes:
+      - type: config
+        source: test-config2
+        key: "test.conf"
+        destination: /var/config/test.conf
+"#;
+
+        let config: ConfigFile = serde_yaml::from_str(yaml_content).unwrap();
+
+        assert_eq!(config.configs.len(), 1);
+        let entry = &config.configs["entrypoints"];
+        assert_eq!(entry.namespace, "ring");
+        assert_eq!(entry.name, "test-config2");
+        assert_eq!(entry.data, r#"{"test.conf":"server {}"}"#);
+        assert_eq!(entry.labels, None);
+        assert_eq!(config.deployments.len(), 1);
+    }
+
+    #[test]
+    fn test_config_file_without_configs() {
+        let yaml_content = r#"
+deployments:
+  api:
+    name: api
+    image: myapp:latest
+    runtime: docker
+"#;
+
+        let config: ConfigFile = serde_yaml::from_str(yaml_content).unwrap();
+        assert_eq!(config.configs.len(), 0);
     }
 
     #[test]

--- a/tests/e2e/docker/t12_config_volume.sh
+++ b/tests/e2e/docker/t12_config_volume.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 # T12: a `volume.type: config` mount must materialise the value of the
 # referenced config (a key inside a Ring config object) as a file inside
-# the container. The whole flow exercised here: create a Ring config via
-# the API, deploy a container that mounts one of its keys, then read the
-# mounted file from inside the container.
+# the container.
+#
+# This exercises the *fully declarative* path: a single manifest carries
+# both the `configs:` block and a deployment that mounts one of its keys.
+# `ring apply` must create the config (POST /configs) before the deployment
+# so the `type: config` volume resolves on first apply — no out-of-band
+# `ring config create` / `POST /configs`. Then we read the mounted file from
+# inside the container.
+#
+# Before `ring apply` honored the top-level `configs:` block, this required
+# a separate API call to seed the config; carrying it in the manifest left
+# the deployment stuck in `creating` ("Config '...' not found"). This test
+# locks in that the manifest alone is self-sufficient.
 
 set -euo pipefail
 
@@ -11,38 +21,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib.sh
 source "$SCRIPT_DIR/../lib.sh"
 
-log "== T12: docker config volume =="
+log "== T12: docker config volume (declarative configs: block) =="
 
 start_ring
 ring_login
 
-# === Create a Ring config via the API ===
-# The CLI has no `ring config create` yet (see ROADMAP). We hit the REST
-# API directly. The data field is a JSON-encoded map<string, string>; one
-# key per "file" we want to materialise.
-TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
-CONFIG_PAYLOAD=$(cat <<'EOF'
-{
-  "namespace": "ring-e2e",
-  "name": "app-conf",
-  "data": "{\"app.conf\":\"hello-from-ring-config\\n\"}"
-}
-EOF
-)
-HTTP_CODE=$(curl -s -o /tmp/ring-config-create.out -w '%{http_code}' \
-  -X POST "$RING_URL/configs" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "$CONFIG_PAYLOAD")
-if [ "$HTTP_CODE" != "201" ]; then
-  cat /tmp/ring-config-create.out >&2
-  fail "POST /configs returned $HTTP_CODE (expected 201)"
-fi
-log "Ring config 'app-conf' created via API"
-
-# === Deploy a container that mounts the config key ===
+# === Single manifest: configs: block + a deployment that mounts a key ===
+# `data` is a JSON-encoded map<string, string>; one key per "file" to
+# materialise. The config is declared inline — no separate POST /configs.
 FIXTURE="$RING_TEST_DIR/cfg-volume.yaml"
 cat > "$FIXTURE" <<'EOF'
+configs:
+  app-conf:
+    namespace: ring-e2e
+    name: app-conf
+    data: '{"app.conf":"hello-from-ring-config\n"}'
+
 deployments:
   cfg-vm:
     name: cfg-vm
@@ -56,11 +50,19 @@ deployments:
         source: app-conf
         key: app.conf
         destination: /etc/app/app.conf
-        driver: local
-        permission: ro
 EOF
 
-"$RING_BIN" apply --file "$FIXTURE"
+APPLY_OUT=$("$RING_BIN" apply --file "$FIXTURE" 2>&1) || { echo "$APPLY_OUT" >&2; fail "ring apply failed"; }
+echo "$APPLY_OUT"
+# The config must have been created by apply, not assumed pre-existing.
+echo "$APPLY_OUT" | grep -qF "Config 'app-conf' created" \
+  || { echo "$APPLY_OUT" >&2; fail "apply did not create the config from the configs: block"; }
+
+# The config is listable in its namespace after apply.
+"$RING_BIN" config list -n ring-e2e 2>&1 | grep -qF "app-conf" \
+  || fail "config 'app-conf' not listable after apply"
+log "config 'app-conf' created and listable via the manifest's configs: block"
+
 wait_deployment_status "ring-e2e" "cfg-vm" "running" 60
 
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "cfg-vm")

--- a/tests/e2e/server/t6_apply_configs_block.sh
+++ b/tests/e2e/server/t6_apply_configs_block.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# T6-server: `ring apply` honors the top-level `configs:` block.
+#
+# Before this change, the `apply` manifest struct only knew `namespaces:` and
+# `deployments:`. serde dropped any unknown top-level key, so a `configs:`
+# block was silently parsed away: never POSTed to /configs, never landing in
+# the DB. A deployment referencing it via a `type: config` volume then got
+# stuck in `creating` forever with "Config '...' not found". The failure was
+# invisible at apply time — the worst kind of silent failure for a declarative
+# tool.
+#
+# This proves the fix against the *real compiled binary* over a TCP socket:
+# the config carried in the manifest actually reaches the server and is
+# listable afterwards. The Rust unit test on `ConfigFile` parsing proves the
+# struct accepts the key; it cannot prove the CLI actually POSTs it.
+#
+# Docker is NOT required here: this test covers the CLI→API path that this
+# change owns (manifest config → POST /configs → listable). The full
+# deployment-reaches-running-with-file-mounted path needs a Docker daemon and
+# is exercised by the runtime e2e suites.
+#
+# Invariants:
+#   1. `ring apply` of a manifest with a `configs:` block succeeds.
+#   2. `ring config list -n <ns>` shows the config afterwards (it was created).
+#   3. Re-applying the same manifest is idempotent: succeeds, no duplicate,
+#      "already exists" is reported instead of erroring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t6-server-salt"
+scheduler.interval = 1
+EOF
+
+NS="t6cfg"
+CONFIG_NAME="test-config2"
+
+cat > "$CFG/manifest.yaml" <<EOF
+namespaces:
+  ${NS}:
+    name: ${NS}
+
+configs:
+  entrypoints:
+    namespace: ${NS}
+    name: "${CONFIG_NAME}"
+    data: '{"test.conf":"server { listen 80; }"}'
+
+deployments:
+  nginx:
+    name: nginx
+    namespace: ${NS}
+    runtime: docker
+    image: "nginx:1.19.5"
+    replicas: 1
+    volumes:
+      - type: config
+        source: ${CONFIG_NAME}
+        key: "test.conf"
+        destination: /var/config/test.conf
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="$KEY"
+
+log "== T6-server: ring apply honors the configs: block =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "ring login failed against the real server"
+
+# --- Invariant 1: apply with a configs: block succeeds and reports the config ---
+if ! APPLY_OUT=$("$RING_BIN" apply -f "$CFG/manifest.yaml" 2>&1); then
+  echo "$APPLY_OUT" >&2
+  fail "1 (apply): exited non-zero"
+fi
+echo "$APPLY_OUT" | grep -qF "Config '${CONFIG_NAME}' created" \
+  || { echo "$APPLY_OUT" >&2; fail "1 (apply): expected \"Config '${CONFIG_NAME}' created\""; }
+log "1 (apply with configs): succeeded, config creation reported"
+
+# --- Invariant 2: the config is now listable in its namespace ---
+LIST_OUT=$("$RING_BIN" config list -n "$NS" 2>&1) \
+  || { echo "$LIST_OUT" >&2; fail "2 (config list): exited non-zero"; }
+echo "$LIST_OUT" | grep -qF "$CONFIG_NAME" \
+  || { echo "$LIST_OUT" >&2; fail "2 (config list): config '${CONFIG_NAME}' not found after apply"; }
+log "2 (config list): config '${CONFIG_NAME}' present after apply"
+
+# --- Invariant 3: re-applying the same manifest is idempotent ---
+if ! REAPPLY_OUT=$("$RING_BIN" apply -f "$CFG/manifest.yaml" 2>&1); then
+  echo "$REAPPLY_OUT" >&2
+  fail "3 (re-apply): exited non-zero — apply is not idempotent"
+fi
+echo "$REAPPLY_OUT" | grep -qF "Config '${CONFIG_NAME}' already exists" \
+  || { echo "$REAPPLY_OUT" >&2; fail "3 (re-apply): expected \"already exists, skipping\" for the config"; }
+
+# And the config must not have been duplicated: exactly one row in the listing.
+COUNT=$("$RING_BIN" config list -n "$NS" 2>&1 | grep -cF "$CONFIG_NAME")
+[ "$COUNT" -eq 1 ] || fail "3 (re-apply): expected 1 config '${CONFIG_NAME}', found $COUNT (duplicate?)"
+log "3 (re-apply): idempotent, no duplicate (count=$COUNT)"
+
+log "== T6-server: all invariants passed =="


### PR DESCRIPTION
## Problem

`ring apply` silently ignored the top-level `configs:` block. The manifest struct only knew `namespaces:` and `deployments:`, so serde dropped the unknown key: the config was never POSTed to `/configs`, never landed in the DB. A deployment referencing it via a `type: config` volume then got stuck in `creating` forever ("Config '...' not found"). The failure was invisible at apply time — the worst kind of silent failure for a declarative tool.

`examples/nginx.yaml` ships such a block and did not work end-to-end.

## Changes

- Add a `configs: HashMap<String, ConfigDefinition>` field to `ConfigFile`.
- Create configs after namespaces and before deployments (so a `type: config` volume resolves on first apply), POSTing each to `/configs`.
- Idempotent: a `409 Conflict` is reported as "already exists, skipping", matching how namespaces behave. Re-applying an unchanged manifest never errors.
- `data`, `namespace` and `name` go through the same `$VAR` interpolation as deployment fields.
- Force `permission: ro` on `type: config` volumes client-side. The API rejects a config volume that is not `ro` (the manifest reference already documented this), but the CLI default was `rw` — which is what made `examples/nginx.yaml` fail with a 422. A manifest carrying a config volume now applies without the user spelling out the permission the server requires anyway.

## Tests

- Unit tests: parsing the `configs:` block, absence of the block, and the `ro` forcing on config volumes.
- `tests/e2e/server/t6_apply_configs_block.sh`: apply a manifest with a `configs:` block → config is listable → re-apply is idempotent with no duplicate.
- `tests/e2e/docker/t12_config_volume.sh` migrated to carry its config in the manifest's `configs:` block instead of an out-of-band `POST /configs`. Validates the full declarative path on a real Docker container: config created by apply → deployment reaches `running` → rendered file mounted read-only with the expected content.
- `documentation/reference/manifest.md` documents the `configs:` top-level block.

All 427 Rust tests pass; e2e t6 (server) and t12 (docker) pass.