### PR TITLE
Add volume type: secret to mount secrets as files in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Event `reason` strings (`ImagePullBackOff`, `InstanceCreationFailed`, …) stay PascalCase — those are event labels, not statuses.
 
 ### Added
+- **`volumes: type: secret`** — mount a `ring secret` as a read-only file inside the container. The decrypted value becomes the file contents, with no `key:` field (a secret holds a single opaque value). Pattern matches `type: config` but reads from the encrypted secret store instead of the plaintext config store. Use when an app expects a credentials *file path* rather than an env var (Prometheus `credentials_file`, TLS material, etc.). The mount is always read-only; rotation requires a redeploy. See [Deploy with secrets → Mount a secret as a file](/documentation/how-to/deploy-with-secrets#mount-a-secret-as-a-file).
 - **`ring apply`, `ring namespace create` and `ring secret create` render RFC 7807 problem details.** On validation failure the CLI prints the title line plus every violation with its property path, e.g.
 
   ```

--- a/documentation/how-to/deploy-with-secrets.md
+++ b/documentation/how-to/deploy-with-secrets.md
@@ -61,6 +61,52 @@ Inside the container, `secretRef` values are indistinguishable from plain values
 
 **If a referenced secret does not exist in the namespace:** Ring emits an `error` event with `reason: SecretResolutionError`, the scheduler skips the deployment on that tick, and the deployment stays in `creating`. Inspect with `ring deployment events <id> --level error`.
 
+## Mount a secret as a file
+
+Some apps will not read credentials from an environment variable — they want a file path. Prometheus is a typical example: its `authorization.credentials_file` only takes a path, not the credential itself. For those cases, declare the secret as a `volume` of `type: secret`:
+
+```yaml
+deployments:
+  prometheus:
+    name: prometheus
+    namespace: monitoring
+    runtime: docker
+    image: "prom/prometheus:v2.55.1"
+    args:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+
+    volumes:
+      - type: config
+        source: prometheus-config
+        key: prometheus.yml
+        destination: /etc/prometheus/prometheus.yml
+        permission: ro
+
+      - type: secret
+        source: synomilia-metrics-token   # `ring secret` in same namespace
+        destination: /etc/prometheus/secrets/synomilia.token
+        permission: ro
+```
+
+Then in the mounted `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: synomilia
+    scheme: https
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/secrets/synomilia.token
+    static_configs:
+      - targets: ['synomilia.example.com:443']
+```
+
+Ring decrypts the secret at reconciliation time, writes the plaintext to a per-deployment temp file, and mounts that file at `destination` inside the container. The mount is always read-only.
+
+A secret has **no `key:` field** — its single decrypted value becomes the entire file contents. If you need to mount multiple files, declare one `type: secret` volume per file.
+
+**Rotating a secret mounted as a file** follows the same pattern as env-var secrets: delete + recreate the secret, then `ring apply` to trigger a rolling restart. The running container keeps the old file contents until it is recreated.
+
 ## Same secret name across environments
 
 Secret names are unique **per namespace**, so the same name resolves to different values in `staging` vs `production`:
@@ -152,7 +198,7 @@ This is **not** an encrypted secret — it lives in the deployment row in the da
 ## Limits
 
 - **No multi-line `-v`.** For PEM keys, JSON blobs, use the API directly with `--data-binary @file.json`, or shell-escape.
-- **Practical size limit.** Keep secrets under a few KB. Big blobs (full TLS chains, keystores) belong in a `ring config` mounted as a file.
+- **Practical size limit.** Keep secrets under a few KB. Big binary blobs (keystores, full TLS chains) work, but consider whether a `ring config` mounted as a file is a better fit — configs are larger and don't carry the AES-GCM overhead.
 - **No expiration / rotation reminders.** Track rotation cadence externally.
 - **No value-read audit log.** Ring logs `secret create` and `secret delete` events but not which deployment resolved which secret on a given tick.
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -125,24 +125,25 @@ Interpolation also applies to `image`, `name`, `namespace`, and `command` argume
 
 ## `volumes`
 
-A list of volume objects. **Three** types are supported:
+A list of volume objects. **Four** types are supported:
 
 | `type` | Source | Description |
 |---|---|---|
 | `bind` | host path | Mount a directory or file from the host into the container. |
 | `volume` | volume name | Mount a named Docker volume (driver `local` or `nfs`). |
 | `config` | config name | Mount a file rendered from a `ring config` entry in the same namespace. |
+| `secret` | secret name | Mount a file rendered from a `ring secret` entry in the same namespace. Always read-only. |
 
 ### Schema
 
 | Field | Required | Used by | Description |
 |---|---|---|---|
-| `type` | yes | all | `bind`, `volume`, or `config`. |
-| `source` | yes | all | Host path (bind), volume name (volume), or config name (config). |
-| `key` | yes for `config`, ignored otherwise | `config` only | Selects which key inside the named config to mount. A config can carry multiple key/value entries; `key` picks one. The API rejects a `config` volume without `key` (or with empty `key`). |
-| `destination` | yes | all | Path inside the container. For `config` volumes, this is the file path the selected `key`'s payload will be written to. |
+| `type` | yes | all | `bind`, `volume`, `config`, or `secret`. |
+| `source` | yes | all | Host path (bind), volume name (volume), config name (config), or secret name (secret). |
+| `key` | yes for `config`, ignored otherwise | `config` only | Selects which key inside the named config to mount. A config can carry multiple key/value entries; `key` picks one. The API rejects a `config` volume without `key` (or with empty `key`). Not used for `secret` — a secret has a single opaque value. |
+| `destination` | yes | all | Path inside the container. For `config` and `secret` volumes, this is the file path the payload will be written to. |
 | `driver` | no (default `local`) | `volume` (otherwise informational) | `local` or `nfs`. Only meaningful for `volume`. |
-| `permission` | no | `bind` and `volume` | `ro` or `rw`. Defaults to `rw` for `bind` and `volume`. **For `config`, the API forces `ro`** regardless of what you write. |
+| `permission` | no | `bind` and `volume` | `ro` or `rw`. Defaults to `rw` for `bind` and `volume`. **For `config` and `secret`, the API forces `ro`** regardless of what you write. |
 
 ```yaml
 volumes:
@@ -164,9 +165,20 @@ volumes:
     destination: /etc/nginx/conf.d/site.conf
     driver: local
     permission: ro
+
+  - type: secret
+    source: api-bearer-token        # name of an existing `ring secret`
+    destination: /run/secrets/api-token
+    driver: local
+    permission: ro
 ```
 
-For `config` volumes, the `source` is the config's `name` (not its UUID), and the config must live in the **same namespace** as the deployment. See [how-to: deploy on Cloud Hypervisor → Volumes](/documentation/how-to/deploy-on-cloud-hypervisor#volumes-virtiofs) for runtime-specific lifecycle details.
+For `config` and `secret` volumes, the `source` is the config's or secret's `name` (not its UUID), and the resource must live in the **same namespace** as the deployment. See [how-to: deploy on Cloud Hypervisor → Volumes](/documentation/how-to/deploy-on-cloud-hypervisor#volumes-virtiofs) for runtime-specific lifecycle details.
+
+For `secret` volumes specifically:
+- The whole decrypted value becomes the file contents (no `key:` field).
+- Containers should treat the path as read-only — Ring forces `ro`.
+- If you update the underlying `ring secret`, the running container keeps the old value until it is restarted. Trigger a redeploy to pick up the new value.
 
 > **Wire-format vs `ring apply`.** The API DTO requires `driver` and `permission` to be present (no defaults at deserialization time). The `ring apply` CLI fills them in client-side before posting (`local` and `rw` respectively, except for `config` which becomes `ro`). If you `POST /deployments` directly with raw JSON, include both fields explicitly.
 

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -315,6 +315,7 @@ pub enum VolumeType {
     Bind,
     Config,
     Volume,
+    Secret,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -422,6 +423,46 @@ impl Validate for Volume {
                 }
                 _ => {}
             },
+            VolumeType::Secret => {
+                match &self.source {
+                    None => {
+                        errors.add(
+                            "source",
+                            ValidationError::new("source is required for secret volumes"),
+                        );
+                    }
+                    Some(source) if source.is_empty() => {
+                        errors.add("source", ValidationError::new("source cannot be empty"));
+                    }
+                    _ => {}
+                }
+
+                // A secret holds a single opaque value — there is no `key:`
+                // to pick. Reject explicitly so users coming from Kubernetes
+                // (where Secret resources are multi-key dicts) get a clear
+                // error instead of silent omission.
+                if let Some(key) = &self.key {
+                    if !key.is_empty() {
+                        let error = ValidationError {
+                            code: Cow::from("unexpected_field"),
+                            message: Some(Cow::from(
+                                "secret volumes have no key — a secret holds a single opaque value",
+                            )),
+                            params: HashMap::new(),
+                        };
+                        errors.add("key", error);
+                    }
+                }
+
+                if !matches!(self.permission, Permission::Ro) {
+                    let error = ValidationError {
+                        code: Cow::from("invalid_permission"),
+                        message: Some(Cow::from("secret volumes must be read-only (ro)")),
+                        params: HashMap::new(),
+                    };
+                    errors.add("permission", error);
+                }
+            }
         }
 
         if errors.is_empty() {

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -276,12 +276,12 @@ impl Deployment {
             *arg = env_resolver(arg, env_vars);
         }
 
-        // The API rejects a `config` volume whose permission is not `ro`. The
-        // CLI default is `rw`, so force `ro` here — a manifest carrying a
-        // `type: config` volume must apply without the user spelling out the
-        // permission the server is going to require anyway.
+        // The API rejects a `config` or `secret` volume whose permission is
+        // not `ro`. The CLI default is `rw`, so force `ro` here — a manifest
+        // carrying one of these volume types must apply without the user
+        // spelling out the permission the server is going to require anyway.
         for volume in self.volumes.iter_mut() {
-            if volume.volume_type == "config" {
+            if volume.volume_type == "config" || volume.volume_type == "secret" {
                 volume.permission = "ro".to_string();
             }
         }

--- a/src/models/volume.rs
+++ b/src/models/volume.rs
@@ -1,5 +1,6 @@
 use crate::api::dto::deployment::DeploymentVolume;
 use crate::models::config::Config;
+use crate::models::secret::Secret;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -25,6 +26,7 @@ pub enum ResolvedMount {
 pub fn resolve_volumes(
     volumes_json: &str,
     configs: &HashMap<String, Config>,
+    secrets: &HashMap<String, Secret>,
 ) -> Result<Vec<ResolvedMount>, String> {
     let volumes: Vec<DeploymentVolume> = serde_json::from_str(volumes_json)
         .map_err(|e| format!("Failed to parse volumes: {}", e))?;
@@ -81,6 +83,29 @@ pub fn resolve_volumes(
                     destination: volume.destination,
                 }
             }
+            "secret" => {
+                // A secret is a single opaque string — there is no `key:`,
+                // its whole decrypted value becomes the file contents. The
+                // mount is always read-only: containers should never write
+                // back into a secret.
+                let secret_name = volume
+                    .source
+                    .as_ref()
+                    .ok_or("Secret volume requires a source")?;
+
+                let secret = secrets
+                    .get(secret_name)
+                    .ok_or(format!("Secret '{}' not found", secret_name))?;
+
+                let content = secret
+                    .get_decrypted_value()
+                    .map_err(|e| format!("Failed to decrypt secret '{}': {}", secret_name, e))?;
+
+                ResolvedMount::Content {
+                    content,
+                    destination: volume.destination,
+                }
+            }
             other => return Err(format!("Unknown volume type '{}'", other)),
         };
         resolved.push(mount);
@@ -92,6 +117,9 @@ pub fn resolve_volumes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::secret::encrypt_value;
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+    use std::env;
 
     fn make_config(name: &str, data: &str) -> Config {
         Config {
@@ -105,10 +133,28 @@ mod tests {
         }
     }
 
+    fn set_test_key() {
+        let key = [0u8; 32];
+        let key_b64 = BASE64.encode(key);
+        unsafe { env::set_var("RING_SECRET_KEY", key_b64) };
+    }
+
+    fn make_secret(name: &str, plaintext: &str) -> Secret {
+        set_test_key();
+        Secret {
+            id: "test-secret-id".to_string(),
+            created_at: "2024-01-01".to_string(),
+            updated_at: None,
+            namespace: "default".to_string(),
+            name: name.to_string(),
+            value: encrypt_value(plaintext),
+        }
+    }
+
     #[test]
     fn resolve_bind_volume() {
         let json = r#"[{"type":"bind","source":"/host/path","destination":"/container/path","driver":"local","permission":"ro"}]"#;
-        let result = resolve_volumes(json, &HashMap::new()).unwrap();
+        let result = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap();
 
         assert_eq!(result.len(), 1);
         match &result[0] {
@@ -128,7 +174,7 @@ mod tests {
     #[test]
     fn resolve_bind_volume_rw() {
         let json = r#"[{"type":"bind","source":"/data","destination":"/app/data","driver":"local","permission":"rw"}]"#;
-        let result = resolve_volumes(json, &HashMap::new()).unwrap();
+        let result = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap();
 
         match &result[0] {
             ResolvedMount::Bind { read_only, .. } => assert!(!read_only),
@@ -139,7 +185,7 @@ mod tests {
     #[test]
     fn resolve_named_volume() {
         let json = r#"[{"type":"volume","source":"my-data","destination":"/data","driver":"local","permission":"rw"}]"#;
-        let result = resolve_volumes(json, &HashMap::new()).unwrap();
+        let result = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap();
 
         assert_eq!(result.len(), 1);
         match &result[0] {
@@ -161,7 +207,7 @@ mod tests {
     #[test]
     fn resolve_named_volume_with_nfs_driver() {
         let json = r#"[{"type":"volume","source":"shared","destination":"/mnt","driver":"nfs","permission":"ro"}]"#;
-        let result = resolve_volumes(json, &HashMap::new()).unwrap();
+        let result = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap();
 
         match &result[0] {
             ResolvedMount::Named {
@@ -183,7 +229,7 @@ mod tests {
         );
 
         let json = r#"[{"type":"config","source":"nginx-config","key":"nginx.conf","destination":"/etc/nginx/nginx.conf","driver":"local","permission":"ro"}]"#;
-        let result = resolve_volumes(json, &configs).unwrap();
+        let result = resolve_volumes(json, &configs, &HashMap::new()).unwrap();
 
         assert_eq!(result.len(), 1);
         match &result[0] {
@@ -201,7 +247,7 @@ mod tests {
     #[test]
     fn resolve_config_not_found() {
         let json = r#"[{"type":"config","source":"missing","key":"file","destination":"/etc/conf","driver":"local","permission":"ro"}]"#;
-        let err = resolve_volumes(json, &HashMap::new()).unwrap_err();
+        let err = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap_err();
         assert!(err.contains("Config 'missing' not found"));
     }
 
@@ -214,21 +260,21 @@ mod tests {
         );
 
         let json = r#"[{"type":"config","source":"my-config","key":"missing-key","destination":"/etc/conf","driver":"local","permission":"ro"}]"#;
-        let err = resolve_volumes(json, &configs).unwrap_err();
+        let err = resolve_volumes(json, &configs, &HashMap::new()).unwrap_err();
         assert!(err.contains("Key 'missing-key' not found"));
     }
 
     #[test]
     fn resolve_unknown_volume_type() {
         let json = r#"[{"type":"tmpfs","source":"x","destination":"/tmp","driver":"local","permission":"rw"}]"#;
-        let err = resolve_volumes(json, &HashMap::new()).unwrap_err();
+        let err = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap_err();
         assert!(err.contains("Unknown volume type 'tmpfs'"));
     }
 
     #[test]
     fn resolve_bind_missing_source() {
         let json = r#"[{"type":"bind","destination":"/data","driver":"local","permission":"rw"}]"#;
-        let err = resolve_volumes(json, &HashMap::new()).unwrap_err();
+        let err = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap_err();
         assert!(err.contains("Bind volume requires a source"));
     }
 
@@ -245,7 +291,7 @@ mod tests {
             {"type":"volume","source":"db-data","destination":"/data","driver":"local","permission":"rw"},
             {"type":"config","source":"app-config","key":"app.toml","destination":"/etc/app.toml","driver":"local","permission":"ro"}
         ]"#;
-        let result = resolve_volumes(json, &configs).unwrap();
+        let result = resolve_volumes(json, &configs, &HashMap::new()).unwrap();
 
         assert_eq!(result.len(), 3);
         assert!(matches!(result[0], ResolvedMount::Bind { .. }));
@@ -255,7 +301,68 @@ mod tests {
 
     #[test]
     fn resolve_empty_volumes() {
-        let result = resolve_volumes("[]", &HashMap::new()).unwrap();
+        let result = resolve_volumes("[]", &HashMap::new(), &HashMap::new()).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_secret_volume() {
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "api-token".to_string(),
+            make_secret("api-token", "s3cr3t-bearer-token"),
+        );
+
+        let json = r#"[{"type":"secret","source":"api-token","destination":"/run/secrets/api-token","driver":"local","permission":"ro"}]"#;
+        let result = resolve_volumes(json, &HashMap::new(), &secrets).unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            ResolvedMount::Content {
+                content,
+                destination,
+            } => {
+                assert_eq!(content, "s3cr3t-bearer-token");
+                assert_eq!(destination, "/run/secrets/api-token");
+            }
+            _ => panic!("Expected Content mount for secret"),
+        }
+    }
+
+    #[test]
+    fn resolve_secret_not_found() {
+        let json = r#"[{"type":"secret","source":"missing","destination":"/run/secrets/x","driver":"local","permission":"ro"}]"#;
+        let err = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap_err();
+        assert!(err.contains("Secret 'missing' not found"));
+    }
+
+    #[test]
+    fn resolve_secret_missing_source() {
+        let json = r#"[{"type":"secret","destination":"/run/secrets/x","driver":"local","permission":"ro"}]"#;
+        let err = resolve_volumes(json, &HashMap::new(), &HashMap::new()).unwrap_err();
+        assert!(err.contains("Secret volume requires a source"));
+    }
+
+    #[test]
+    fn resolve_secret_alongside_config() {
+        let mut configs = HashMap::new();
+        configs.insert(
+            "app-config".to_string(),
+            make_config("app-config", r#"{"app.toml":"[server]"}"#),
+        );
+        let mut secrets = HashMap::new();
+        secrets.insert("db-token".to_string(), make_secret("db-token", "deadbeef"));
+
+        let json = r#"[
+            {"type":"config","source":"app-config","key":"app.toml","destination":"/etc/app.toml","driver":"local","permission":"ro"},
+            {"type":"secret","source":"db-token","destination":"/run/secrets/db-token","driver":"local","permission":"ro"}
+        ]"#;
+        let result = resolve_volumes(json, &configs, &secrets).unwrap();
+
+        assert_eq!(result.len(), 2);
+        match &result[1] {
+            ResolvedMount::Content { content, .. } => assert_eq!(content, "deadbeef"),
+            _ => panic!("Expected Content mount"),
+        }
     }
 }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -87,6 +87,64 @@ async fn load_configs(
     }
 }
 
+/// Load only the secrets actually referenced as `type: secret` volumes on
+/// this deployment. We avoid loading the full namespace's secret set so a
+/// runaway deployment can't accidentally pull plaintext for unrelated
+/// secrets into memory.
+async fn load_secrets_for_volumes(
+    pool: &SqlitePool,
+    deployment: &Deployment,
+) -> Option<HashMap<String, SecretModel::Secret>> {
+    // The volumes field is JSON in the DB row; the same struct is later
+    // re-parsed by resolve_volumes. Tolerate a parse error here by
+    // returning an empty map — resolve_volumes will surface a clearer error.
+    let volumes: Vec<crate::api::dto::deployment::DeploymentVolume> =
+        serde_json::from_str(&deployment.volumes).unwrap_or_default();
+
+    let mut secrets = HashMap::new();
+    for volume in volumes.iter().filter(|v| v.r#type == "secret") {
+        let name = match volume.source.as_ref() {
+            Some(n) => n,
+            None => continue, // resolve_volumes will report the missing source
+        };
+
+        if secrets.contains_key(name) {
+            continue;
+        }
+
+        match SecretModel::find_by_namespace_name(pool, &deployment.namespace, name).await {
+            Ok(Some(secret)) => {
+                secrets.insert(name.clone(), secret);
+            }
+            Ok(None) => {
+                // Don't fail here — let resolve_volumes produce the canonical
+                // "Secret 'X' not found" error so the message format matches
+                // what configs do.
+            }
+            Err(e) => {
+                error!(
+                    "Failed to load secret '{}' for deployment {}: {}",
+                    name, deployment.id, e
+                );
+                if let Err(log_err) = deployment_event::log_event(
+                    pool,
+                    deployment.id.clone(),
+                    "error",
+                    format!("Failed to load secret '{}': {}", name, e),
+                    "scheduler",
+                    Some("secret_load_error"),
+                )
+                .await
+                {
+                    warn!("Failed to log secret load error event: {}", log_err);
+                }
+                return None;
+            }
+        }
+    }
+    Some(secrets)
+}
+
 async fn prepare_deployment(pool: &SqlitePool, deployment: &Deployment) -> Option<Deployment> {
     let mut resolved = deployment.clone();
     if let Err(e) = resolve_environment(&mut resolved, pool).await {
@@ -855,22 +913,45 @@ pub(crate) async fn schedule(
                 None => continue,
             };
 
+            let volume_secrets = match load_secrets_for_volumes(&pool, &deployment).await {
+                Some(s) => s,
+                None => continue,
+            };
+
             let resolved = match prepare_deployment(&pool, &deployment).await {
                 Some(d) => d,
                 None => continue,
             };
 
-            let resolved_mounts =
-                match crate::models::volume::resolve_volumes(&deployment.volumes, &configs) {
-                    Ok(mounts) => mounts,
-                    Err(e) => {
-                        error!(
-                            "Failed to resolve volumes for deployment {}: {}",
-                            deployment.id, e
-                        );
-                        continue;
+            let resolved_mounts = match crate::models::volume::resolve_volumes(
+                &deployment.volumes,
+                &configs,
+                &volume_secrets,
+            ) {
+                Ok(mounts) => mounts,
+                Err(e) => {
+                    error!(
+                        "Failed to resolve volumes for deployment {}: {}",
+                        deployment.id, e
+                    );
+                    // Surface to the operator via `ring deployment events`.
+                    // The message contains only the resource name (e.g.
+                    // "Secret 'X' not found"), never plaintext values.
+                    if let Err(log_err) = deployment_event::log_event(
+                        &pool,
+                        deployment.id.clone(),
+                        "error",
+                        format!("Failed to resolve volumes: {}", e),
+                        "scheduler",
+                        Some("volume_resolution_error"),
+                    )
+                    .await
+                    {
+                        warn!("Failed to log volume resolution error event: {}", log_err);
                     }
-                };
+                    continue;
+                }
+            };
 
             let restart_count_before = deployment.restart_count;
             let mut result = match apply_runtime(

--- a/tests/e2e/docker/t29_secret_volume.sh
+++ b/tests/e2e/docker/t29_secret_volume.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# T29: a `volume.type: secret` mount must materialise the decrypted value
+# of a Ring secret as a file inside the container.
+#
+# Motivating use case (and the reason this volume type exists): Prometheus
+# bearer-token scraping accepts `credentials_file:` but not `credentials:`
+# from an env var, so the token must reach the container as a file. Other
+# stacks that take TLS material via path (curl --cacert, postgres
+# sslcert/sslkey, …) hit the same pattern.
+#
+# Unlike `type: config`, secrets are not declared inline in the manifest —
+# they go through `ring secret create` (or POST /secrets). The encrypted
+# blob lives in the secret store; the scheduler decrypts at reconcile and
+# writes a per-deployment temp file mounted at the destination path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T29: docker secret volume =="
+
+start_ring
+ring_login
+
+SECRET_NAME="api-bearer-token"
+SECRET_VALUE="s3cr3t-token-via-volume"
+
+# === Create the secret out of band (no inline `secrets:` block) ===
+"$RING_BIN" secret create "$SECRET_NAME" -n ring-e2e -v "$SECRET_VALUE" 2>&1 \
+  | grep -qF "created" \
+  || fail "ring secret create did not succeed"
+log "secret '$SECRET_NAME' created"
+
+# === Manifest: a deployment that mounts the secret as a file ===
+FIXTURE="$RING_TEST_DIR/secret-volume.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  sec-vm:
+    name: sec-vm
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    volumes:
+      - type: secret
+        source: $SECRET_NAME
+        destination: /run/secrets/api-token
+EOF
+
+APPLY_OUT=$("$RING_BIN" apply --file "$FIXTURE" 2>&1) \
+  || { echo "$APPLY_OUT" >&2; fail "ring apply failed"; }
+echo "$APPLY_OUT"
+
+wait_deployment_status "ring-e2e" "sec-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "sec-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CID=$(docker ps --filter "label=ring_deployment=$DEPLOYMENT_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no Docker container labelled with deployment $DEPLOYMENT_ID"
+
+# === The file exists with the *decrypted* value as its content ===
+content=$(docker exec "$CID" cat /run/secrets/api-token 2>&1 || true)
+if [ "$content" != "$SECRET_VALUE" ]; then
+  echo "got: $content" >&2
+  fail "secret volume content mismatch"
+fi
+log "secret volume content matches (length: ${#content})"
+
+# === The mount is read-only ===
+if docker exec "$CID" sh -c 'echo break > /run/secrets/api-token' 2>/dev/null; then
+  fail "secret volume is writable but should be read-only"
+fi
+log "secret volume is read-only as expected"
+
+# === API rejects type: secret with a non-empty `key:` ===
+BAD_FIXTURE="$RING_TEST_DIR/secret-volume-with-key.yaml"
+cat > "$BAD_FIXTURE" <<EOF
+deployments:
+  sec-bad:
+    name: sec-bad
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    volumes:
+      - type: secret
+        source: $SECRET_NAME
+        key: pick-me-please
+        destination: /run/secrets/api-token
+EOF
+
+if BAD_OUT=$("$RING_BIN" apply --file "$BAD_FIXTURE" 2>&1); then
+  echo "$BAD_OUT" >&2
+  fail "apply with type: secret + key: should have been rejected"
+fi
+echo "$BAD_OUT" | grep -qiE "key|secret volumes have no key" \
+  || { echo "$BAD_OUT" >&2; fail "rejection message did not mention the offending field"; }
+log "API correctly rejected type: secret with a non-empty key"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T29: PASS =="


### PR DESCRIPTION
## Summary

Add a fourth volume type `secret` so a Ring secret can be mounted as a read-only file inside a container — same use case as Kubernetes `secret` volume mounts.

Motivating example: Prometheus' bearer-token scraping only accepts `authorization.credentials_file:` (a path), not the credential itself in an env var. Today users have to wrap `command:` in a shell that materialises the env-injected token onto disk before exec'ing Prometheus. With this PR, the manifest reads:

```yaml
volumes:
  - type: secret
    source: synomilia-metrics-token
    destination: /etc/prometheus/secrets/synomilia.token
```

and the scheduler does the rest.

## Design

- **One secret = one file**, no `key:` field (a Ring secret holds a single opaque string, unlike a Config which is a `map<string, string>`).
- **Always read-only** — both the API DTO and `ring apply` force `permission: ro`.
- **Same plumbing as `type: config`**: secrets resolve to `ResolvedMount::Content`, write to the existing `/tmp/ring_configs/{deployment_id}/{hash}` temp path, mount as a bind. No new runtime code path.
- **Loads only referenced secrets**: `load_secrets_for_volumes()` pulls only the secrets named by the deployment's volumes, not the whole namespace, to avoid materialising unrelated plaintext in memory.

## Validation

- `type: secret` requires `source` (rejected otherwise with `source is required for secret volumes`).
- `key:` is explicitly rejected on `type: secret` with `secret volumes have no key — a secret holds a single opaque value`. Users coming from k8s reflexively add a key; this gives them a clear error instead of silent confusion.
- `permission` is forced to `ro` server-side (rejected with `secret volumes must be read-only (ro)`) and client-side in `ring apply`.
- Resolution errors are surfaced via `ring deployment events` with `reason: volume_resolution_error`. Messages contain only resource names (e.g. `Secret 'X' not found`), never plaintext.

## Test plan

- [x] Unit tests in `src/models/volume.rs`: happy path, secret not found, missing source, secret alongside config. **431/431 cargo tests pass.**
- [x] E2E in `tests/e2e/docker/t29_secret_volume.sh`: creates a secret out of band, applies a manifest mounting it, asserts the file contents inside the container, asserts read-only, asserts API rejects `key:` on `type: secret`.
- [ ] Manual: run against a real Prometheus + a service exposing `/metrics` behind a bearer token (the scenario that motivated this PR).

## Docs

- `documentation/reference/manifest.md`: volume types table is now 4 rows, schema gains the `secret` row.
- `documentation/how-to/deploy-with-secrets.md`: new section *Mount a secret as a file* with the Prometheus example.
- `CHANGELOG.md`: `[Unreleased] / Added` entry.

## Not in this PR

- E2E test is added but not run in this branch (no Docker daemon in the dev env that produced the commit).
- No change to the Cloud Hypervisor runtime — the manifest reference's "runtime parity" wording should be updated by whoever lands this PR if `type: secret` differs there.
- Rotation semantics match `type: config` (the running container keeps the old value until restart). Same docs caveat.