### PR TITLE
feat(cli): filter deployments by label (runtime-agnostic)

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -140,6 +140,7 @@ ring deployment list [OPTIONS]
 - `-n` / `--namespace <NAMESPACE>` — filter by namespace
 - `-s` / `--status <STATUS>` — filter by status (repeatable)
 - `--type <TYPE>` — filter by deployment kind: `worker` or `job`
+- `-l` / `--label <SELECTOR>` — filter by label, `key=value` or just `key` (repeatable; a deployment must match **all** selectors). Works the same across runtimes (Docker and Cloud Hypervisor) since labels are matched on Ring's stored metadata.
 - `-o` / `--output <FORMAT>` — `table` (default) or `json`
 
 **Output (table):**
@@ -159,6 +160,8 @@ ring deployment list --namespace production
 ring deployment list --status running
 ring deployment list --status running --status pending
 ring deployment list --type job
+ring deployment list --label env=prod
+ring deployment list -l env=prod -l tier=web   # both must match
 ring deployment list -o json | jq -r '.[].id'
 ```
 

--- a/src/api/action/deployment/list.rs
+++ b/src/api/action/deployment/list.rs
@@ -22,6 +22,11 @@ pub(crate) struct QueryParameters {
     status: Vec<String>,
     #[serde(default)]
     kind: Vec<String>,
+    /// `key=value` label selectors. A deployment matches only if it carries
+    /// every selector. Stored as JSON in the `labels` column, so this is
+    /// filtered in memory rather than in SQL.
+    #[serde(default)]
+    labels: Vec<String>,
 }
 
 impl<S> FromRequestParts<S> for QueryParameters
@@ -39,6 +44,7 @@ where
         let mut status = Vec::new();
         let mut namespaces = Vec::new();
         let mut kind = Vec::new();
+        let mut labels = Vec::new();
 
         for (key, value) in parsed {
             match key.as_str() {
@@ -48,6 +54,8 @@ where
                 "status" => status.push(value),
                 "kind[]" => kind.push(value),
                 "kind" => kind.push(value),
+                "label[]" => labels.push(value),
+                "label" => labels.push(value),
                 _ => {}
             }
         }
@@ -56,6 +64,7 @@ where
             namespaces,
             status,
             kind,
+            labels,
         })
     }
 }
@@ -90,7 +99,29 @@ pub(crate) async fn list(
         }
     };
 
+    // Labels live as JSON in the `labels` column, so they can't go through the
+    // column-based SQL filter — match them in memory. Each selector is `key` or
+    // `key=value`; a deployment must satisfy every selector to be kept.
+    let label_selectors: Vec<(String, Option<String>)> = query_parameters
+        .labels
+        .iter()
+        .map(|sel| match sel.split_once('=') {
+            Some((k, v)) => (k.to_string(), Some(v.to_string())),
+            None => (sel.clone(), None),
+        })
+        .collect();
+
+    let matches_labels = |deployment: &deployments::Deployment| {
+        label_selectors.iter().all(|(k, want)| match want {
+            Some(v) => deployment.labels.get(k).is_some_and(|got| got == v),
+            None => deployment.labels.contains_key(k),
+        })
+    };
+
     for deployment in list_deployments.into_iter() {
+        if !matches_labels(&deployment) {
+            continue;
+        }
         let id = deployment.id.clone();
         let runtime_name = deployment.runtime.clone();
         let mut output = DeploymentOutput::from_to_model(deployment);

--- a/src/commands/deployment/list.rs
+++ b/src/commands/deployment/list.rs
@@ -32,6 +32,13 @@ pub(crate) fn command_config() -> Command {
                 .help("Filter by type (worker or job)")
                 .value_parser(["worker", "job"]),
         )
+        .arg(
+            Arg::new("label")
+                .action(ArgAction::Append)
+                .short('l')
+                .long("label")
+                .help("Filter by label, e.g. -l env=prod (repeatable; all must match)"),
+        )
         .arg(output_arg())
 }
 
@@ -94,6 +101,16 @@ pub(crate) async fn execute(
     if args.contains_id("type") {
         let type_filter = args.get_one::<String>("type").unwrap();
         params.push(format!("kind={}", type_filter));
+    }
+
+    if args.contains_id("label") {
+        let labels = args.get_many::<String>("label").unwrap();
+        for label in labels {
+            // A selector like `env=prod` carries an `=`; percent-encode it so
+            // the server parses one `label[]` value, not `label[]=env` + `prod`.
+            let encoded: String = url::form_urlencoded::byte_serialize(label.as_bytes()).collect();
+            params.push(format!("label[]={}", encoded));
+        }
     }
 
     if !params.is_empty() {

--- a/tests/e2e/docker/t33_filter_by_label.sh
+++ b/tests/e2e/docker/t33_filter_by_label.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# T33: `ring deployment list --label` filters by label, matched on Ring's
+# stored metadata (so it works the same for any runtime). Selectors are
+# `key=value` or just `key`, and multiple selectors AND together.
+#
+# Invariants (against the real binary, `--output json`):
+#   1. -l env=prod returns only the prod deployment
+#   2. -l tier=web -l env=dev returns only the dev deployment (AND semantics)
+#   3. -l tier (key-only) returns both
+#   4. -l env=staging returns none
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T33: docker deployment list --label =="
+
+start_ring
+ring_login
+
+names() {
+  # Print the names returned by a label-filtered list, sorted, space-joined.
+  "$RING_BIN" deployment list "$@" --output json \
+    | jq -r '.[].name' | sort | tr '\n' ' ' | sed 's/ $//'
+}
+
+FIXTURE="$RING_TEST_DIR/labels.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  lbl-prod:
+    name: lbl-prod
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    labels: { env: prod, tier: web }
+  lbl-dev:
+    name: lbl-dev
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    labels: { env: dev, tier: web }
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "lbl-prod" "running" 60
+wait_deployment_status "ring-e2e" "lbl-dev" "running" 60
+
+# Scope every query to the namespace so other deployments don't interfere.
+NS=(--namespace ring-e2e)
+
+got=$(names "${NS[@]}" -l env=prod)
+[ "$got" = "lbl-prod" ] || fail "1: -l env=prod returned '$got' (expected 'lbl-prod')"
+log "1 (env=prod): $got"
+
+got=$(names "${NS[@]}" -l tier=web -l env=dev)
+[ "$got" = "lbl-dev" ] || fail "2: -l tier=web -l env=dev returned '$got' (expected 'lbl-dev')"
+log "2 (tier=web AND env=dev): $got"
+
+got=$(names "${NS[@]}" -l tier)
+[ "$got" = "lbl-dev lbl-prod" ] || fail "3: -l tier returned '$got' (expected both)"
+log "3 (key-only tier): $got"
+
+got=$(names "${NS[@]}" -l env=staging)
+[ -z "$got" ] || fail "4: -l env=staging returned '$got' (expected none)"
+log "4 (env=staging): none"
+
+# Cleanup
+"$RING_BIN" deployment delete "$(get_deployment_id ring-e2e lbl-prod)" >/dev/null 2>&1 || true
+"$RING_BIN" deployment delete "$(get_deployment_id ring-e2e lbl-dev)" >/dev/null 2>&1 || true
+
+log "== T33: all invariants passed =="


### PR DESCRIPTION
## What

Adds `--label` filtering to `ring deployment list` (and the `GET /deployments?label[]=` query param). Selectors are `key=value` or just `key`; multiple selectors AND together.

```bash
ring deployment list --label env=prod
ring deployment list -l tier=web -l env=dev   # both must match
ring deployment list -l tier                  # key present, any value
```

Part of finishing the Cloud Hypervisor runtime: the roadmap flagged labels as "silently ignored" on CH. In fact labels are already persisted and exposed for every runtime — what was missing was a way to *use* them. Filtering is matched on Ring's stored metadata, so it behaves identically for Docker and Cloud Hypervisor (not delegated to the runtime).

## Implementation

- API (`deployment/list.rs`): parse `label[]` / `label` query params; since labels are JSON in the `labels` column (not a filterable SQL column), match them in memory after the column-based filter — a deployment must satisfy every selector.
- CLI (`deployment/list.rs`): repeatable `-l` / `--label`, percent-encoded into `label[]=` (handles the `=` in `key=value`).

## Validation

- Live test against the real binary: `env=prod`, `tier=web AND env=dev`, key-only `tier`, and a no-match selector all behave correctly.
- New e2e `tests/e2e/docker/t33_filter_by_label.sh` (4 invariants).
- `cargo test` 444 passed, `clippy -D warnings` clean.

## Docs

- `reference/cli.md`: documents `--label` with examples.