### PR TITLE
feat(dashboard): dark/light theme toggle and version in the sidebar

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.58.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "@types/node": "^25.9.1",
     "svelte": "^5.55.5",
     "svelte-check": "^4.4.7",
     "typescript": "^6.0.3",

--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -40,6 +40,42 @@
   color-scheme: dark;
 }
 
+/* Light theme — applied to <html data-theme="light"> by the sidebar toggle.
+ * Values stay on the same semantic ramp (bg-0 lightest surface, fg-0
+ * highest-contrast text) so every page that uses the tokens inverts cleanly.
+ * Status colours keep their hue but lose saturation so they don't bleed on a
+ * white background. */
+:root[data-theme='light'] {
+  --bg-0: #ffffff;
+  --bg-1: #f7f8fa;
+  --bg-2: #eef0f4;
+  --bg-3: #e3e7ee;
+  --bg-hover: #dde2ea;
+  --border: #d8dde6;
+  --border-strong: #b9c2cf;
+
+  --fg-0: #0f172a;
+  --fg-1: #2d3a52;
+  --fg-2: #5b6779;
+  --fg-3: #8a93a3;
+
+  --accent: #0f766e;
+  --accent-hover: #0b5d57;
+  --accent-bg: rgba(15, 118, 110, 0.1);
+
+  --success: #1f9b4a;
+  --success-bg: rgba(31, 155, 74, 0.12);
+  --warning: #b8860b;
+  --warning-bg: rgba(184, 134, 11, 0.12);
+  --danger: #c93838;
+  --danger-bg: rgba(201, 56, 56, 0.1);
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+
+  color-scheme: light;
+}
+
 @supports (font-variation-settings: normal) {
   :root {
     font-family: 'Inter var', var(--font-sans);

--- a/dashboard/src/app.d.ts
+++ b/dashboard/src/app.d.ts
@@ -6,6 +6,9 @@ declare global {
     // interface PageData {}
     // interface Platform {}
   }
+
+  /** Injected by Vite `define` from the workspace Cargo.toml version. */
+  const __RING_VERSION__: string;
 }
 
 export {};

--- a/dashboard/src/lib/theme.ts
+++ b/dashboard/src/lib/theme.ts
@@ -1,0 +1,50 @@
+/** Dashboard theme persistence.
+ *
+ * Two modes: `dark` (default) and `light`. The choice is persisted in
+ * localStorage under `ring.theme`. When nothing is saved we follow the
+ * `prefers-color-scheme` media query.
+ *
+ * The active theme is reflected as `data-theme="light"` (or absent for dark)
+ * on `<html>`, so `app.css` only needs to override variables under the
+ * `:root[data-theme="light"]` selector.
+ */
+
+export type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'ring.theme';
+
+function systemPreference(): Theme {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'dark';
+  }
+  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+
+export function loadTheme(): Theme {
+  if (typeof localStorage === 'undefined') {
+    return 'dark';
+  }
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'dark' || stored === 'light') {
+    return stored;
+  }
+  return systemPreference();
+}
+
+export function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  if (theme === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
+}
+
+export function saveTheme(theme: Theme): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, theme);
+}

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -5,9 +5,17 @@
   import { goto } from '$app/navigation';
   import { getCurrentUser, type CurrentUser } from '$lib/api';
   import { clearToken, getToken } from '$lib/auth';
+  import { applyTheme, loadTheme, saveTheme, type Theme } from '$lib/theme';
 
   let { children } = $props();
   let currentUser = $state<CurrentUser | null>(null);
