### PR TITLE
Classify Docker image pull failures into actionable error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   instead of the legacy `API returned status 422: <raw body>` one-liner. Non-validation problems (404, 409) print the same way with the server's `title` and `detail`. Non-7807 responses fall back to the previous behaviour.
 
+### Changed
+- **Failed Docker image pulls now surface an actionable reason instead of a raw daemon dump.** A `ImagePullBackOff` event previously read `Failed to pull image '…': <bollard string>`. Ring now classifies the failure and rewrites it: authentication refused → `registry authentication failed … — check config.server, config.username and config.password`; registry unreachable (connection refused, host not found, timeout) → `cannot reach the registry … — is it up and the registry host correct?`; missing tag/digest stays as `not found`. The original daemon string is preserved verbatim in `(original error: …)`. The deployment status (`image_pull_back_off`) and event reason are unchanged.
+
 ## [0.8.0] - 2026-05-12
 
 ### Added

--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -126,7 +126,13 @@ Most common causes:
 ring deployment events <DEPLOYMENT_ID> --level error --limit 20
 ```
 
-The event's message includes Docker's exact rejection. For private registries, set `config.username` / `config.password` in the manifest:
+The event message names the likely cause and the fix, and keeps Docker's exact rejection in `(original error: …)` for the full detail. Three cases are distinguished:
+
+- **`… not found …`** — the tag or digest doesn't exist in the registry (or `image_pull_policy: Never` and the image isn't cached locally). Check the image reference.
+- **`registry authentication failed … — check config.server, config.username and config.password`** — the registry refused the credentials (or required some and none were sent). Fix the credentials below.
+- **`cannot reach the registry … — is it up and the registry host correct?`** — a transport failure (connection refused, host not found, timeout). The registry host is wrong or down; verify with `docker pull <image>` from the host.
+
+For private registries, set `config.server` / `config.username` / `config.password` in the manifest:
 
 ```yaml
 config:

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -148,6 +148,50 @@ pub(crate) fn prefer_local_cache(
         || matches!(reference, ImageReference::Digest(_))
 }
 
+/// Classify a Docker image-pull error into a `RuntimeError` whose message
+/// names the likely cause *and* the fix. Bollard surfaces registry failures
+/// as opaque strings; left untouched they reach the operator as
+/// `Failed to pull image '…': <bollard dump>`, which says what failed but not
+/// why or what to do. We match on the substrings Docker/registries emit and
+/// rewrite them into one actionable line. The `image` argument lets the
+/// "registry unreachable" case name the host the operator must check.
+///
+/// Order matters: a missing image (404) is distinct from an unreachable or
+/// auth-refusing registry, so it's matched first and kept as `ImageNotFound`.
+fn classify_pull_error(msg: &str, image: &str) -> RuntimeError {
+    let lower = msg.to_lowercase();
+
+    if lower.contains("404") || lower.contains("not found") || lower.contains("manifest unknown") {
+        return RuntimeError::ImageNotFound(msg.to_string());
+    }
+
+    if lower.contains("unauthorized")
+        || lower.contains("authentication required")
+        || lower.contains("denied")
+        || lower.contains("forbidden")
+    {
+        return RuntimeError::ImagePullFailed(format!(
+            "registry authentication failed for '{image}' — check config.server, \
+             config.username and config.password (original error: {msg})"
+        ));
+    }
+
+    if lower.contains("connection refused")
+        || lower.contains("no such host")
+        || lower.contains("dial tcp")
+        || lower.contains("timeout")
+        || lower.contains("i/o timeout")
+        || lower.contains("connection reset")
+    {
+        return RuntimeError::ImagePullFailed(format!(
+            "cannot reach the registry for '{image}' — is it up and the registry \
+             host correct? (original error: {msg})"
+        ));
+    }
+
+    RuntimeError::ImagePullFailed(msg.to_string())
+}
+
 async fn pull_image(
     docker: Docker,
     image_config: DockerImage,
@@ -217,17 +261,12 @@ async fn pull_image(
             let error_msg = e.to_string();
             error!("Docker image pull error: {}", error_msg);
 
-            if error_msg.contains("404")
-                || error_msg.contains("not found")
-                || error_msg.contains("manifest unknown")
-            {
-                return Err(RuntimeError::ImageNotFound(error_msg));
-            }
-            // Bail on the first non-404 error instead of draining the rest of
-            // the stream — the previous version kept iterating to find the
-            // "last" error, which delayed the failure and could mask the
-            // root cause behind a later io error.
-            return Err(RuntimeError::ImagePullFailed(error_msg));
+            // Bail on the first error instead of draining the rest of the
+            // stream — the previous version kept iterating to find the "last"
+            // error, which delayed the failure and could mask the root cause
+            // behind a later io error. `classify_pull_error` rewrites registry
+            // failures into an actionable message (auth / unreachable / 404).
+            return Err(classify_pull_error(&error_msg, &image_name));
         }
     }
 
