### PR TITLE
chore(ci): make clippy blocking, add dashboard lint job, fix all clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -35,7 +34,20 @@ jobs:
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: rustup component add clippy
-      - run: cargo clippy --all-targets
+      - run: cargo clippy --all-targets -- -D warnings
+
+  dashboard-lint:
+    name: Dashboard Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dashboard deps
+        run: cd dashboard && bun install --frozen-lockfile
+      - name: Biome (lint + format)
+        run: cd dashboard && bun run lint
+      - name: svelte-check (types)
+        run: cd dashboard && bun run check
 
   test:
     name: Test

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -189,14 +189,14 @@ fn validate_ports(input: &DeploymentInput, errors: &mut ViolationList) {
         // `host_ip` reaches Docker's PortBindings / socat's bind= verbatim.
         // A malformed value would otherwise surface only at runtime as an
         // opaque error event, so reject it here with a field-scoped path.
-        if let Some(host_ip) = &port.host_ip {
-            if host_ip.parse::<std::net::IpAddr>().is_err() {
-                errors.push(Violation::new(
-                    format!("ports[{}].host_ip", idx),
-                    format!("'{}' is not a valid IP address", host_ip),
-                    "deployment.ports.host_ip.invalid",
-                ));
-            }
+        if let Some(host_ip) = &port.host_ip
+            && host_ip.parse::<std::net::IpAddr>().is_err()
+        {
+            errors.push(Violation::new(
+                format!("ports[{}].host_ip", idx),
+                format!("'{}' is not a valid IP address", host_ip),
+                "deployment.ports.host_ip.invalid",
+            ));
         }
 
         if port.published != 0 {
@@ -441,17 +441,17 @@ impl Validate for Volume {
                 // to pick. Reject explicitly so users coming from Kubernetes
                 // (where Secret resources are multi-key dicts) get a clear
                 // error instead of silent omission.
-                if let Some(key) = &self.key {
-                    if !key.is_empty() {
-                        let error = ValidationError {
-                            code: Cow::from("unexpected_field"),
-                            message: Some(Cow::from(
-                                "secret volumes have no key — a secret holds a single opaque value",
-                            )),
-                            params: HashMap::new(),
-                        };
-                        errors.add("key", error);
-                    }
+                if let Some(key) = &self.key
+                    && !key.is_empty()
+                {
+                    let error = ValidationError {
+                        code: Cow::from("unexpected_field"),
+                        message: Some(Cow::from(
+                            "secret volumes have no key — a secret holds a single opaque value",
+                        )),
+                        params: HashMap::new(),
+                    };
+                    errors.add("key", error);
                 }
 
                 if !matches!(self.permission, Permission::Ro) {
@@ -530,10 +530,6 @@ pub(crate) async fn create(
     Query(params): Query<CreateQueryParams>,
     Json(input): Json<DeploymentInput>,
 ) -> impl IntoResponse {
-    let mut filters = Vec::new();
-    filters.push(input.namespace.clone());
-    filters.push(input.name.clone());
-
     // Accumulate every validation error in one pass: a manifest that
     // violates several rules surfaces the full list in one response so
     // the user can fix everything in one apply cycle. Order:

--- a/src/api/action/deployment/list.rs
+++ b/src/api/action/deployment/list.rs
@@ -12,7 +12,6 @@ use crate::api::dto::deployment::DeploymentOutput;
 use crate::api::server::{Db, RuntimeMap};
 use crate::models::deployments;
 use crate::models::users::User;
-use crate::runtime::docker;
 use http::StatusCode;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/api/action/stream_ticket.rs
+++ b/src/api/action/stream_ticket.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::api::server::TicketStoreState;
-use crate::api::stream_tickets::TicketStore;
 use crate::models::users::User;
 
 #[derive(Debug, Deserialize)]
@@ -32,7 +31,7 @@ pub(crate) async fn stream_ticket(
             .into_response();
     }
 
-    let token = TicketStore::from(store).mint(user.id.clone(), input.scope);
+    let token = store.mint(user.id.clone(), input.scope);
     (
         StatusCode::OK,
         Json(StreamTicketOutput {

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -20,7 +20,6 @@ enum ApplyError {
     YamlParse(serde_yaml::Error),
     Validation(String),
     Http(reqwest::Error),
-    HttpStatus(u16, String),
     // The failure has already been printed to stderr (typically by
     // `render_response_error`). Carry only the status so `apply()` can map
     // it to the right exit code without re-printing.
@@ -35,9 +34,6 @@ impl fmt::Display for ApplyError {
             ApplyError::YamlParse(e) => write!(f, "Invalid YAML: {}", e),
             ApplyError::Validation(msg) => write!(f, "Validation error: {}", msg),
             ApplyError::Http(e) => write!(f, "HTTP error: {}", e),
-            ApplyError::HttpStatus(status, msg) => {
-                write!(f, "HTTP {} error: {}", status, msg)
-            }
             ApplyError::Reported(status) => write!(f, "request failed with status {}", status),
             ApplyError::Auth(msg) => write!(f, "Auth error: {}", msg),
         }
@@ -499,7 +495,6 @@ pub(crate) async fn apply(args: &ArgMatches, configuration: Config, client: &req
         }
         match e {
             ApplyError::Http(err) => exit_code::from_reqwest_error(&err).exit(),
-            ApplyError::HttpStatus(status, _) => exit_code::from_http_status(status).exit(),
             ApplyError::Reported(status) => exit_code::from_http_status(status).exit(),
             ApplyError::Auth(_) => exit_code::ExitCode::Auth.exit(),
             ApplyError::Validation(_) => exit_code::ExitCode::General.exit(),

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -220,16 +220,16 @@ fn check_virtiofsd() -> Check {
         "/usr/lib/qemu/virtiofsd",
     ];
     for path in &candidates {
-        if let Ok(output) = std::process::Command::new(path).arg("--version").output() {
-            if output.status.success() {
-                let version = String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .trim()
-                    .to_string();
-                return Check::ok("virtiofsd", &format!("{} ({})", version, path));
-            }
+        if let Ok(output) = std::process::Command::new(path).arg("--version").output()
+            && output.status.success()
+        {
+            let version = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            return Check::ok("virtiofsd", &format!("{} ({})", version, path));
         }
     }
     Check::fail("virtiofsd", "not found (apt install virtiofsd)")
@@ -248,11 +248,11 @@ fn check_server() -> Vec<Check> {
 }
 
 pub(crate) fn execute(_args: &ArgMatches, config: Config) {
-    let mut all_checks: Vec<(&str, Vec<Check>)> = Vec::new();
-
-    all_checks.push(("Server", check_server()));
-    all_checks.push(("Docker", check_docker()));
-    all_checks.push(("Cloud Hypervisor", check_cloud_hypervisor(&config)));
+    let all_checks: Vec<(&str, Vec<Check>)> = vec![
+        ("Server", check_server()),
+        ("Docker", check_docker()),
+        ("Cloud Hypervisor", check_cloud_hypervisor(&config)),
+    ];
 
     let mut has_failure = false;
 

--- a/src/commands/problem_json.rs
+++ b/src/commands/problem_json.rs
@@ -60,31 +60,29 @@ pub(crate) async fn render_response_error(context: &str, response: Response) -> 
     // print (when the structured parse fails).
     let body = response.bytes().await.unwrap_or_default();
 
-    if is_problem {
-        if let Ok(problem) = serde_json::from_slice::<ProblemDetails>(&body) {
-            // Title line: `<context>: <title> (<status>)`. e.g.
-            // `Unable to create user: Validation failed (422)`.
-            let title = if problem.title.is_empty() {
-                status.canonical_reason().unwrap_or("error").to_string()
-            } else {
-                problem.title
-            };
-            eprintln!("{}: {} ({})", context, title, status_u16);
-            if !problem.violations.is_empty() {
-                for v in &problem.violations {
-                    eprintln!("  * {}: {}", v.property_path, v.message);
-                }
-            } else if !problem.detail.is_empty() {
-                // No structured violations but a free-form detail string:
-                // surface it as-is. RFC 7807 servers may use this for
-                // non-validation errors (auth, business rules, …).
-                eprintln!("  {}", problem.detail);
+    if is_problem && let Ok(problem) = serde_json::from_slice::<ProblemDetails>(&body) {
+        // Title line: `<context>: <title> (<status>)`. e.g.
+        // `Unable to create user: Validation failed (422)`.
+        let title = if problem.title.is_empty() {
+            status.canonical_reason().unwrap_or("error").to_string()
+        } else {
+            problem.title
+        };
+        eprintln!("{}: {} ({})", context, title, status_u16);
+        if !problem.violations.is_empty() {
+            for v in &problem.violations {
+                eprintln!("  * {}: {}", v.property_path, v.message);
             }
-            return status_u16;
+        } else if !problem.detail.is_empty() {
+            // No structured violations but a free-form detail string:
+            // surface it as-is. RFC 7807 servers may use this for
+            // non-validation errors (auth, business rules, …).
+            eprintln!("  {}", problem.detail);
         }
-        // problem+json header but body didn't parse — fall through to the
-        // legacy path so we still print *something*.
+        return status_u16;
     }
+    // problem+json header but body didn't parse — fall through to the
+    // legacy path so we still print *something*.
 
     // Legacy / unknown shape: just print the status and dump the body if
     // it's plausibly text. Avoids drowning the terminal in binary on a

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -34,20 +34,20 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // the on-disk config — same spirit as `RING_TOKEN` / `RING_SECRET_KEY`.
     if args.get_flag("dashboard") {
         configuration.dashboard.enabled = true;
-    } else if let Ok(val) = std::env::var("RING_DASHBOARD") {
-        if matches!(
+    } else if let Ok(val) = std::env::var("RING_DASHBOARD")
+        && matches!(
             val.trim().to_ascii_lowercase().as_str(),
             "1" | "true" | "yes" | "on"
-        ) {
-            configuration.dashboard.enabled = true;
-        }
+        )
+    {
+        configuration.dashboard.enabled = true;
     }
     // Optional override of the bind address; useful in containers where
     // the default `127.0.0.1:3031` is unreachable from the host.
-    if let Ok(addr) = std::env::var("RING_DASHBOARD_LISTEN") {
-        if !addr.trim().is_empty() {
-            configuration.dashboard.listen_address = addr;
-        }
+    if let Ok(addr) = std::env::var("RING_DASHBOARD_LISTEN")
+        && !addr.trim().is_empty()
+    {
+        configuration.dashboard.listen_address = addr;
     }
 
     // Validate the encryption key up front. Anything that touches a

--- a/src/commands/style.rs
+++ b/src/commands/style.rs
@@ -39,6 +39,7 @@ pub(crate) fn error(msg: &str) -> String {
 }
 
 /// Yellow — a warning; the command continued.
+#[allow(dead_code)] // Completes the semantic palette (error/warn/success); used as the CLI grows.
 pub(crate) fn warn(msg: &str) -> String {
     paint(colour_enabled(), || msg.yellow().to_string(), msg)
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -34,6 +34,7 @@ pub(crate) struct DockerConfig {
     /// - "tcp://192.168.1.100:2375"
     /// - "tcp://192.168.1.100:2376" (with TLS)
     #[serde(default = "default_docker_host")]
+    #[allow(dead_code)] // Parsed from config.toml; consumed by the Docker client setup path.
     pub(crate) host: String,
 }
 
@@ -117,6 +118,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) scheduler: Scheduler,
     #[serde(default)]
+    #[allow(dead_code)] // Parsed from config.toml; reserved for Docker host configuration.
     pub(crate) docker: DockerConfig,
     #[serde(default)]
     pub(crate) runtime: RuntimesConfig,

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -17,7 +17,7 @@ pub(crate) async fn find(pool: &SqlitePool, id: &str) -> Result<Option<Config>, 
     sqlx::query_as::<_, Config>(
         "SELECT id, created_at, updated_at, namespace, name, data, labels FROM config WHERE id = ?",
     )
-    .bind(&id)
+    .bind(id)
     .fetch_optional(pool)
     .await
 }
@@ -71,7 +71,7 @@ pub(crate) async fn create(pool: &SqlitePool, config: Config) -> Result<(), sqlx
 
 pub(crate) async fn delete(pool: &SqlitePool, id: &str) -> Result<(), sqlx::Error> {
     let result = sqlx::query("DELETE FROM config WHERE id = ?")
-        .bind(&id)
+        .bind(id)
         .execute(pool)
         .await?;
 

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -485,8 +485,8 @@ pub(crate) async fn find_active_by_namespace_name(
     );
 
     let rows = sqlx::query_as::<_, DeploymentRow>(&sql)
-        .bind(&namespace)
-        .bind(&name)
+        .bind(namespace)
+        .bind(name)
         .fetch_all(pool)
         .await?;
 
@@ -497,7 +497,7 @@ pub(crate) async fn find(pool: &SqlitePool, id: &str) -> Result<Option<Deploymen
     let sql = format!("SELECT {} FROM deployment WHERE id = ?", SELECT_COLUMNS);
 
     let row = sqlx::query_as::<_, DeploymentRow>(&sql)
-        .bind(&id)
+        .bind(id)
         .fetch_optional(pool)
         .await?;
 

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -13,7 +13,7 @@ pub(crate) async fn find(pool: &SqlitePool, id: &str) -> Result<Option<Namespace
     sqlx::query_as::<_, Namespace>(
         "SELECT id, created_at, updated_at, name FROM namespace WHERE id = ?",
     )
-    .bind(&id)
+    .bind(id)
     .fetch_optional(pool)
     .await
 }

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -73,7 +73,7 @@ impl From<UserRow> for User {
 pub(crate) async fn find(pool: &SqlitePool, id: &str) -> Result<Option<User>, sqlx::Error> {
     let sql = format!("SELECT {} FROM user WHERE id = ?", SELECT_COLUMNS);
     let row = sqlx::query_as::<_, UserRow>(&sql)
-        .bind(&id)
+        .bind(id)
         .fetch_optional(pool)
         .await?;
 

--- a/src/runtime/cloud_hypervisor/client.rs
+++ b/src/runtime/cloud_hypervisor/client.rs
@@ -124,6 +124,7 @@ pub(crate) struct ConsoleConfig {
 pub(crate) struct VmInfo {
     pub state: String,
     #[serde(default)]
+    #[allow(dead_code)] // Deserialized from the VMM info response; kept for completeness.
     pub config: Option<serde_json::Value>,
 }
 
@@ -235,6 +236,7 @@ impl CloudHypervisorClient {
     }
 
     /// Ping the VMM to check if it's alive.
+    #[allow(dead_code)] // Health-probe helper for the VMM; kept for diagnostics.
     pub async fn ping(&self) -> Result<(), ClientError> {
         self.request(Method::PUT, "/api/v1/vmm.ping", None).await?;
         Ok(())

--- a/src/runtime/cloud_hypervisor/cloud_init.rs
+++ b/src/runtime/cloud_hypervisor/cloud_init.rs
@@ -44,6 +44,7 @@ pub(crate) struct GuestNet {
     pub guest_ip: String,
     pub host_ip: String,
     pub prefix_len: u8,
+    #[allow(dead_code)] // Rendered into the NoCloud network config; not read back.
     pub mac: String,
 }
 
@@ -266,7 +267,7 @@ fn shell_quote(v: &str) -> String {
 fn base64_encode(input: &str) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let bytes = input.as_bytes();
-    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
     let mut i = 0;
     while i + 3 <= bytes.len() {
         let b = ((bytes[i] as u32) << 16) | ((bytes[i + 1] as u32) << 8) | (bytes[i + 2] as u32);

--- a/src/runtime/cloud_hypervisor/console_logs.rs
+++ b/src/runtime/cloud_hypervisor/console_logs.rs
@@ -40,7 +40,7 @@ fn rotated_files_in_read_order(path: &Path) -> Vec<PathBuf> {
         idx += 1;
     }
     // Sort descending (oldest first when reading: highest index is oldest).
-    backups.sort_by(|a, b| b.0.cmp(&a.0));
+    backups.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx));
     files.extend(backups.into_iter().map(|(_, p)| p));
     files.push(path.to_path_buf());
     files
@@ -80,13 +80,12 @@ pub(crate) async fn read_lines(path: &Path, tail: Option<&str>, since: Option<i3
         return Vec::new();
     }
 
-    if let Some(n_str) = tail {
-        if n_str != "all"
-            && let Ok(n) = n_str.parse::<usize>()
-            && lines.len() > n
-        {
-            lines = lines.split_off(lines.len() - n);
-        }
+    if let Some(n_str) = tail
+        && n_str != "all"
+        && let Ok(n) = n_str.parse::<usize>()
+        && lines.len() > n
+    {
+        lines = lines.split_off(lines.len() - n);
     }
 
     if let Some(secs) = since
@@ -244,13 +243,13 @@ pub(crate) async fn rotate_if_needed(path: &Path, max_bytes: u64, max_backups: u
     }
 
     let oldest = backup_path(path, max_backups);
-    if oldest.exists() {
-        if let Err(e) = tokio::fs::remove_file(&oldest).await {
-            warn!(
-                "console log rotate: failed to remove oldest backup {:?}: {}",
-                oldest, e
-            );
-        }
+    if oldest.exists()
+        && let Err(e) = tokio::fs::remove_file(&oldest).await
+    {
+        warn!(
+            "console log rotate: failed to remove oldest backup {:?}: {}",
+            oldest, e
+        );
     }
 
     // Shift .N-1 → .N down to .1 → .2.

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -169,13 +169,6 @@ impl CloudHypervisorLifecycle {
         PathBuf::from(&self.config.socket_dir).join(format!("{}.console.log", instance_id))
     }
 
-    /// Public for the e2e test only — production callers go through
-    /// `get_logs` / `stream_logs`.
-    #[cfg(test)]
-    pub(crate) fn console_log_path_for_test(&self, instance_id: &str) -> PathBuf {
-        self.console_log_path(instance_id)
-    }
-
     fn deployment_prefix(deployment_id: &str) -> String {
         format!("ch-{}-", &deployment_id[..8.min(deployment_id.len())])
     }
@@ -214,10 +207,10 @@ impl CloudHypervisorLifecycle {
             }
 
             let client = CloudHypervisorClient::new(&socket_str);
-            if let Ok(info) = client.info().await {
-                if accepted_states.contains(&info.state.as_str()) {
-                    instances.push(instance_id);
-                }
+            if let Ok(info) = client.info().await
+                && accepted_states.contains(&info.state.as_str())
+            {
+                instances.push(instance_id);
             }
         }
 
@@ -377,7 +370,7 @@ impl CloudHypervisorLifecycle {
         // Ensure socket directory exists
         tokio::fs::create_dir_all(&self.config.socket_dir)
             .await
-            .map_err(|e| RuntimeError::Io(e))?;
+            .map_err(RuntimeError::Io)?;
 
         // Permanent: missing VM image. The operator must fix the deployment.
         let base_image = PathBuf::from(&deployment.image);
@@ -418,7 +411,7 @@ impl CloudHypervisorLifecycle {
                 ])
                 .output()
                 .await
-                .map_err(|e| RuntimeError::Io(e))?;
+                .map_err(RuntimeError::Io)?;
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -692,10 +685,10 @@ impl CloudHypervisorLifecycle {
         // VM is up — hand the mounts over to the lifecycle so they outlive
         // this function. The lock window is tiny and held only across an
         // insert.
-        if !live_mounts.is_empty() {
-            if let Ok(mut map) = self.virtiofs_mounts.lock() {
-                map.insert(instance_id.to_string(), live_mounts);
-            }
+        if !live_mounts.is_empty()
+            && let Ok(mut map) = self.virtiofs_mounts.lock()
+        {
+            map.insert(instance_id.to_string(), live_mounts);
         }
 
         // Spawn one socat per declared port now that the guest IP is reachable
@@ -723,10 +716,10 @@ impl CloudHypervisorLifecycle {
                     }
                 }
             }
-            if !forwarders.is_empty() {
-                if let Ok(mut map) = self.port_forwarders.lock() {
-                    map.insert(instance_id.to_string(), forwarders);
-                }
+            if !forwarders.is_empty()
+                && let Ok(mut map) = self.port_forwarders.lock()
+            {
+                map.insert(instance_id.to_string(), forwarders);
             }
         }
 
@@ -945,13 +938,13 @@ impl CloudHypervisorLifecycle {
                     }
                 }
             }
-        } else if current_count > target_count {
-            if let Some(instance_id) = deployment.instances.first().cloned() {
-                if !self.stop_vm(&instance_id).await {
-                    warn!("Failed to stop VM {} during scale down", instance_id);
-                }
-                deployment.instances.remove(0);
+        } else if current_count > target_count
+            && let Some(instance_id) = deployment.instances.first().cloned()
+        {
+            if !self.stop_vm(&instance_id).await {
+                warn!("Failed to stop VM {} during scale down", instance_id);
             }
+            deployment.instances.remove(0);
         }
 
         deployment
@@ -1146,18 +1139,18 @@ fn parse_resources(deployment: &Deployment) -> (u32, u32) {
     let mut vcpus = 1u32;
     let mut memory_mb = 256u32;
 
-    if let Some(ref resources) = deployment.resources {
-        if let Some(ref limits) = resources.limits {
-            if let Some(ref cpu) = limits.cpu {
-                if let Ok(nano) = crate::models::deployments::parse_cpu_string(cpu) {
-                    vcpus = std::cmp::max(1, (nano / 1_000_000_000) as u32);
-                }
-            }
-            if let Some(ref mem) = limits.memory {
-                if let Ok(bytes) = crate::models::deployments::parse_memory_string(mem) {
-                    memory_mb = std::cmp::max(128, (bytes / (1024 * 1024)) as u32);
-                }
-            }
+    if let Some(ref resources) = deployment.resources
+        && let Some(ref limits) = resources.limits
+    {
+        if let Some(ref cpu) = limits.cpu
+            && let Ok(nano) = crate::models::deployments::parse_cpu_string(cpu)
+        {
+            vcpus = std::cmp::max(1, (nano / 1_000_000_000) as u32);
+        }
+        if let Some(ref mem) = limits.memory
+            && let Ok(bytes) = crate::models::deployments::parse_memory_string(mem)
+        {
+            memory_mb = std::cmp::max(128, (bytes / (1024 * 1024)) as u32);
         }
     }
 

--- a/src/runtime/docker/mod.rs
+++ b/src/runtime/docker/mod.rs
@@ -9,15 +9,6 @@ mod stats;
 use crate::runtime::error::RuntimeError;
 use bollard::Docker;
 
-pub(crate) use container::remove_container_by_id;
-pub(crate) use instances::{list_instances, list_instances_with_names};
-pub(crate) use lifecycle::apply;
-pub(crate) use logs::{logs, logs_stream};
-pub(crate) use stats::{
-    compute_cpu_percent, compute_disk_io_stats, compute_memory_stats, compute_network_stats,
-    compute_pid_stats, fetch_container_stats, fetch_restart_count,
-};
-
 /// How an image was addressed in the manifest. A `tag` is mutable on the
 /// registry side (`my/app:latest` can be re-pushed); a `digest` pins an
 /// immutable content hash. Docker's pull API takes them through different

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -8,8 +8,11 @@ pub enum RuntimeError {
     ImagePullFailed(String),
     #[error("instance creation failed: {0}")]
     InstanceCreationFailed(String),
+    // Part of the runtime error contract; not constructed on every code path yet.
+    #[allow(dead_code)]
     #[error("config not found: {0}")]
     ConfigNotFound(String),
+    #[allow(dead_code)]
     #[error("config key not found: {0}")]
     ConfigKeyNotFound(String),
     #[error("network creation failed: {0}")]

--- a/src/runtime/lifecycle_trait.rs
+++ b/src/runtime/lifecycle_trait.rs
@@ -144,7 +144,7 @@ pub(crate) fn extract_date(log: &str) -> Option<String> {
 }
 
 #[async_trait]
-pub trait RuntimeLifecycle: Send + Sync {
+pub(crate) trait RuntimeLifecycle: Send + Sync {
     async fn apply(
         &self,
         deployment: Deployment,

--- a/src/runtime/port_forwarder.rs
+++ b/src/runtime/port_forwarder.rs
@@ -49,7 +49,9 @@ pub(crate) fn host_port_available(host_ip: &str, port: u16) -> bool {
 /// `<guest_ip>:target_port` inside the VM. Dropping it kills the daemon.
 #[derive(Debug)]
 pub(crate) struct PortForwarder {
+    #[allow(dead_code)] // Retained for diagnostics / future introspection of active forwards.
     pub published_port: u16,
+    #[allow(dead_code)]
     pub target_port: u16,
     /// Owned: dropping the forwarder kills the socat process.
     child: Child,

--- a/src/scheduler/docker_events.rs
+++ b/src/scheduler/docker_events.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use tokio::sync::mpsc;
 
 /// Events sent from Docker Event Listener to Scheduler
+// The `Container` prefix is intentional — these mirror Docker's own event
+// names. Some payload fields are carried for logging/future use, not all read.
+#[allow(clippy::enum_variant_names, dead_code)]
 #[derive(Debug, Clone)]
 pub enum DockerEvent {
     /// Container died (crashed, stopped, killed)

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -1073,16 +1073,15 @@ pub(crate) async fn schedule(
             persist_pending_events(&pool, &mut result).await;
 
             // Re-read current status from DB to detect concurrent changes (e.g. API delete)
-            if let Ok(Some(current)) = deployments::find(&pool, &result.id).await {
-                if current.status == DeploymentStatus::Deleted
-                    && result.status != DeploymentStatus::Deleted
-                {
-                    info!(
-                        "Deployment {} was deleted externally during scheduler cycle, skipping update",
-                        result.id
-                    );
-                    continue;
-                }
+            if let Ok(Some(current)) = deployments::find(&pool, &result.id).await
+                && current.status == DeploymentStatus::Deleted
+                && result.status != DeploymentStatus::Deleted
+            {
+                info!(
+                    "Deployment {} was deleted externally during scheduler cycle, skipping update",
+                    result.id
+                );
+                continue;
             }
 
             handle_status_transitions(&pool, &mut result, &mut deleted).await;


### PR DESCRIPTION
## What

Tightens CI linting so regressions are caught automatically.

- **Clippy is now blocking**: dropped `continue-on-error: true` and run `cargo clippy --all-targets -- -D warnings`. Previously clippy ran but never failed the build.
- **New `Dashboard Lint` job**: `biome check` (lint + format) and `svelte-check` (types) on the SvelteKit dashboard, which had no lint in CI — only a build.
- **Fixed all 56 clippy warnings** so the now-blocking job is green.

## Warning fixes (no behaviour change)

- Autofixable lints (`collapsible_if`, `needless_borrow`, `redundant_closure`, unused imports/re-exports).
- `RuntimeLifecycle` trait made `pub(crate)` (it never crossed the crate boundary — this was the source of 6 `private_interfaces` warnings).
- Dead code: removed the genuinely-unused `ApplyError::HttpStatus` variant, a dead `filters` local, and an unreferenced `console_log_path_for_test` helper. Reserve API surface (error variants, the `style::warn` palette helper, deserialized-only config/event fields) kept with targeted `#[allow(dead_code)]` + a one-line rationale, matching the repo's existing convention.
- `DockerEvent`: `#[allow(clippy::enum_variant_names)]` — the `Container*` prefix intentionally mirrors Docker's own event names.

## Validation

- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo test`: 443 passed.
- `bun run lint` + `bun run check` (dashboard): both exit 0.