### PR TITLE
feat(dashboard): live CPU/memory/IO metrics on the deployment detail page

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -107,6 +107,53 @@ export interface DeploymentDetail extends Deployment {
   network?: unknown;
 }
 
+export interface MemoryStats {
+  usage_bytes: number;
+  limit_bytes: number;
+  usage_percent: number;
+}
+
+export interface NetworkStats {
+  rx_bytes: number;
+  tx_bytes: number;
+  rx_packets: number;
+  tx_packets: number;
+}
+
+export interface DiskIoStats {
+  read_bytes: number;
+  write_bytes: number;
+}
+
+export interface PidStats {
+  current: number;
+  limit: number;
+}
+
+export interface InstanceStats {
+  instance_id: string;
+  instance_name: string;
+  cpu_usage_percent: number;
+  memory: MemoryStats;
+  network: NetworkStats;
+  disk_io: DiskIoStats;
+  pids: PidStats;
+  restart_count: number;
+}
+
+/** Mirrors `DeploymentStatsOutput` from `src/api/dto/stats.rs`. */
+export interface DeploymentStats {
+  deployment_id: string;
+  deployment_name: string;
+  instance_count: number;
+  total_cpu_usage_percent: number;
+  total_memory: MemoryStats;
+  total_network: NetworkStats;
+  total_disk_io: DiskIoStats;
+  total_pids: number;
+  instances: InstanceStats[];
+}
+
 export interface Secret {
   id: string;
   created_at: string;
@@ -230,6 +277,10 @@ export function getDeployment(id: string): Promise<DeploymentDetail> {
 
 export function listDeploymentEvents(id: string): Promise<DeploymentEvent[]> {
   return request<DeploymentEvent[]>(`/deployments/${encodeURIComponent(id)}/events`);
+}
+
+export function getDeploymentMetrics(id: string): Promise<DeploymentStats> {
+  return request<DeploymentStats>(`/deployments/${encodeURIComponent(id)}/metrics`);
 }
 
 export function listSecrets(): Promise<Secret[]> {

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -36,13 +36,25 @@ export function formatDate(iso: string | null | undefined): string {
   return d.toLocaleString();
 }
 
+/** Human-readable byte size (binary units), mirroring the CLI's `format_bytes`. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) {
+    return `${(bytes / 1_073_741_824).toFixed(2)} GiB`;
+  }
+  if (bytes >= 1_048_576) {
+    return `${(bytes / 1_048_576).toFixed(2)} MiB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(2)} KiB`;
+  }
+  return `${bytes} B`;
+}
+
 function normaliseTimestamp(input: string): string {
   // SQL-style: `YYYY-MM-DD HH:MM:SS[.nnn...] UTC` → `YYYY-MM-DDTHH:MM:SS[.nnn]Z`.
   // We keep at most 3 fractional digits because `Date` ignores anything beyond
   // milliseconds and some browsers complain about longer precision.
-  const m = input.match(
-    /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(\.\d+)? UTC$/
-  );
+  const m = input.match(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(\.\d+)? UTC$/);
   if (m) {
     const frac = m[3] ? m[3].slice(0, 4) : '';
     return `${m[1]}T${m[2]}${frac}Z`;

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -5,20 +5,24 @@
   import {
     fetchLogsSnapshot,
     getDeployment,
+    getDeploymentMetrics,
     listDeploymentEvents,
     streamLogs,
     type DeploymentDetail,
     type DeploymentEvent,
+    type DeploymentStats,
     type EnvValue,
     type HealthCheck,
     type LogEntry,
     type LogStreamHandle
   } from '$lib/api';
   import { getToken } from '$lib/auth';
-  import { formatDate, timeAgo } from '$lib/utils';
+  import { formatBytes, formatDate, timeAgo } from '$lib/utils';
 
   let detail = $state<DeploymentDetail | null>(null);
   let events = $state<DeploymentEvent[]>([]);
+  let metrics = $state<DeploymentStats | null>(null);
+  let metricsError = $state<string | null>(null);
   let loading = $state(true);
   let errorMsg = $state<string | null>(null);
   let lastFetch = $state<Date | null>(null);
@@ -155,12 +159,24 @@
       return;
     }
     try {
-      // Events can fail (e.g. older versions of the API) without invalidating
-      // the rest of the page — degrade gracefully.
-      const [d, ev] = await Promise.all([
+      // Events and metrics can fail (older API, or a deployment with no live
+      // instances) without invalidating the rest of the page — degrade
+      // gracefully. Metrics carry their own error so the card can explain why
+      // it's empty instead of silently showing nothing.
+      const [d, ev, m] = await Promise.all([
         getDeployment(id),
-        listDeploymentEvents(id).catch(() => [] as DeploymentEvent[])
+        listDeploymentEvents(id).catch(() => [] as DeploymentEvent[]),
+        getDeploymentMetrics(id)
+          .then((stats) => {
+            metricsError = null;
+            return stats;
+          })
+          .catch((e) => {
+            metricsError = e instanceof Error ? e.message : String(e);
+            return null;
+          })
       ]);
+      metrics = m;
       // The API omits empty collections in some shapes (e.g. health_checks
       // is missing entirely when none are configured). Normalize so the
       // template can safely read `.length`, `Object.keys`, etc.
@@ -391,6 +407,87 @@
           <li class="mono">{inst}</li>
         {/each}
       </ul>
+    {/if}
+  </section>
+
+  <section class="card">
+    <header class="section-head">
+      <h2>Metrics</h2>
+      <span class="count">live</span>
+    </header>
+    {#if metrics && metrics.instance_count > 0}
+      <div class="metrics-totals">
+        <div class="metric">
+          <span class="metric-label">CPU</span>
+          <span class="metric-value mono">{metrics.total_cpu_usage_percent.toFixed(1)}%</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Memory</span>
+          <span class="metric-value mono">
+            {formatBytes(metrics.total_memory.usage_bytes)}
+            <span class="metric-sub"
+              >/ {formatBytes(metrics.total_memory.limit_bytes)} ({metrics.total_memory.usage_percent.toFixed(
+                1
+              )}%)</span
+            >
+          </span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Net I/O</span>
+          <span class="metric-value mono">
+            {formatBytes(metrics.total_network.rx_bytes)} rx
+            <span class="metric-sub">/ {formatBytes(metrics.total_network.tx_bytes)} tx</span>
+          </span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Disk I/O</span>
+          <span class="metric-value mono">
+            {formatBytes(metrics.total_disk_io.read_bytes)} read
+            <span class="metric-sub">/ {formatBytes(metrics.total_disk_io.write_bytes)} write</span>
+          </span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">PIDs</span>
+          <span class="metric-value mono">{metrics.total_pids}</span>
+        </div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Instance</th>
+            <th class="num">CPU</th>
+            <th class="num">Memory</th>
+            <th class="num">Net rx / tx</th>
+            <th class="num">Disk r / w</th>
+            <th class="num">PIDs</th>
+            <th class="num">Restarts</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each metrics.instances as inst (inst.instance_id)}
+            <tr>
+              <td class="mono" title={inst.instance_id}>{inst.instance_name}</td>
+              <td class="num mono">{inst.cpu_usage_percent.toFixed(1)}%</td>
+              <td class="num mono">
+                {formatBytes(inst.memory.usage_bytes)}
+                <span class="metric-sub">({inst.memory.usage_percent.toFixed(1)}%)</span>
+              </td>
+              <td class="num mono">
+                {formatBytes(inst.network.rx_bytes)} / {formatBytes(inst.network.tx_bytes)}
+              </td>
+              <td class="num mono">
+                {formatBytes(inst.disk_io.read_bytes)} / {formatBytes(inst.disk_io.write_bytes)}
+              </td>
+              <td class="num mono">{inst.pids.current} / {inst.pids.limit}</td>
+              <td class="num mono">{inst.restart_count}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {:else if metricsError}
+      <p class="muted pad">Metrics unavailable: {metricsError}</p>
+    {:else}
+      <p class="muted pad">No live instances to report metrics for.</p>
     {/if}
   </section>
 
@@ -683,6 +780,35 @@
   }
   .muted.pad {
     padding: 1.25rem;
+  }
+
+  .metrics-totals {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.85rem 1.5rem;
+    padding: 1rem 1.125rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .metric-label {
+    color: var(--fg-2);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .metric-value {
+    color: var(--fg-0);
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .metric-sub {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+    font-weight: 400;
   }
 
   dl {

--- a/documentation/how-to/use-the-dashboard.md
+++ b/documentation/how-to/use-the-dashboard.md
@@ -79,9 +79,14 @@ Local mode is always available — there's nothing to disable, it only runs when
 
 ## What the dashboard currently shows
 
-This is the v0.9 MVP — intentionally minimal:
-
 - A login screen
-- A list of all deployments visible to your account, with namespace / name / runtime / status / replicas / image
+- A list of all deployments visible to your account, with namespace / name / runtime / status / replicas / image, plus namespace filters
+- A deployment **detail page** (`/deployments/{id}`) with:
+  - Overview and configured resources
+  - Running instances
+  - **Live metrics** — per-instance and aggregated CPU, memory, network I/O, disk I/O and PID counts, refreshed every few seconds (sourced from `GET /deployments/{id}/metrics`). The card shows a message instead when the deployment has no live instances.
+  - Ports, volumes, environment variables, and configured health checks
+  - Streamed logs (live tail) and a recent-events timeline
+- Read-only views for namespaces, secrets, and configs
 
-Future cycles will add drill-down (instances, events, live logs) and actions (restart, scale, delete). Until then, the CLI remains the source of truth for anything mutating.
+The dashboard is read-only: the CLI and manifest remain the source of truth for anything mutating (create, scale, restart, delete).


### PR DESCRIPTION
## What

Adds a **Metrics** card to the deployment detail page (`/deployments/{id}`), wiring up the existing `GET /deployments/{id}/metrics` endpoint that until now only the CLI consumed.

- Aggregated totals: CPU %, memory (used / limit / %), network rx/tx, disk read/write, PID count.
- Per-instance table: CPU, memory, net I/O, disk I/O, PIDs (current/limit) and restart count.
- Refreshed on the same 5s poll as the rest of the page.
- Degrades gracefully: metrics are fetched in parallel and carry their own error, so a deployment with no live instances (or an older API) shows an explanatory message instead of breaking the page.

## Implementation

- `api.ts`: typed `DeploymentStats` / `InstanceStats` (mirrors `src/api/dto/stats.rs`) and `getDeploymentMetrics()`.
- `utils.ts`: shared `formatBytes()` (binary units, mirrors the CLI's `format_bytes`).
- Detail page: new state + parallel fetch in `refresh()`, the Metrics card between Instances and Ports, and its styles.

## Validation

- Verified the live endpoint shape against a real running deployment on a local server (`mugiwara-demo-go-app`, 2 instances): JSON matches the TS types field-for-field.
- `svelte-check`: 0 errors.
- `biome check`: clean.
- `bun run build`: success.

The project has no dashboard UI test harness; validation follows the existing dashboard convention (check + lint + build) plus the live endpoint shape check.

## Docs

- `how-to/use-the-dashboard.md`: refreshed the "what the dashboard shows" section to reflect the detail page (metrics, logs, events, etc.) instead of the stale "MVP — list only" wording.