### PR TITLE
feat(dashboard): health check probe history on the deployment detail page

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -283,6 +283,28 @@ export function getDeploymentMetrics(id: string): Promise<DeploymentStats> {
   return request<DeploymentStats>(`/deployments/${encodeURIComponent(id)}/metrics`);
 }
 
+/** One recorded health-check probe. Mirrors `HealthCheckResultRecord` from
+ *  `src/models/health_check_logs.rs`. `status` is `success` | `failed` |
+ *  `timeout`; timestamps are RFC3339. */
+export interface HealthCheckResult {
+  id: string;
+  deployment_id: string;
+  check_type: string;
+  status: string;
+  message?: string | null;
+  created_at: string;
+  started_at: string;
+  finished_at: string;
+}
+
+/** Recent probe history for a deployment, newest first (server default).
+ *  `limit` caps how many records come back. */
+export function getDeploymentHealthChecks(id: string, limit = 50): Promise<HealthCheckResult[]> {
+  return request<HealthCheckResult[]>(
+    `/deployments/${encodeURIComponent(id)}/health-checks?limit=${limit}`
+  );
+}
+
 /** Mirrors `NodeRootDto` from `src/api/dto/node.rs`. Memory figures are GiB. */
 export interface NodeInfo {
   hostname: string;

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import {
     fetchLogsSnapshot,
     getDeployment,
+    getDeploymentHealthChecks,
     getDeploymentMetrics,
     listDeploymentEvents,
     streamLogs,
@@ -13,6 +14,7 @@
     type DeploymentStats,
     type EnvValue,
     type HealthCheck,
+    type HealthCheckResult,
     type LogEntry,
     type LogStreamHandle
   } from '$lib/api';
@@ -23,6 +25,7 @@
   let events = $state<DeploymentEvent[]>([]);
   let metrics = $state<DeploymentStats | null>(null);
   let metricsError = $state<string | null>(null);
+  let hcHistory = $state<HealthCheckResult[]>([]);
   let loading = $state(true);
   let errorMsg = $state<string | null>(null);
   let lastFetch = $state<Date | null>(null);
@@ -163,7 +166,7 @@
       // instances) without invalidating the rest of the page — degrade
       // gracefully. Metrics carry their own error so the card can explain why
       // it's empty instead of silently showing nothing.
-      const [d, ev, m] = await Promise.all([
+      const [d, ev, m, hc] = await Promise.all([
         getDeployment(id),
         listDeploymentEvents(id).catch(() => [] as DeploymentEvent[]),
         getDeploymentMetrics(id)
@@ -174,9 +177,11 @@
           .catch((e) => {
             metricsError = e instanceof Error ? e.message : String(e);
             return null;
-          })
+          }),
+        getDeploymentHealthChecks(id).catch(() => [] as HealthCheckResult[])
       ]);
       metrics = m;
+      hcHistory = hc;
       // The API omits empty collections in some shapes (e.g. health_checks
       // is missing entirely when none are configured). Normalize so the
       // template can safely read `.length`, `Object.keys`, etc.
@@ -202,7 +207,7 @@
 
   onMount(() => {
     if (!getToken()) {
-      goto('/');
+      goto('/login');
       return;
     }
     void refresh();
@@ -253,6 +258,19 @@
       case 'command':
         return hc.command;
     }
+  }
+
+  /** Map a recorded probe status to a colour class. `success` → green,
+   *  `failed`/`timeout` → red, anything else neutral. */
+  function hcStatusClass(status: string): string {
+    const s = status.toLowerCase();
+    if (s === 'success') {
+      return 'hc-ok';
+    }
+    if (s === 'failed' || s === 'timeout') {
+      return 'hc-fail';
+    }
+    return 'hc-unknown';
   }
 
   /** Collapse runs of consecutive events sharing the same level + message
@@ -622,6 +640,41 @@
     {/if}
   </section>
 
+  {#if detail.health_checks.length > 0}
+    <section class="card">
+      <header class="section-head">
+        <h2>Health check history</h2>
+        <span class="count">{hcHistory.length}</span>
+      </header>
+      {#if hcHistory.length === 0}
+        <p class="muted pad">No probe results recorded yet.</p>
+      {:else}
+        <table>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Message</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each hcHistory as r (r.id)}
+              <tr>
+                <td class="mono">{formatDate(r.finished_at)}</td>
+                <td>{r.check_type}</td>
+                <td>
+                  <span class="hc-status {hcStatusClass(r.status)}">{r.status}</span>
+                </td>
+                <td class="mono small">{r.message ?? '—'}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    </section>
+  {/if}
+
   <section class="card">
     <header class="section-head logs-head">
       <h2>Logs</h2>
@@ -930,6 +983,31 @@
     padding: 0.1rem 0.45rem;
     border-radius: var(--radius-sm);
     font-size: 0.75rem;
+  }
+
+  .hc-status {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .hc-ok {
+    color: var(--success);
+    background: var(--success-bg);
+  }
+  .hc-fail {
+    color: var(--danger);
+    background: var(--danger-bg);
+  }
+  .hc-unknown {
+    color: var(--fg-3);
+    background: var(--bg-2);
+  }
+  td.small {
+    font-size: 0.78rem;
+    color: var(--fg-1);
   }
 
   .events {

--- a/documentation/how-to/use-the-dashboard.md
+++ b/documentation/how-to/use-the-dashboard.md
@@ -86,6 +86,7 @@ Local mode is always available — there's nothing to disable, it only runs when
   - Running instances
   - **Live metrics** — per-instance and aggregated CPU, memory, network I/O, disk I/O and PID counts, refreshed every few seconds (sourced from `GET /deployments/{id}/metrics`). The card shows a message instead when the deployment has no live instances.
   - Ports, volumes, environment variables, and configured health checks
+  - **Health check history** — recorded probe results over time (time, type, success/failed/timeout status, message), sourced from `GET /deployments/{id}/health-checks`. Shown only when the deployment has health checks configured.
   - Streamed logs (live tail) and a recent-events timeline
 - Read-only views for namespaces, secrets, and configs
 - A **Node** page (`/node`) showing the host the server runs on: hostname, OS, architecture, uptime, CPU cores, memory usage, and load average (sourced from `GET /node/get`, refreshed every few seconds)


### PR DESCRIPTION
## What

Closes the in-progress roadmap item: the detail page already rendered the health-check *config*; this adds the *probe history* — the actual results recorded over time.

A new **Health check history** section on `/deployments/{id}` lists recent probes (time, check type, status, message), sourced from `GET /deployments/{id}/health-checks`. Status is colour-coded (success → green, failed/timeout → red). The section only appears when the deployment has health checks configured, and degrades gracefully (empty list → "No probe results recorded yet").

## Implementation

- `api.ts`: typed `HealthCheckResult` (mirrors `HealthCheckResultRecord` from `src/models/health_check_logs.rs`) and `getDeploymentHealthChecks(id, limit)`.
- `deployments/[id]/+page.svelte`: fetch the history alongside the existing detail/events/metrics (degrades independently), render the table, `hcStatusClass` for colouring.

## Validation

- Verified the live endpoint shape against a real deployment with a TCP health check: matches the TS type field-for-field, probes accumulate every interval.
- `svelte-check` 0 errors / 0 warnings, `biome` clean, `bun run build` OK.

## Docs

- `how-to/use-the-dashboard.md`: lists the new history section.