### PR TITLE
feat(server): print a Vite-style startup banner with Local/Network URLs

### DIFF
--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -115,6 +115,21 @@ On first start, Ring:
 - Runs SQLite migrations to create `ring.db` in the current directory
 - Seeds the default admin user: username `admin`, password `changeme`
 
+It prints a short banner telling you where it's reachable:
+
+```text
+  Ring 0.8.0  ready
+
+  ➜  Local:     http://127.0.0.1:3030
+  ➜  Network:   http://192.168.1.67:3030
+  ➜  Dashboard: disabled (enable with --dashboard)
+  ➜  Runtimes:  cloud-hypervisor, docker
+```
+
+- **Local** is the loopback address; **Network** is your machine's LAN IP, resolved automatically — share it to reach Ring from another host.
+- With `--dashboard`, the `Dashboard` line shows its URL (default `http://127.0.0.1:3031`).
+- When `host` is set to a specific address (not `0.0.0.0`), only the matching line is shown.
+
 Leave this terminal running. You should see log output if you set `RUST_LOG=info` before starting:
 
 ```bash

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,4 +1,5 @@
 use crate::api::server as ApiServer;
+use crate::commands::style;
 use crate::runtime::cloud_hypervisor::CloudHypervisorLifecycle;
 use crate::runtime::docker;
 use crate::runtime::docker::docker_lifecycle::DockerLifecycle;
@@ -126,6 +127,8 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
         });
     }
 
+    print_startup_banner(&configuration, runtimes.as_ref());
+
     let scheduler_handler = task::spawn(schedule(
         pool,
         configuration,
@@ -143,4 +146,62 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     if let Err(e) = event_listener_handler.await {
         eprintln!("Docker event listener task failed: {}", e);
     }
+}
+
+/// Print a concise, human-readable summary of where the server is reachable
+/// once it has started: API endpoint, embedded dashboard (if enabled), and the
+/// registered runtimes. Goes to stdout (not the logger) so it shows regardless
+/// of `RUST_LOG`, and uses the shared `style` palette so colour is dropped in
+/// pipes / under `NO_COLOR`.
+fn print_startup_banner(
+    configuration: &Config,
+    runtimes: &std::collections::HashMap<String, Arc<dyn RuntimeLifecycle>>,
+) {
+    let version = env!("CARGO_PKG_VERSION");
+    let scheme = &configuration.api.scheme;
+    let port = configuration.api.port;
+    let host = configuration.host.as_str();
+
+    // Vite-style Local / Network lines. When bound to all interfaces we show
+    // both loopback and the machine's LAN IP (the actually-reachable address);
+    // a specific bind host shows only that one, on the matching line.
+    let url = |h: &str| format!("{}://{}:{}", scheme, h, port);
+    let lan_ip = local_ip_address::local_ip().ok().map(|ip| ip.to_string());
+
+    let (local, network): (Option<String>, Option<String>) = match host {
+        "0.0.0.0" => (Some(url("127.0.0.1")), lan_ip.map(|ip| url(&ip))),
+        "127.0.0.1" | "localhost" => (Some(url(host)), None),
+        other => (None, Some(url(other))),
+    };
+
+    let mut names: Vec<&String> = runtimes.keys().collect();
+    names.sort();
+    let runtime_list = names
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let arrow = style::success("➜");
+    println!();
+    println!("  {} {}  ready", style::success("Ring"), version);
+    println!();
+    if let Some(u) = &local {
+        println!("  {}  Local:     {}", arrow, u);
+    }
+    if let Some(u) = &network {
+        println!("  {}  Network:   {}", arrow, u);
+    } else if host == "0.0.0.0" {
+        println!("  {}  Network:   (no LAN address detected)", arrow);
+    }
+    if configuration.dashboard.enabled {
+        println!(
+            "  {}  Dashboard: http://{}",
+            arrow, configuration.dashboard.listen_address
+        );
+    } else {
+        println!("  {}  Dashboard: disabled (enable with --dashboard)", arrow);
+    }
+    println!("  {}  Runtimes:  {}", arrow, runtime_list);
+    println!();
 }


### PR DESCRIPTION
## What

`ring server start` now prints a Vite-style banner once it's up, so you can see at a glance where it's reachable — including the actual LAN address, not a `0.0.0.0` placeholder:

```text
  Ring 0.8.0  ready

  ➜  Local:     http://127.0.0.1:3030
  ➜  Network:   http://192.168.1.67:3030
  ➜  Dashboard: http://127.0.0.1:3031
  ➜  Runtimes:  cloud-hypervisor, docker
```

- **Local** / **Network** lines mirror Vite. The Network IP is resolved with `local_ip_address` (already a dependency, used by `ring init` and config defaults).
- Bound to `0.0.0.0` → both lines (Network = LAN IP, or "(no LAN address detected)" if it can't be resolved).
- Bound to `127.0.0.1`/`localhost` → Local only. Bound to a specific IP → that address on the Network line.
- **Dashboard**: its URL when enabled (default `http://127.0.0.1:3031`), or a hint to enable it.
- **Runtimes**: registered runtimes (docker, cloud-hypervisor).

Printed to stdout (shows regardless of `RUST_LOG`); colour via the shared `style` palette, so it's dropped in pipes / under `NO_COLOR`.

## Validation

- Ran the real binary (`--dashboard`, bound to `0.0.0.0`): banner renders with the resolved LAN IP `192.168.1.67`.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` (443): all green.

## Docs

- `tutorials/install-and-run.md`: shows the banner and explains Local vs Network.