### PR TITLE
Force parent drain after rollout deadline

### DIFF
--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -363,6 +363,29 @@ fn min_healthy_time_for(child: &Deployment) -> Duration {
     window
 }
 
+/// True when the child has been alive longer than the rollout deadline.
+///
+/// Used as a safety valve: if a child's readiness probe never turns green, the
+/// parent would otherwise stay up forever. After this deadline we force the
+/// drain so a broken probe can't pin two instances indefinitely. Configurable
+/// via RING_ROLLOUT_DEADLINE (seconds, default 600). A child with an
+/// unparseable created_at is treated as not-yet-expired (fail safe: never force
+/// a drain on bad data).
+fn rollout_deadline_exceeded(child: &Deployment) -> bool {
+    let deadline_secs: i64 = std::env::var("RING_ROLLOUT_DEADLINE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(600);
+
+    let created = match chrono::DateTime::parse_from_rfc3339(&child.created_at) {
+        Ok(dt) => dt.with_timezone(&chrono::Utc),
+        Err(_) => return false,
+    };
+
+    (chrono::Utc::now() - created).num_seconds() >= deadline_secs
+}
+
 /// True when the child either has no readiness HC at all (legacy behaviour)
 /// or all of its readiness HCs have been green for the configured anti-flap
 /// window.
@@ -541,8 +564,31 @@ async fn handle_rolling_update(
     // green for at least `min_healthy_time`. Deployments without any
     // readiness HC keep the legacy behaviour (drain on `Running`) so this
     // change is fully opt-in for existing manifests.
+    //
+    // Deadline guard: a child whose readiness probe never turns green would
+    // otherwise pin the parent forever — leaving two instances running
+    // indefinitely (e.g. a broken probe). Once the child has been alive past
+    // RING_ROLLOUT_DEADLINE (default 600s), force the drain: the child is
+    // serving traffic regardless, so one instance is strictly better than a
+    // stuck pair. Operators still get a warning + event to fix the probe.
     if !is_ready_to_drain(pool, child).await {
-        return;
+        if rollout_deadline_exceeded(child) {
+            warn!(
+                "Rolling update: child {} still not ready after deadline — forcing parent drain to avoid a stuck duplicate (check its readiness probe)",
+                child.id
+            );
+            let _ = deployment_event::log_event(
+                pool,
+                child.id.clone(),
+                "warning",
+                "Rolling update: readiness never turned green before the deadline; draining the previous deployment anyway to avoid running two instances. Check the readiness health check.".to_string(),
+                "scheduler",
+                Some("rolling_update_deadline_forced"),
+            )
+            .await;
+        } else {
+            return;
+        }
     }
 
     // Load the parent deployment.
@@ -1072,6 +1118,29 @@ mod tests {
             parent_id: Some("parent-id".to_string()),
             network: None,
         }
+    }
+
+    #[test]
+    fn rollout_deadline_not_exceeded_for_fresh_child() {
+        // created_at = now → well within the 600s default deadline.
+        let child = child_with_health_checks("fresh", vec![]);
+        assert!(!rollout_deadline_exceeded(&child));
+    }
+
+    #[test]
+    fn rollout_deadline_exceeded_for_old_child() {
+        let mut child = child_with_health_checks("old", vec![]);
+        // created 20 minutes ago → past the 600s default deadline.
+        child.created_at = (chrono::Utc::now() - chrono::Duration::seconds(1200)).to_rfc3339();
+        assert!(rollout_deadline_exceeded(&child));
+    }
+
+    #[test]
+    fn rollout_deadline_safe_on_unparseable_created_at() {
+        let mut child = child_with_health_checks("bad", vec![]);
+        child.created_at = "not-a-date".to_string();
+        // Bad data must never force a drain.
+        assert!(!rollout_deadline_exceeded(&child));
     }
 
     /// Insert a health_check row directly so the gate has something to read.

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -378,8 +378,13 @@ fn rollout_deadline_exceeded(child: &Deployment) -> bool {
         .filter(|&v| v > 0)
         .unwrap_or(600);
 
-    let created = match chrono::DateTime::parse_from_rfc3339(&child.created_at) {
-        Ok(dt) => dt.with_timezone(&chrono::Utc),
+    // Ring stores timestamps as `Utc::now().to_string()`, e.g.
+    // "2026-05-30 20:07:20.341309196 UTC" — a space (not `T`) and a trailing
+    // ` UTC` zone *name*, which chrono's RFC3339/strptime parsers reject. Strip
+    // the zone name and parse the naive datetime; every Ring timestamp is UTC.
+    let trimmed = child.created_at.trim_end_matches(" UTC").trim();
+    let created = match chrono::NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%.f") {
+        Ok(dt) => dt.and_utc(),
         Err(_) => return false,
     };
 
@@ -1094,7 +1099,9 @@ mod tests {
     fn child_with_health_checks(id: &str, hcs: Vec<HealthCheck>) -> Deployment {
         Deployment {
             id: id.to_string(),
-            created_at: chrono::Utc::now().to_rfc3339(),
+            // Match how Ring actually stores timestamps (`Utc::now().to_string()`),
+            // not RFC3339 — the deadline parser must handle this exact format.
+            created_at: chrono::Utc::now().to_string(),
             updated_at: None,
             status: DeploymentStatus::Running,
             restart_count: 0,
@@ -1130,8 +1137,9 @@ mod tests {
     #[test]
     fn rollout_deadline_exceeded_for_old_child() {
         let mut child = child_with_health_checks("old", vec![]);
-        // created 20 minutes ago → past the 600s default deadline.
-        child.created_at = (chrono::Utc::now() - chrono::Duration::seconds(1200)).to_rfc3339();
+        // created 20 minutes ago → past the 600s default deadline. Uses Ring's
+        // real timestamp format (to_string, not RFC3339).
+        child.created_at = (chrono::Utc::now() - chrono::Duration::seconds(1200)).to_string();
         assert!(rollout_deadline_exceeded(&child));
     }
 


### PR DESCRIPTION
## Problem

During a rolling update, the previous deployment is kept running as the `parent` and is only drained once the new (child) deployment's readiness probe has been green long enough (`is_ready_to_drain`).

If the child's readiness probe **never** turns green — a broken or misconfigured probe, a check command that always exits non-zero, etc. — `is_ready_to_drain` returns `false` on every scheduler cycle and the parent is **never** drained. The result is two instances of the same deployment running side by side indefinitely, with no timeout and no failure: an operator has to notice and delete the stale deployment by hand.

## Change

Add a rollout deadline as a safety valve in `handle_rolling_update`:

- New `rollout_deadline_exceeded(child)` — true once the child has been alive longer than `RING_ROLLOUT_DEADLINE` (seconds, default `600`).
- When readiness still isn't green but the deadline has passed, force the drain anyway. The child is already serving traffic, so a single instance is strictly better than a stuck pair.
- A `warning` log + a `rolling_update_deadline_forced` deployment event are emitted so the operator can still fix the underlying probe.
- Fail-safe: an unparseable `created_at` never triggers a forced drain.

Deployments with a healthy readiness probe are unaffected — they drain normally, well before the deadline.

## Tests

Added unit tests: fresh child not past deadline, old child past deadline, and unparseable timestamp treated as not-expired. Existing rolling-update tests still pass.