### PR TITLE
fix(cli): exit non-zero on network/HTTP failure in metrics, events, node get

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -528,6 +528,7 @@ esac
 
 Notes:
 
+- Every command that talks to the API honours this table: a command that cannot reach the API or gets a non-2xx response exits non-zero (never `0`), so `set -e`, CI gates and `&&` chains detect the failure.
 - `ring apply` processes multiple deployments; if any fail, the command exits with the code of the **first** failure.
 - Follow modes (`logs --follow`, `events --follow`) keep running on transient errors and only exit if the initial request fails.
 

--- a/src/commands/deployment/events.rs
+++ b/src/commands/deployment/events.rs
@@ -1,4 +1,6 @@
+use crate::commands::problem_json::transport_error;
 use crate::commands::style;
+use crate::exit_code::{self, ExitCode};
 use clap::{Arg, ArgMatches, Command};
 use cli_table::{Table, WithTitle};
 use serde::Deserialize;
@@ -81,8 +83,9 @@ pub(crate) async fn execute(
                     display_events(&events);
                 }
             }
-            Err(e) => {
-                eprintln!("Error: {}", e);
+            Err((message, code)) => {
+                eprintln!("{}", message);
+                code.exit();
             }
         }
     }
@@ -94,7 +97,7 @@ async fn fetch_events(
     limit: u32,
     config: &mut Config,
     client: &reqwest::Client,
-) -> Result<Vec<EventItem>, String> {
+) -> Result<Vec<EventItem>, (String, ExitCode)> {
     let mut url = format!(
         "{}/deployments/{}/events?limit={}",
         config.get_api_url(),
@@ -116,20 +119,26 @@ async fn fetch_events(
 
     match response {
         Ok(response) => {
-            let events: Vec<EventItem> = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response as JSON: {}", e))?;
+            let status = response.status();
+            if !status.is_success() {
+                let message = match status.as_u16() {
+                    401 | 403 => {
+                        "Authentication failed. Please login again with 'ring login'".to_string()
+                    }
+                    404 => format!("Deployment '{}' not found", deployment_id),
+                    other => format!("Failed to fetch events: server returned {}", other),
+                };
+                return Err((message, exit_code::from_http_status(status.as_u16())));
+            }
 
-            Ok(events)
+            response.json().await.map_err(|e| {
+                (
+                    format!("Failed to parse response as JSON: {}", e),
+                    ExitCode::General,
+                )
+            })
         }
-        Err(e) if e.to_string().contains("401") => {
-            Err("Authentication failed. Please login again with 'ring login'".to_string())
-        }
-        Err(e) if e.to_string().contains("404") => {
-            Err(format!("Deployment '{}' not found", deployment_id))
-        }
-        Err(e) => Err(format!("Failed to fetch events: {}", e)),
+        Err(e) => Err((transport_error(&e, &url), exit_code::from_reqwest_error(&e))),
     }
 }
 
@@ -148,11 +157,16 @@ async fn follow_events(
     let mut last_seen_id: Option<String> = None;
     let mut all_events: Vec<EventItem> = Vec::new();
 
-    // Show initial events and store them
-    let initial_events = fetch_events(deployment_id, level, limit, config, client).await;
-    if let Ok(events) = initial_events
-        && !events.is_empty()
-    {
+    // Show initial events and store them. A failure here (server down, auth, not
+    // found) is fatal: bail out non-zero instead of spinning the polling loop blind.
+    let events = match fetch_events(deployment_id, level, limit, config, client).await {
+        Ok(events) => events,
+        Err((message, code)) => {
+            eprintln!("{}", message);
+            code.exit();
+        }
+    };
+    if !events.is_empty() {
         // Reverse the events to show oldest first (tail -f style)
         all_events = events.clone();
         all_events.reverse();
@@ -195,8 +209,10 @@ async fn follow_events(
                     last_seen_id = new_events.first().map(|e| e.id.clone());
                 }
             }
-            Err(e) => {
-                eprintln!("Error fetching events: {}", e);
+            Err((message, _code)) => {
+                // Transient failure mid-follow: report and keep polling rather
+                // than tearing down the stream on a single hiccup.
+                eprintln!("Error fetching events: {}", message);
             }
         }
     }

--- a/src/commands/deployment/metrics.rs
+++ b/src/commands/deployment/metrics.rs
@@ -1,7 +1,8 @@
 use crate::api::dto::stats::DeploymentStatsOutput;
-use crate::commands::problem_json::http_error;
+use crate::commands::problem_json::{http_error, transport_error};
 use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
+use crate::exit_code;
 use clap::{Arg, ArgMatches, Command};
 
 pub(crate) fn command_config() -> Command {
@@ -30,18 +31,20 @@ pub(crate) async fn execute(
     let id = args.get_one::<String>("id").unwrap();
     let api_url = configuration.get_api_url();
     let auth_config = load_auth_config(configuration.name.clone());
+    let endpoint = format!("{}/deployments/{}/metrics", api_url, id);
 
     let response = client
-        .get(format!("{}/deployments/{}/metrics", api_url, id))
+        .get(&endpoint)
         .header("Authorization", format!("Bearer {}", auth_config.token))
         .send()
         .await;
 
     match response {
         Ok(res) => {
-            if res.status() != 200 {
-                style::print_error(&http_error(res.status().as_u16(), "deployment", id));
-                return;
+            let status = res.status();
+            if status != 200 {
+                style::print_error(&http_error(status.as_u16(), "deployment", id));
+                exit_code::from_http_status(status.as_u16()).exit();
             }
 
             match res.json::<DeploymentStatsOutput>().await {
@@ -93,9 +96,15 @@ pub(crate) async fn execute(
                         println!();
                     }
                 }
-                Err(e) => eprintln!("Failed to parse metrics: {}", e),
+                Err(e) => {
+                    eprintln!("Failed to parse metrics: {}", e);
+                    exit_code::ExitCode::General.exit();
+                }
             }
         }
-        Err(e) => eprintln!("Failed to fetch metrics: {}", e),
+        Err(e) => {
+            style::print_error(&transport_error(&e, &endpoint));
+            exit_code::from_reqwest_error(&e).exit();
+        }
     }
 }

--- a/src/commands/node/get.rs
+++ b/src/commands/node/get.rs
@@ -1,5 +1,8 @@
 use crate::api::dto::node::NodeRootDto;
+use crate::commands::problem_json::transport_error;
+use crate::commands::style;
 use crate::config::config::{Config, load_auth_config};
+use crate::exit_code;
 use clap::{ArgMatches, Command};
 
 pub(crate) fn command_config() -> Command {
@@ -42,10 +45,12 @@ pub(crate) async fn execute(
             }
             Err(e) => {
                 eprintln!("Failed to parse JSON: {}", e);
+                exit_code::ExitCode::General.exit();
             }
         },
         Err(err) => {
-            eprintln!("Failed to fetch node info: {}", err);
+            style::print_error(&transport_error(&err, &query));
+            exit_code::from_reqwest_error(&err).exit();
         }
     }
 }

--- a/tests/e2e/server/t7_cli_exit_code_server_down.sh
+++ b/tests/e2e/server/t7_cli_exit_code_server_down.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# T7-server: every CLI command that talks to the API must exit non-zero when
+# the server is unreachable. Before this change, several read commands printed
+# their error to stderr but fell off the end of the function and exited 0 —
+# so `set -e`, CI gates and `ring metrics <id> && deploy` chains never noticed
+# the API was down.
+#
+# This proves, against the *real compiled binary* and with no server running,
+# that the commands fixed in fix/cli-exit-code-* exit non-zero. namespace list
+# is included as a regression guard (it was already correct).
+#
+# Invariants (per command):
+#   - exit code is non-zero when the server is down
+#   - the reqwest source chain does not leak to the user
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+# Port 1 is privileged and never listened to by a normal process; connect()
+# refuses immediately, so every command hits a transport error.
+PORT=1
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t7-server-salt"
+scheduler.interval = 1
+EOF
+
+cleanup() { rm -rf "$CFG"; }
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+# Supply a token via env so the CLI does not try (and log a failure) to read a
+# non-existent auth.json — we are testing transport failure, not auth loading.
+export RING_TOKEN="t7-dummy-token"
+
+log "== T7-server: CLI exit codes against a down server =="
+
+# run_case <label> <strict|exitonly> -- <ring args...>
+#   strict   : exit non-zero AND no reqwest source-chain leak (commands this PR
+#              routes through transport_error)
+#   exitonly : exit non-zero only (regression guard for commands that already
+#              exited non-zero; their human-message cleanup is a separate change)
+run_case() {
+  local label="$1" mode="$2"; shift 2
+  [ "$1" = "--" ] && shift
+  set +e
+  OUT=$("$RING_BIN" "$@" 2>&1)
+  RC=$?
+  set -e
+
+  [ "$RC" -ne 0 ] || { echo "$OUT" >&2; fail "$label: must exit non-zero when server is down (got $RC)"; }
+
+  if [ "$mode" = "strict" ]; then
+    if echo "$OUT" | grep -qiE 'os error|tcp connect error|trying to connect|error sending request'; then
+      echo "$OUT" >&2
+      fail "$label: reqwest source chain leaked to the user"
+    fi
+    log "$label: exit $RC, human message (no chain leak)"
+  else
+    log "$label: exit $RC (regression guard)"
+  fi
+}
+
+run_case "deployment metrics" strict   -- deployment metrics some-id
+run_case "deployment events"  strict   -- deployment events some-id
+run_case "node get"           strict   -- node get
+run_case "namespace list"     exitonly -- namespace list
+
+log "== T7-server: all invariants passed =="


### PR DESCRIPTION
## Problem

`ring deployment metrics`, `ring deployment events` and `ring node get` printed their error to stderr but fell off the end of the handler and exited `0` when the API was unreachable or returned a non-2xx status. As a result `set -e`, CI gates and `cmd && next` chains never noticed the failure — e.g. `ring deployment metrics <id> && deploy` would proceed even with the server down.

The shared `exit_code` infrastructure and the `transport_error` helper already existed and were wired into ~20 other commands; these three were missed.

## Fix

- `deployment metrics`, `deployment events`, `node get`: every failure path now exits with the documented code (`from_http_status` for non-2xx, `from_reqwest_error` for transport failures, `General` for body-parse errors).
- Network failures are rendered through `transport_error` (single human line) instead of leaking the raw reqwest source chain.
- `events`: a failed **initial** fetch in `--follow` mode now bails out non-zero instead of spinning the polling loop blind; transient mid-follow errors keep the stream alive (matches the documented follow-mode contract). The brittle `e.to_string().contains("401"/"404")` matching is replaced with real HTTP status inspection.

## Tests

- New e2e `tests/e2e/server/t7_cli_exit_code_server_down.sh` runs the real compiled binary against an unbound port: the three fixed commands assert exit non-zero **and** no chain leak; `namespace list` is a regression guard for exit code. Passes against the real binary.
- `cargo test`: 443 passed.

## Docs

- `reference/cli.md`: note that every API-talking command honours the exit-code table.

## Out of scope

~19 other commands already exit non-zero but still print the raw reqwest chain on network errors. That is a message-only cleanup (no exit-code bug) and is left for a separate change.