@@ -964,5 +1003,78 @@ mod tests {
         // the registry on every reconcile.
         let r = ImageReference::Tag("9809f6b1".to_string());
         assert!(!prefer_local_cache(ImagePullPolicy::Always, &r, true));
+    }
+
+    #[test]
+    fn classify_pull_error_missing_image_stays_not_found() {
+        // 404 / manifest unknown is a missing image, not an unreachable or
+        // auth-refusing registry — it must keep the ImageNotFound variant so
+        // the deployment lands in ImagePullBackOff with the right reason.
+        let e = classify_pull_error(
+            "manifest unknown: manifest unknown",
+            "registry.example.com/app:v1",
+        );
+        assert!(matches!(e, RuntimeError::ImageNotFound(_)));
+
+        let e = classify_pull_error("received unexpected HTTP status: 404 Not Found", "app:v1");
+        assert!(matches!(e, RuntimeError::ImageNotFound(_)));
+    }
+
+    #[test]
+    fn classify_pull_error_auth_names_the_credentials_fix() {
+        for raw in [
+            "unauthorized: authentication required",
+            "denied: requested access to the resource is denied",
+            "pull access denied, repository does not exist or may require authorization",
+        ] {
+            let e = classify_pull_error(raw, "private.io/app:v1");
+            match e {
+                RuntimeError::ImagePullFailed(msg) => {
+                    assert!(
+                        msg.contains("config.username") && msg.contains("config.password"),
+                        "auth error should point at the credential config, got: {msg}"
+                    );
+                    assert!(msg.contains("private.io/app:v1"), "should name the image");
+                }
+                other => panic!("expected ImagePullFailed, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn classify_pull_error_unreachable_names_the_registry() {
+        for raw in [
+            "dial tcp 10.0.0.1:5000: connect: connection refused",
+            "dial tcp: lookup registry.invalid: no such host",
+            "Get \"https://registry.invalid/v2/\": net/http: request canceled (Client.Timeout exceeded)",
+        ] {
+            let e = classify_pull_error(raw, "registry.invalid/app:v1");
+            match e {
+                RuntimeError::ImagePullFailed(msg) => {
+                    assert!(
+                        msg.contains("cannot reach the registry"),
+                        "unreachable error should say so, got: {msg}"
+                    );
+                    assert!(
+                        msg.contains("registry.invalid/app:v1"),
+                        "should name the image"
+                    );
+                }
+                other => panic!("expected ImagePullFailed, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn classify_pull_error_unknown_keeps_the_original_detail() {
+        // An error we don't recognise must still surface its detail rather
+        // than being swallowed — operator clarity beats a tidy generic string.
+        let e = classify_pull_error("some unexpected daemon hiccup", "app:v1");
+        match e {
+            RuntimeError::ImagePullFailed(msg) => {
+                assert!(msg.contains("some unexpected daemon hiccup"));
+            }
+            other => panic!("expected ImagePullFailed, got {other:?}"),
+        }
     }
 }

--- a/tests/e2e/docker/t30_image_pull_registry_error.sh
+++ b/tests/e2e/docker/t30_image_pull_registry_error.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# T30: a failed registry pull surfaces an actionable error, not a raw bollard
+# dump.
+#
+# When `image_pull_policy: Always` forces a pull and the registry can't be
+# reached, Ring used to emit `Failed to pull image '…': <bollard string>` —
+# correct but opaque. `classify_pull_error` now rewrites the unreachable case
+# into a line that names the registry and tells the operator what to check.
+#
+# Deterministic and offline: we point the image at 127.0.0.1:1, a port nothing
+# listens on, so the pull fails with a connection error every run without
+# depending on a real (down) registry.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T30: registry pull error is actionable =="
+
+start_ring
+ring_login
+
+# 127.0.0.1:1 — privileged port nothing binds; the pull dials it and fails
+# with "connection refused" (or a comparable transport error) deterministically.
+UNREACHABLE_FIXTURE="$RING_TEST_DIR/unreachable-registry.yaml"
+cat > "$UNREACHABLE_FIXTURE" <<'EOF'
+deployments:
+  unreachable-registry:
+    name: unreachable-registry
+    namespace: ring-e2e
+    runtime: docker
+    image: 127.0.0.1:1/ring-e2e/nope:latest
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Always
+EOF
+"$RING_BIN" apply --file "$UNREACHABLE_FIXTURE"
+
+# The pull fails → ImagePullFailed → ImagePullBackOff.
+wait_deployment_status "ring-e2e" "unreachable-registry" "image_pull_back_off" 30
+DEP_ID=$(get_deployment_id "ring-e2e" "unreachable-registry")
+log "unreachable-registry reached image_pull_back_off as expected"
+
+# The whole point of this work: the event must read as an actionable line,
+# naming the registry, not a bare bollard dump. If we regress to the generic
+# string this grep fails.
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+EVENT_MSG=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.[].message' \
+  | grep -i "cannot reach the registry" | head -n1 || true)
+if [ -z "$EVENT_MSG" ]; then
+  log "events seen:"
+  curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.[].message' >&2 || true
+  fail "expected an event mentioning 'cannot reach the registry', got none"
+fi
+log "event message is actionable: $EVENT_MSG"
+
+# It must also name the offending image so the operator knows which one.
+case "$EVENT_MSG" in
+  *127.0.0.1:1/ring-e2e/nope:latest*) ;;
+  *) fail "event should name the image, got: $EVENT_MSG" ;;
+esac
+log "event names the offending image"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEP_ID"
+
+log "== T30: PASS =="


### PR DESCRIPTION
## What

When a Docker image pull fails, the deployment lands in `ImagePullBackOff` with an event message. Previously any non-404 failure (bad credentials, unreachable registry) was surfaced as `Failed to pull image '…': <raw bollard string>` — accurate, but it told the operator *what* failed, not *why* or *what to do*.

This adds `classify_pull_error` (`src/runtime/docker/container.rs`), which rewrites the failure into one actionable line while preserving the original daemon string in `(original error: …)`:

- **auth refused** (`unauthorized`, `authentication required`, `denied`, `forbidden`) → `registry authentication failed for '<image>' — check config.server, config.username and config.password`
- **registry unreachable** (`connection refused`, `no such host`, `dial tcp`, `timeout`, `connection reset`) → `cannot reach the registry for '<image>' — is it up and the registry host correct?`
- **missing image** (`404`, `not found`, `manifest unknown`) → unchanged, stays `ImageNotFound`
- **unrecognised** → keeps the original detail verbatim

The deployment status (`image_pull_back_off`) and event reason are unchanged — only the message text improves.

## Scope

This closes the last open sub-case of the runtime-error work. An audit of the other listed cases confirmed they were already correct and needed no code change:

- virtiofsd missing / KVM absent → already an actionable message plus captured CH stderr
- health check `command:` pointing at a missing binary → `HealthCheckStatus::Failed` (expected health-check semantics, not a runtime error)
- namespace referenced at runtime → networks are created on demand, so there is no "missing namespace" case
- re-applying a running deployment → idempotent reconcile, no-op

The Docker host-port-conflict case stays deprioritised, as noted previously.

## Testing

- 4 unit tests covering each classification family (auth / unreachable / 404 / unknown).
- New e2e `tests/e2e/docker/t30_image_pull_registry_error.sh`: points an image at `127.0.0.1:1` (offline, deterministic), asserts the event reads `cannot reach the registry` and names the image. Stable over 3 runs.
- `t16_image_pull_policy.sh` (shares the modified code path) still passes — no regression.
- Full unit suite green (438 passed), `cargo fmt` clean.

## Docs

`documentation/help/troubleshooting.md` § `image_pull_back_off` now describes the three message families, and the change is recorded under `[Unreleased] → Changed` in the changelog.