### PR TITLE
chore(db): harden SQLite integration (busy_timeout + transactional event writes)

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9,7 +9,13 @@ pub(crate) async fn get_database_pool() -> SqlitePool {
         .expect("Invalid database path")
         .create_if_missing(true)
         .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-        .foreign_keys(true);
+        .foreign_keys(true)
+        // Without a busy timeout, a write that hits a momentarily locked
+        // database (another connection mid-write) fails instantly with
+        // "database is locked". WAL allows concurrent readers but still
+        // serializes writers, and the scheduler + API can write at the same
+        // time. 5s lets SQLite retry internally instead of bubbling the error.
+        .busy_timeout(std::time::Duration::from_secs(5));
 
     let max_connections = env::var("RING_DB_POOL_SIZE")
         .ok()

--- a/src/models/deployment_event.rs
+++ b/src/models/deployment_event.rs
@@ -38,6 +38,12 @@ pub(crate) async fn create_event(
     pool: &SqlitePool,
     event: &DeploymentEvent,
 ) -> Result<(), sqlx::Error> {
+    // Insert the event and bump the deployment's `last_event_at` atomically.
+    // Outside a transaction a concurrent reader could see the new event row
+    // before `last_event_at` is updated (or the update could land without the
+    // row if the second statement fails), leaving the two out of sync.
+    let mut tx = pool.begin().await?;
+
     sqlx::query(
         "INSERT INTO deployment_event (id, deployment_id, timestamp, level, message, component, reason)
          VALUES (?, ?, ?, ?, ?, ?, ?)"
@@ -49,16 +55,16 @@ pub(crate) async fn create_event(
     .bind(&event.message)
     .bind(&event.component)
     .bind(&event.reason)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
 
     sqlx::query("UPDATE deployment SET last_event_at = ? WHERE id = ?")
         .bind(&event.timestamp)
         .bind(&event.deployment_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
 
-    Ok(())
+    tx.commit().await
 }
 
 pub(crate) async fn find_events_by_deployment(


### PR DESCRIPTION
## Why

An audit of the sqlx integration found the setup fundamentally sound (WAL, foreign keys, derived `FromRow`, parameterized SQL) but with two concrete reliability gaps under concurrency. The scheduler and the API both write to the same SQLite database.

## What

- **`busy_timeout` on the pool** (`database.rs`): without it, a write that hits a momentarily locked database fails instantly with "database is locked". WAL allows concurrent readers but still serializes writers, so the scheduler + API can collide. A 5s busy timeout lets SQLite retry internally instead of bubbling the error.
- **Transactional event writes** (`deployment_event.rs::create_event`): the INSERT into `deployment_event` and the `UPDATE deployment SET last_event_at` are now wrapped in a single transaction, so the two can never be observed out of sync (or land half-applied if the second statement fails).

## Verification

- `cargo build --bin ring` — clean.
- `cargo test --bin ring` — 434 passing.

## Notes

Out of scope (deliberately, as larger follow-ups): migrating runtime-checked `sqlx::query` strings to compile-time `sqlx::query!` macros (`cargo sqlx prepare` + offline CI), and batching the N+1 loop in `health_check_logs::cleanup_old_health_checks`.