### PR TITLE
fix(scheduler): purge deleted deployments without resolving their secrets/configs/volumes

### DIFF
--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -120,6 +120,12 @@ Most common causes:
 - **`ImagePullBackOff`** — Docker can't pull the image. Wrong tag, missing credentials, network problem. Verify with `docker pull <image>` from the host
 - **`InstanceCreationFailed`** — Docker rejected the container creation. Common subreasons: port conflict (`bind: address already in use`), invalid bind mount (source path missing), unsupported runtime option
 
+### Stuck in `deleted`
+
+A deployment shown as `deleted` should disappear within a scheduler cycle or two once its containers are gone — the row is purged automatically. If it lingers and `ring deployment events <ID>` keeps logging `secret_resolution_error` / `config_load_error` / `volume_resolution_error`, you are on a build prior to the fix where the scheduler tried to resolve a deployment's secrets/configs/volumes *before* tearing it down. A resource deleted alongside the deployment (e.g. the secret a `secretRef` pointed at) then made resolution fail every tick, so cleanup was never reached.
+
+Current builds reconcile a `deleted` deployment straight to teardown and purge, ignoring secret/config/volume resolution. If you hit this on an older server, upgrade; the stuck row clears on the next cycle after restart.
+
 ### `image_pull_back_off`
 
 ```bash

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -950,10 +950,44 @@ pub(crate) async fn schedule(
                 }
             };
 
-            // Honour the retry backoff. Deletes always go through so the
-            // user can wipe a stuck deployment without waiting.
-            if deployment.status != DeploymentStatus::Deleted && backoff.is_blocked(&deployment.id)
-            {
+            // A deleted deployment is on its way out: its only remaining job is
+            // to tear down its containers and be purged. Resolving configs /
+            // secrets / volumes is both pointless and actively harmful here —
+            // those resources are often deleted alongside the deployment, and a
+            // missing one makes the resolution step `continue` before we ever
+            // reach `handle_status_transitions`, leaving the deployment stuck in
+            // `deleted` forever. The runtime's delete path removes containers
+            // without reading env or mounts, so reconcile with the unresolved
+            // deployment and go straight to cleanup.
+            if deployment.status == DeploymentStatus::Deleted {
+                backoff.clear(&deployment.id);
+                let mut result = match apply_runtime(
+                    &pool,
+                    &deployment,
+                    deployment.clone(),
+                    Vec::new(),
+                    apply_timeout,
+                    apply_timeout_secs,
+                    runtime.as_ref(),
+                )
+                .await
+                {
+                    Some(d) => d,
+                    None => continue,
+                };
+
+                persist_pending_events(&pool, &mut result).await;
+                handle_status_transitions(&pool, &mut result, &mut deleted).await;
+
+                if let Err(e) = deployments::update(&pool, &result).await {
+                    error!("Failed to update deployment {}: {}", result.id, e);
+                }
+                continue;
+            }
+
+            // Honour the retry backoff. (Deletes are handled above and never
+            // reach this point, so they're never blocked by backoff.)
+            if backoff.is_blocked(&deployment.id) {
                 debug!(
                     "Deployment {} in retry backoff, skipping cycle",
                     deployment.id

--- a/tests/e2e/docker/t32_delete_with_missing_secret.sh
+++ b/tests/e2e/docker/t32_delete_with_missing_secret.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# T32: a deleted deployment must converge to a full purge even when one of its
+# referenced resources (here: a secretRef) has been removed in the meantime.
+#
+# Regression for the scheduler getting stuck: it used to resolve configs /
+# secrets / volumes for *every* deployment before reaching the cleanup path.
+# A deployment in `deleted` whose secret no longer exists failed secret
+# resolution, hit `continue`, and never reached `handle_status_transitions` —
+# so it sat in `deleted` forever (containers gone, row never purged), spamming
+# `secret_resolution_error` every tick. Observed live on `kemeter-api` after
+# its `DATABASE_PASSWORD` secret was deleted.
+#
+# The fix reconciles a `deleted` deployment straight to teardown + cleanup
+# without touching secret/config/volume resolution.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T32: delete converges even with a missing secret =="
+
+start_ring
+ring_login
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+# === namespace + secret ===
+HTTP=$(curl -s -o /tmp/ring-ns.out -w '%{http_code}' \
+  -X POST "$RING_URL/namespaces" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"ring-e2e"}')
+if [ "$HTTP" != "201" ] && [ "$HTTP" != "409" ]; then
+  cat /tmp/ring-ns.out >&2
+  fail "POST /namespaces returned $HTTP (expected 201 or 409)"
+fi
+
+HTTP=$(curl -s -o /tmp/ring-secret.out -w '%{http_code}' \
+  -X POST "$RING_URL/secrets" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"namespace":"ring-e2e","name":"doomed-secret","value":"will-be-deleted"}')
+if [ "$HTTP" != "201" ]; then
+  cat /tmp/ring-secret.out >&2
+  fail "POST /secrets returned $HTTP (expected 201)"
+fi
+log "secret 'doomed-secret' created"
+
+# === deploy a container that references the secret ===
+FIXTURE="$RING_TEST_DIR/doomed.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  doomed:
+    name: doomed
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    environment:
+      SECRET:
+        secretRef: "doomed-secret"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "doomed" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "doomed")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === pull the rug: delete the secret while the deployment still references it ===
+# Secrets are addressed by id (route is /secrets/{id}), so resolve it first.
+SECRET_ID=$(curl -fsS "$RING_URL/secrets" -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.[] | select(.namespace=="ring-e2e" and .name=="doomed-secret") | .id' | head -n1)
+[ -z "$SECRET_ID" ] && fail "could not resolve id of secret 'doomed-secret'"
+
+HTTP=$(curl -s -o /dev/null -w '%{http_code}' \
+  -X DELETE "$RING_URL/secrets/$SECRET_ID" \
+  -H "Authorization: Bearer $TOKEN")
+[ "$HTTP" = "204" ] || [ "$HTTP" = "200" ] || fail "DELETE /secrets/$SECRET_ID returned $HTTP"
+
+# Confirm it's really gone — the whole point of the test is a *missing* secret.
+gone=$(curl -fsS "$RING_URL/secrets" -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.[] | select(.namespace=="ring-e2e" and .name=="doomed-secret") | .id' | head -n1)
+[ -z "$gone" ] || fail "secret 'doomed-secret' still present after delete"
+log "secret deleted — deployment now references a missing secret"
+
+# === now delete the deployment ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# === it must fully disappear, not get stuck in `deleted` ===
+# Poll the deployment listing: once purged, get_deployment_id returns empty.
+deadline=$((SECONDS + 60))
+while [ $SECONDS -lt $deadline ]; do
+  still=$(get_deployment_id "ring-e2e" "doomed" || true)
+  if [ -z "$still" ]; then
+    log "deployment purged from the store ✓"
+    break
+  fi
+  sleep 3
+done
+
+still=$(get_deployment_id "ring-e2e" "doomed" || true)
+if [ -n "$still" ]; then
+  curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID" -H "Authorization: Bearer $TOKEN" >&2 || true
+  fail "deployment $DEPLOYMENT_ID stuck in 'deleted' — never purged despite missing secret"
+fi
+
+# Containers must be gone too.
+wait_docker_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T32: PASS =="


### PR DESCRIPTION
## Problem

A deployment stuck in `deleted` forever, with the scheduler logging `secret_resolution_error` every tick. Observed live on `kemeter-api` after its `DATABASE_PASSWORD` secret was deleted.

Root cause: the reconcile loop resolves configs, secrets and volumes for **every** deployment before reaching `handle_status_transitions` (the only path to cleanup). Each resolution step `continue`s the loop on failure. When a deployment is `deleted` but one of its referenced resources is also gone — which is exactly what happens when you delete a deployment and its secret together — resolution fails on every cycle and cleanup is never reached. The container is long gone; the DB row lingers indefinitely.

## Fix

Handle `deleted` deployments up front: reconcile straight to teardown + cleanup, skipping config/secret/volume resolution entirely. The runtime's delete path (`remove_all_instances`) only removes containers — it never reads env or mounts — so passing the unresolved deployment is safe.

## Validation

- **Reproduced on a real server**: two deployments (`kemeter-api`, `sozune`) stuck in `deleted`; after restarting with the fix they were purged within ~15s.
- **New e2e `tests/e2e/docker/t32_delete_with_missing_secret.sh`**: deploy with a `secretRef`, delete the secret, delete the deployment, assert it is purged (not stuck). Verified it **fails on the pre-fix binary** (deployment stuck in `deleted`, scheduler spams `secret_resolution_error`) and **passes with the fix**.
- `cargo test`: 443 passed.

## Docs

- `help/troubleshooting.md`: new "Stuck in `deleted`" entry.