### PR TITLE
feat(dashboard): add a Node page showing host info

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -283,6 +283,22 @@ export function getDeploymentMetrics(id: string): Promise<DeploymentStats> {
   return request<DeploymentStats>(`/deployments/${encodeURIComponent(id)}/metrics`);
 }
 
+/** Mirrors `NodeRootDto` from `src/api/dto/node.rs`. Memory figures are GiB. */
+export interface NodeInfo {
+  hostname: string;
+  os: string;
+  arch: string;
+  uptime: string;
+  cpu_count: number;
+  memory_total: number;
+  memory_available: number;
+  load_average: number[];
+}
+
+export function getNode(): Promise<NodeInfo> {
+  return request<NodeInfo>('/node/get');
+}
+
 export function listSecrets(): Promise<Secret[]> {
   return request<Secret[]>('/secrets');
 }

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -13,7 +13,8 @@
     { href: '/deployments', label: 'Deployments', icon: 'grid' },
     { href: '/namespaces', label: 'Namespaces', icon: 'folder' },
     { href: '/secrets', label: 'Secrets', icon: 'key' },
-    { href: '/configs', label: 'Configs', icon: 'file' }
+    { href: '/configs', label: 'Configs', icon: 'file' },
+    { href: '/node', label: 'Node', icon: 'server' }
   ];
 
   function isActive(href: string): boolean {
@@ -106,6 +107,19 @@
                 >
                   <path d="M3 1.5h6L13 5.5V14a.5.5 0 0 1-.5.5h-9A.5.5 0 0 1 3 14V1.5z" />
                   <path d="M9 1.5V5.5h4" />
+                </svg>
+              {:else if item.icon === 'server'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="2" y="2.5" width="12" height="4.5" rx="1" />
+                  <rect x="2" y="9" width="12" height="4.5" rx="1" />
+                  <path d="M4.5 4.75h.01M4.5 11.25h.01" />
                 </svg>
               {/if}
             </span>

--- a/dashboard/src/routes/node/+page.svelte
+++ b/dashboard/src/routes/node/+page.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getNode, type NodeInfo } from '$lib/api';
+  import { getToken } from '$lib/auth';
+  import { timeAgo } from '$lib/utils';
+
+  let node = $state<NodeInfo | null>(null);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function refresh() {
+    try {
+      node = await getNode();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/');
+      return;
+    }
+    void refresh();
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  /** Memory percent used, guarding against a zero total. */
+  let memUsedPercent = $derived(
+    node && node.memory_total > 0
+      ? ((node.memory_total - node.memory_available) / node.memory_total) * 100
+      : 0
+  );
+</script>
+
+<header class="page-header">
+  <h1>Node</h1>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if loading && !node}
+  <p class="muted">Loading…</p>
+{:else if errorMsg && !node}
+  <div class="alert"><strong>error</strong> {errorMsg}</div>
+{:else if node}
+  <section class="grid">
+    <div class="card pad">
+      <h2>Host</h2>
+      <dl>
+        <dt>Hostname</dt>
+        <dd class="mono">{node.hostname}</dd>
+        <dt>OS</dt>
+        <dd>{node.os}</dd>
+        <dt>Architecture</dt>
+        <dd class="mono">{node.arch}</dd>
+        <dt>Uptime</dt>
+        <dd>{node.uptime}</dd>
+      </dl>
+    </div>
+
+    <div class="card pad">
+      <h2>Resources</h2>
+      <dl>
+        <dt>CPU cores</dt>
+        <dd class="mono">{node.cpu_count}</dd>
+        <dt>Memory</dt>
+        <dd class="mono">
+          {(node.memory_total - node.memory_available).toFixed(2)} / {node.memory_total.toFixed(2)}
+          GiB
+          <span class="metric-sub">({memUsedPercent.toFixed(1)}% used)</span>
+        </dd>
+        <dt>Memory free</dt>
+        <dd class="mono">{node.memory_available.toFixed(2)} GiB</dd>
+        <dt>Load average</dt>
+        <dd class="mono">
+          {node.load_average.map((l) => l.toFixed(2)).join(', ')}
+          <span class="metric-sub">(1m, 5m, 15m)</span>
+        </dd>
+      </dl>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.25rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.4rem;
+    letter-spacing: -0.02em;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.78rem;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  .card.pad {
+    padding: 1.125rem 1.25rem;
+  }
+  h2 {
+    margin: 0 0 0.9rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 1.5rem;
+    row-gap: 0.55rem;
+    margin: 0;
+  }
+  dt {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  dd {
+    margin: 0;
+    color: var(--fg-0);
+    font-size: 0.85rem;
+    word-break: break-word;
+  }
+  .mono {
+    font-family: var(--font-mono);
+  }
+  .metric-sub {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+  }
+</style>

--- a/documentation/how-to/use-the-dashboard.md
+++ b/documentation/how-to/use-the-dashboard.md
@@ -88,5 +88,6 @@ Local mode is always available — there's nothing to disable, it only runs when
   - Ports, volumes, environment variables, and configured health checks
   - Streamed logs (live tail) and a recent-events timeline
 - Read-only views for namespaces, secrets, and configs
+- A **Node** page (`/node`) showing the host the server runs on: hostname, OS, architecture, uptime, CPU cores, memory usage, and load average (sourced from `GET /node/get`, refreshed every few seconds)
 
 The dashboard is read-only: the CLI and manifest remain the source of truth for anything mutating (create, scale, restart, delete).


### PR DESCRIPTION
## What

Adds a **Node** entry to the dashboard sidebar and a `/node` page that surfaces the host the Ring server runs on, wiring up the existing `GET /node/get` endpoint (previously only the CLI's `ring node get` consumed it).

The page shows two cards, refreshed every 5s:
- **Host**: hostname, OS, architecture, uptime.
- **Resources**: CPU cores, memory used / total (+ % used), memory free, load average (1m/5m/15m).

## Implementation

- `api.ts`: typed `NodeInfo` (mirrors `src/api/dto/node.rs`) and `getNode()`.
- `+layout.svelte`: new "Node" nav item with a server icon.
- `routes/node/+page.svelte`: the page, following the same card/`dl` style and 5s poll as the deployment detail page.

## Validation

- Verified the live endpoint shape against the running server via the vite proxy: matches the TS type field-for-field.
- `/node` route loads (200), `svelte-check` 0 errors, `biome` clean, `bun run build` OK.

## Docs

- `how-to/use-the-dashboard.md`: lists the new Node page.