### PR TITLE
feat(dashboard): UX polish — created-at, page titles, copy IDs, responsive

### DIFF
--- a/dashboard/src/lib/CopyButton.svelte
+++ b/dashboard/src/lib/CopyButton.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  /** A small inline button that copies `value` to the clipboard and briefly
+   *  shows a checkmark. Used next to IDs and other copy-worthy mono values. */
+  let { value, label = 'Copy' }: { value: string; label?: string } = $props();
+
+  let copied = $state(false);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      copied = true;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        copied = false;
+      }, 1200);
+    } catch {
+      // Clipboard can be blocked (insecure context, permissions). Fail quietly
+      // — the value is still visible for manual selection.
+    }
+  }
+</script>
+
+<button
+  class="copy"
+  class:copied
+  onclick={copy}
+  title={copied ? 'Copied!' : label}
+  aria-label={label}
+  type="button"
+>
+  {#if copied}
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M3 8.5l3.5 3.5L13 5" />
+    </svg>
+  {:else}
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
+      <path d="M3.5 10.5h-.5a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v.5" />
+    </svg>
+  {/if}
+</button>
+
+<style>
+  .copy {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    padding: 0;
+    margin-left: 0.35rem;
+    border: 0;
+    background: transparent;
+    color: var(--fg-3);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    vertical-align: middle;
+    transition:
+      color 0.1s,
+      background 0.1s;
+  }
+  .copy:hover {
+    color: var(--fg-0);
+    background: var(--bg-hover);
+  }
+  .copy.copied {
+    color: var(--success);
+  }
+  .copy :global(svg) {
+    width: 12px;
+    height: 12px;
+  }
+</style>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -13,6 +13,8 @@ export interface Deployment {
   status: string;
   replicas: number;
   image: string;
+  /** SQL-style timestamp from the API; parse with `formatDate`. */
+  created_at?: string;
 }
 
 export interface CurrentUser {

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -413,4 +413,53 @@
     max-width: 1400px;
     width: 100%;
   }
+
+  /* On narrow screens the fixed 220px rail wastes space and tables overflow.
+   * Collapse to a single column: the sidebar becomes a top bar with a
+   * horizontally-scrollable nav, the content takes full width. */
+  @media (max-width: 768px) {
+    .shell {
+      grid-template-columns: 1fr;
+    }
+    .sidebar {
+      position: static;
+      height: auto;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem 1rem;
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .brand {
+      border-bottom: 0;
+      margin: 0;
+      padding: 0 0.5rem 0 0;
+    }
+    nav {
+      flex-direction: row;
+      flex-wrap: wrap;
+      margin-top: 0;
+      flex: 1 1 100%;
+      overflow-x: auto;
+    }
+    .sidebar-footer {
+      margin-top: 0;
+      border-top: 0;
+      flex-direction: row;
+      align-items: center;
+      flex-wrap: wrap;
+      flex: 1 1 100%;
+      padding: 0.5rem 0.625rem 0;
+    }
+    .sidebar-footer .user {
+      margin-right: auto;
+    }
+    .main {
+      padding: 1.25rem 1rem;
+    }
+    :global(.card) {
+      overflow-x: auto;
+    }
+  }
 </style>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -121,6 +121,8 @@
   });
 </script>
 
+<svelte:head><title>Ring · Overview</title></svelte:head>
+
 <main class="overview">
   <header class="topbar">
     <div>

--- a/dashboard/src/routes/configs/+page.svelte
+++ b/dashboard/src/routes/configs/+page.svelte
@@ -80,6 +80,8 @@
   let filtered = $derived(nsFilter ? configs.filter((c) => c.namespace === nsFilter) : configs);
 </script>
 
+<svelte:head><title>Ring · Configs</title></svelte:head>
+
 <header class="page-header">
   <div>
     <h1>Configs</h1>

--- a/dashboard/src/routes/deployments/+page.svelte
+++ b/dashboard/src/routes/deployments/+page.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/stores';
   import { listDeployments, type Deployment } from '$lib/api';
   import { getToken } from '$lib/auth';
-  import { timeAgo } from '$lib/utils';
+  import { formatDate, timeAgo } from '$lib/utils';
 
   let items = $state<Deployment[]>([]);
   let loading = $state(true);
@@ -139,6 +139,8 @@
   let totalReplicas = $derived(visible.reduce((acc, d) => acc + (d.replicas ?? 0), 0));
 </script>
 