+  let theme = $state<Theme>('dark');
+
+  function toggleTheme() {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    applyTheme(theme);
+    saveTheme(theme);
+  }
 
   const nav = [
     { href: '/deployments', label: 'Deployments', icon: 'grid' },
@@ -25,6 +33,11 @@
   let onLoginPage = $derived($page.url.pathname === '/');
 
   onMount(async () => {
+    // Apply the persisted (or system-preferred) theme as early as possible so
+    // the dashboard doesn't briefly flash the opposite palette.
+    theme = loadTheme();
+    applyTheme(theme);
+
     if (onLoginPage) {
       return;
     }
@@ -140,6 +153,28 @@
           </svg>
           <span>Documentation</span>
         </a>
+        <button
+          class="theme-toggle"
+          onclick={toggleTheme}
+          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {#if theme === 'dark'}
+            <!-- Sun: shown in dark mode → click to go light -->
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="8" cy="8" r="3" />
+              <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4" />
+            </svg>
+            <span>Light mode</span>
+          {:else}
+            <!-- Moon: shown in light mode → click to go dark -->
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M13.5 9.2A5.5 5.5 0 0 1 6.8 2.5 6 6 0 1 0 13.5 9.2z" />
+            </svg>
+            <span>Dark mode</span>
+          {/if}
+        </button>
+        <div class="version mono">v{__RING_VERSION__}</div>
       </div>
     </aside>
 
@@ -200,6 +235,17 @@
     color: var(--fg-2);
     text-transform: uppercase;
     letter-spacing: 0.08em;
+  }
+
+  .version {
+    margin-left: auto;
+    align-self: flex-start;
+    font-size: 0.65rem;
+    color: var(--fg-3);
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.1rem 0.35rem;
   }
 
   nav {
@@ -265,6 +311,37 @@
     color: var(--fg-2);
     text-transform: uppercase;
     letter-spacing: 0.06em;
+  }
+
+  .theme-toggle {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.625rem;
+    border-radius: var(--radius);
+    color: var(--fg-2);
+    font-size: 0.75rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .theme-toggle:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .theme-toggle :global(svg) {
+    width: 14px;
+    height: 14px;
+  }
+
+  .version {
+    color: var(--fg-3);
+    font-size: 0.7rem;
+    padding: 0.25rem 0.625rem 0;
   }
 
   .logout {

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,7 +1,24 @@
+import { readFileSync } from 'node:fs';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+// Single source of truth for the displayed version: the workspace Cargo.toml.
+// Read at build time and exposed as __RING_VERSION__ so the menu never drifts
+// from the actual project version.
+function ringVersion(): string {
+  try {
+    const cargo = readFileSync(new URL('../Cargo.toml', import.meta.url), 'utf8');
+    const m = cargo.match(/^\s*version\s*=\s*"([^"]+)"/m);
+    return m ? m[1] : 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+
 export default defineConfig({
+  define: {
+    __RING_VERSION__: JSON.stringify(ringVersion())
+  },
   plugins: [sveltekit()],
   server: {
     port: 5173,


### PR DESCRIPTION
## What

Ports two things from the Sōzune dashboard into Ring's, matching its markup and CSS:

- **Dark/light theme toggle** in the sidebar footer. Persisted in `localStorage` (`ring.theme`), falls back to `prefers-color-scheme`, applied as `data-theme="light"` on `<html>` (dark is the default, attribute absent). The theme is applied early on mount to avoid a flash of the wrong palette.
- **Version badge** in the sidebar (`v{version}`), so you can see which build you're on at a glance.

## Implementation

- `lib/theme.ts`: `loadTheme` / `applyTheme` / `saveTheme` (same shape as Sōzune's).
- `app.css`: `:root[data-theme="light"]` overrides on the same semantic token ramp. Accent stays Ring's green (the rest of the light palette matches Sōzune).
- `+layout.svelte`: the toggle button (sun/moon icon, identical markup/CSS to Sōzune) after the Documentation link, and the version `<div>`.
- `vite.config.ts`: reads the version from the workspace `Cargo.toml` at build time and exposes it as `__RING_VERSION__` — single source of truth, never drifts (currently `0.9.0-dev`).
- `app.d.ts`: declares `__RING_VERSION__`.
- `@types/node` added as a devDependency (needed for the `node:fs` read in the vite config).

## Validation

- `svelte-check`: 0 errors, 0 warnings.
- `biome check`: clean.
- `bun run build`: OK; `v0.9.0-dev` confirmed injected in the bundle.