### PR TITLE
test(e2e): create namespace before secret in t29 so it passes in isolation

### DIFF
--- a/tests/e2e/docker/t29_secret_volume.sh
+++ b/tests/e2e/docker/t29_secret_volume.sh
@@ -28,6 +28,12 @@ SECRET_NAME="api-bearer-token"
 SECRET_VALUE="s3cr3t-token-via-volume"
 
 # === Create the secret out of band (no inline `secrets:` block) ===
+# Secrets require the namespace to exist first — POST /secrets returns 404
+# otherwise. Deployments auto-create namespaces; secrets don't.
+"$RING_BIN" namespace create ring-e2e 2>&1 \
+  | grep -qiE "created|already exists" \
+  || fail "ring namespace create did not succeed"
+
 "$RING_BIN" secret create "$SECRET_NAME" -n ring-e2e -v "$SECRET_VALUE" 2>&1 \
   | grep -qF "created" \
   || fail "ring secret create did not succeed"


### PR DESCRIPTION
## Problem

`tests/e2e/docker/t29_secret_volume.sh` creates a secret in namespace `ring-e2e` without creating the namespace first. `POST /secrets` returns `404 namespace does not exist`, so `ring secret create` fails and the test aborts with `ring secret create did not succeed`.

The bug predates this change (introduced with the test in `241c4ee`); it went unnoticed because the e2e suite doesn't run in CI and the test was never re-run in isolation.

## Fix

Create the namespace before the secret (same pattern as `t13_environment`). Deployments auto-create their namespace; secrets don't.

## Validation

- `t29_secret_volume.sh`: PASS (was FAIL).
- Reproduced the root cause directly: `ring secret create -n ring-e2e` → `404 namespace 'ring-e2e' does not exist` without the namespace, exit 0 with it.