### PR TITLE
feat(cli): scriptable ring init via --runtime and --port flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -481,6 +482,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.20", features = ["full"] }
 log = "0.4.0"
 env_logger = "0.11.2"
 bollard = "0.20.2"
-clap = "4.5.1"
+clap = { version = "4.5.1", features = ["derive"] }
 chrono = "0.4"
 uuid = { version = "1.4.1", features = ["v4"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }

--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -103,6 +103,19 @@ If `config.toml` or `secret-key` already exists, `ring init` refuses to overwrit
 
 In CI or any non-interactive shell, `ring init` skips the prompts and falls back to defaults (Docker, port 3030).
 
+### Scripting `ring init`
+
+To configure a non-default runtime or port without a prompt (CI, Ansible, etc.), pass the flags explicitly:
+
+```bash
+ring init --runtime cloud-hypervisor --port 4030
+```
+
+- `--runtime` — `docker`, `cloud-hypervisor`, or `both`.
+- `--port` — the API port (default `3030`).
+
+Flags take precedence over prompts and over the non-interactive defaults, and compose per-field: passing only `--port` still prompts for the runtime on a TTY (or defaults to Docker when there's no TTY), and vice versa.
+
 ## 3. Start the server
 
 ```bash

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -16,7 +16,7 @@
 use crate::config::config::get_config_dir;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as B64;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command, ValueEnum};
 use rand::RngCore;
 use std::fs;
 use std::io::IsTerminal;
@@ -24,12 +24,28 @@ use std::path::Path;
 
 pub(crate) fn command_config() -> Command {
     Command::new("init")
-        .about("Initialize Ring configuration interactively")
+        .about("Initialize Ring configuration (interactive, or scriptable via flags)")
         .arg(
             Arg::new("force")
                 .long("force")
                 .help("Overwrite an existing config.toml")
                 .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("runtime")
+                .long("runtime")
+                .value_name("RUNTIME")
+                .help(
+                    "Runtime to configure, skipping the prompt: docker, cloud-hypervisor, or both",
+                )
+                .value_parser(clap::value_parser!(RuntimeChoice)),
+        )
+        .arg(
+            Arg::new("port")
+                .long("port")
+                .value_name("PORT")
+                .help("API port to configure, skipping the prompt (default 3030)")
+                .value_parser(clap::value_parser!(u16).range(1..)),
         )
 }
 
@@ -40,7 +56,10 @@ pub(crate) struct InitSettings {
     pub port: u16,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `ValueEnum` lets clap parse and validate `--runtime` directly into this
+/// type (kebab-case CLI spellings: `docker`, `cloud-hypervisor`, `both`) — no
+/// hand-rolled string matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum RuntimeChoice {
     Docker,
     CloudHypervisor,
@@ -85,7 +104,7 @@ pub(crate) fn init(args: &ArgMatches) {
         std::process::exit(1);
     }
 
-    let settings = collect_settings();
+    let settings = collect_settings(args);
     let toml_content = build_config_toml(&settings);
 
     if let Err(e) = fs::create_dir_all(&config_dir) {
@@ -115,42 +134,66 @@ pub(crate) fn init(args: &ArgMatches) {
     print_next_steps();
 }
 
-/// Either prompt the user or fall back to sensible defaults when stdin is
-/// not interactive (CI, piped scripts, etc.). The defaults match the most
-/// common deployment shape: Docker on port 3030.
-fn collect_settings() -> InitSettings {
+const DEFAULT_PORT: u16 = 3030;
+
+/// Resolve the runtime + port, in this order of precedence:
+///   1. an explicit `--runtime` / `--port` flag (scriptable, no prompt),
+///   2. an interactive prompt when stdin is a TTY,
+///   3. a sensible default (Docker, port 3030) when stdin is not a TTY.
+///
+/// Flags and prompts compose per-field: passing only `--runtime` on a TTY
+/// still prompts for the port, and vice versa. This makes `ring init` fully
+/// scriptable (`--runtime cloud-hypervisor --port 4030`) without a TTY, while
+/// keeping the friendly prompts for an interactive first run.
+fn collect_settings(args: &ArgMatches) -> InitSettings {
+    let runtime_flag = args.get_one::<RuntimeChoice>("runtime").copied();
+    let port_flag = args.get_one::<u16>("port").copied();
+
+    // Fully specified by flags → no prompt, no TTY needed.
+    if let (Some(runtime), Some(port)) = (runtime_flag, port_flag) {
+        return InitSettings { runtime, port };
+    }
+
     if !is_tty() {
-        println!("(non-interactive stdin detected — using defaults: Docker, port 3030)");
-        return InitSettings {
-            runtime: RuntimeChoice::Docker,
-            port: 3030,
-        };
+        let runtime = runtime_flag.unwrap_or(RuntimeChoice::Docker);
+        let port = port_flag.unwrap_or(DEFAULT_PORT);
+        println!(
+            "(non-interactive stdin detected — using runtime: {}, port: {})",
+            runtime, port
+        );
+        return InitSettings { runtime, port };
     }
 
     use inquire::{CustomType, Select};
 
-    let runtime = Select::new(
-        "Which runtime do you want to use?",
-        vec![
-            RuntimeChoice::Docker,
-            RuntimeChoice::CloudHypervisor,
-            RuntimeChoice::Both,
-        ],
-    )
-    .prompt()
-    .unwrap_or_else(|e| {
-        eprintln!("Aborted: {}", e);
-        std::process::exit(1);
-    });
-
-    let port: u16 = CustomType::<u16>::new("Which port should the API listen on?")
-        .with_default(3030)
-        .with_error_message("Enter a number between 1 and 65535")
+    let runtime = match runtime_flag {
+        Some(r) => r,
+        None => Select::new(
+            "Which runtime do you want to use?",
+            vec![
+                RuntimeChoice::Docker,
+                RuntimeChoice::CloudHypervisor,
+                RuntimeChoice::Both,
+            ],
+        )
         .prompt()
         .unwrap_or_else(|e| {
             eprintln!("Aborted: {}", e);
             std::process::exit(1);
-        });
+        }),
+    };
+
+    let port = match port_flag {
+        Some(p) => p,
+        None => CustomType::<u16>::new("Which port should the API listen on?")
+            .with_default(DEFAULT_PORT)
+            .with_error_message("Enter a number between 1 and 65535")
+            .prompt()
+            .unwrap_or_else(|e| {
+                eprintln!("Aborted: {}", e);
+                std::process::exit(1);
+            }),
+    };
 
     InitSettings { runtime, port }
 }
@@ -274,6 +317,33 @@ fn print_next_steps() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn init_command_parses_runtime_and_port_flags() {
+        // The CLI must parse `--runtime` / `--port` so the command is
+        // scriptable. clap's ValueEnum gives us a typed RuntimeChoice directly.
+        let m = command_config()
+            .try_get_matches_from(["init", "--runtime", "cloud-hypervisor", "--port", "4030"])
+            .expect("valid flags must parse");
+        assert_eq!(
+            *m.get_one::<RuntimeChoice>("runtime").unwrap(),
+            RuntimeChoice::CloudHypervisor
+        );
+        assert_eq!(*m.get_one::<u16>("port").unwrap(), 4030u16);
+
+        // Unknown runtime is rejected by ValueEnum.
+        assert!(
+            command_config()
+                .try_get_matches_from(["init", "--runtime", "podman"])
+                .is_err()
+        );
+        // Port 0 is out of the 1.. range.
+        assert!(
+            command_config()
+                .try_get_matches_from(["init", "--port", "0"])
+                .is_err()
+        );
+    }
 
     #[test]
     fn build_config_docker_only() {

--- a/tests/e2e/server/t8_init_non_interactive.sh
+++ b/tests/e2e/server/t8_init_non_interactive.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# T8-server: `ring init` is scriptable via flags. Validates against the real
+# binary that `--runtime` / `--port` skip the prompts entirely (no TTY), write
+# the expected config.toml, and that clap rejects an unknown runtime.
+#
+# Invariants:
+#   1. `init --runtime cloud-hypervisor --port 4030` writes api.port = 4030
+#      and a [contexts.default.runtime.cloud_hypervisor] block, with no prompt.
+#   2. `init --port 9090` (no --runtime, no TTY) → custom port, Docker default
+#      (no cloud_hypervisor block).
+#   3. an invalid `--runtime` value is rejected (non-zero exit, lists the
+#      accepted values).
+#   4. re-running without --force refuses to overwrite (non-zero exit).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+log "== T8-server: ring init --non-interactive flags =="
+
+# --- Invariant 1: fully scripted CH init ---
+D1=$(mktemp -d -t ring-e2e-init-XXXXXX)
+RING_CONFIG_DIR="$D1" "$RING_BIN" init --runtime cloud-hypervisor --port 4030 >/dev/null 2>&1 \
+  || fail "1: init with flags exited non-zero"
+grep -qF "api.port = 4030" "$D1/config.toml" || { cat "$D1/config.toml" >&2; fail "1: api.port = 4030 missing"; }
+grep -qF "[contexts.default.runtime.cloud_hypervisor]" "$D1/config.toml" \
+  || { cat "$D1/config.toml" >&2; fail "1: cloud_hypervisor block missing"; }
+log "1 (scripted CH init): config.toml correct"
+
+# --- Invariant 2: --port only, no TTY → custom port + Docker default ---
+D2=$(mktemp -d -t ring-e2e-init-XXXXXX)
+RING_CONFIG_DIR="$D2" "$RING_BIN" init --port 9090 </dev/null >/dev/null 2>&1 \
+  || fail "2: init --port exited non-zero"
+grep -qF "api.port = 9090" "$D2/config.toml" || fail "2: api.port = 9090 missing"
+if grep -qF "cloud_hypervisor" "$D2/config.toml"; then
+  fail "2: expected Docker default (no cloud_hypervisor block) when --runtime omitted"
+fi
+log "2 (--port only → Docker default): correct"
+
+# --- Invariant 3: invalid runtime rejected ---
+D3=$(mktemp -d -t ring-e2e-init-XXXXXX)
+set +e
+OUT=$(RING_CONFIG_DIR="$D3" "$RING_BIN" init --runtime podman 2>&1)
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "3: invalid --runtime must exit non-zero"
+echo "$OUT" | grep -qiE "docker, cloud-hypervisor, both" \
+  || { echo "$OUT" >&2; fail "3: expected accepted runtime values in the error"; }
+[ -f "$D3/config.toml" ] && fail "3: no config.toml should be written on rejection"
+log "3 (invalid runtime rejected): exit $RC, no config written"
+
+# --- Invariant 4: refuse to overwrite without --force ---
+set +e
+OUT=$(RING_CONFIG_DIR="$D1" "$RING_BIN" init --runtime docker --port 3030 2>&1)
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "4: re-init without --force must refuse"
+echo "$OUT" | grep -qiF "already exists" || { echo "$OUT" >&2; fail "4: expected 'already exists'"; }
+log "4 (no clobber without --force): refused"
+
+rm -rf "$D1" "$D2" "$D3"
+log "== T8-server: all invariants passed =="


### PR DESCRIPTION
## What

Makes `ring init` fully scriptable, closing the roadmap item: `ring init` could only prompt (TTY) or fall back to fixed defaults (Docker / 3030) with no TTY. There was no way to script a non-Docker or custom-port init.

Adds two flags:
- `--runtime docker|cloud-hypervisor|both`
- `--port <1-65535>`

Precedence, per-field: an explicit flag wins; otherwise prompt on a TTY; otherwise the non-interactive default (Docker, 3030). Passing only `--port` still prompts for the runtime on a TTY (or defaults to Docker without one), and vice versa — so `ring init --runtime cloud-hypervisor --port 4030` runs unattended.

## Implementation

- `RuntimeChoice` now derives clap's `ValueEnum`, so clap parses and validates `--runtime` straight into the typed enum (kebab-case spellings) and generates the `[possible values: …]` help — no hand-rolled string matching. This enables clap's `derive` feature (previously the crate was builder-only).
- `collect_settings` resolves flags → prompt → default per field.

## Validation

- Real binary: `--runtime cloud-hypervisor --port 4030` writes the right config with no prompt; `--port 9090` alone keeps Docker; `--runtime podman` is rejected with the accepted values listed.
- New e2e `tests/e2e/server/t8_init_non_interactive.sh` (4 invariants vs the real binary).
- `cargo test` 444 passed, `clippy -D warnings` clean.

## Docs

- `tutorials/install-and-run.md`: new "Scripting `ring init`" section.