+<svelte:head><title>Ring · Deployments</title></svelte:head>
+
 <header class="page-header">
   <div>
     <h1>Deployments</h1>
@@ -235,6 +237,7 @@
           <th>Status</th>
           <th class="num">Replicas</th>
           <th>Image</th>
+          <th>Created</th>
         </tr>
       </thead>
       <tbody>
@@ -262,6 +265,7 @@
             </td>
             <td class="num mono">{d.replicas}</td>
             <td class="mono">{d.image}</td>
+            <td class="created">{formatDate(d.created_at)}</td>
           </tr>
         {/each}
       </tbody>
@@ -397,6 +401,11 @@
   td.mono {
     font-family: var(--font-mono);
     color: var(--fg-1);
+  }
+  .created {
+    color: var(--fg-2);
+    font-size: 0.8rem;
+    white-space: nowrap;
   }
   .deployment-name {
     font-weight: 500;

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -18,6 +18,7 @@
     type LogEntry,
     type LogStreamHandle
   } from '$lib/api';
+  import CopyButton from '$lib/CopyButton.svelte';
   import { getToken } from '$lib/auth';
   import { formatBytes, formatDate, timeAgo } from '$lib/utils';
 
@@ -300,6 +301,10 @@
   let groupedEvents = $derived(groupConsecutive(events));
 </script>
 
+<svelte:head>
+  <title>{detail ? `Ring · ${detail.name}` : 'Ring · Deployment'}</title>
+</svelte:head>
+
 {#if loading && !detail}
   <p class="muted">Loading…</p>
 {:else if errorMsg && !detail}
@@ -336,6 +341,7 @@
       </div>
       <p class="subtitle">
         <span class="mono">{detail.id}</span>
+        <CopyButton value={detail.id} label="Copy deployment ID" />
       </p>
     </div>
     <div class="header-actions">

--- a/dashboard/src/routes/login/+page.svelte
+++ b/dashboard/src/routes/login/+page.svelte
@@ -31,6 +31,8 @@
   }
 </script>
 
+<svelte:head><title>Ring · Sign in</title></svelte:head>
+
 <div class="login-shell">
   <form class="card" onsubmit={submit}>
     <div class="brand">

--- a/dashboard/src/routes/namespaces/+page.svelte
+++ b/dashboard/src/routes/namespaces/+page.svelte
@@ -59,6 +59,8 @@
   );
 </script>
 
+<svelte:head><title>Ring · Namespaces</title></svelte:head>
+
 <header class="page-header">
   <div>
     <h1>Namespaces</h1>

--- a/dashboard/src/routes/node/+page.svelte
+++ b/dashboard/src/routes/node/+page.svelte
@@ -46,6 +46,8 @@
   );
 </script>
 
+<svelte:head><title>Ring · Node</title></svelte:head>
+
 <header class="page-header">
   <h1>Node</h1>
   <div class="header-actions">

--- a/dashboard/src/routes/secrets/+page.svelte
+++ b/dashboard/src/routes/secrets/+page.svelte
@@ -56,6 +56,8 @@
   let filtered = $derived(nsFilter ? secrets.filter((s) => s.namespace === nsFilter) : secrets);
 </script>
 
+<svelte:head><title>Ring · Secrets</title></svelte:head>
+
 <header class="page-header">
   <div>
     <h1>Secrets</h1>


### PR DESCRIPTION
## What

A batch of pure-UX improvements to the dashboard (no backend changes).

- **Created-at column** on the deployments list — the list showed namespace/name/runtime/status/replicas/image but not when a deployment was created. The API already returns `created_at`; now it's a column (typed on the `Deployment` interface).
- **Per-page browser titles** via `<svelte:head><title>`. Every tab showed the same "ring dashboard"; now: `Ring · Overview`, `Ring · Deployments`, `Ring · <name>` (detail, dynamic), `Ring · Node`, etc.
- **Copy-to-clipboard** on the deployment ID (detail page), via a reusable `CopyButton.svelte` (checkmark feedback, fails quietly when clipboard is blocked).
- **Responsive layout** — the fixed 220px sidebar + wide tables broke on small screens. Under 768px the sidebar collapses to a top bar with a scrollable nav, content goes full-width, and cards scroll horizontally instead of overflowing.

Empty states (no deployments/secrets/configs/namespaces) were already handled and left as-is.

## Validation

- `svelte-check` 0 errors / 0 warnings, `biome` clean, `bun run build` OK.