### PR TITLE
feat(cloud-hypervisor): warn on silently-ignored fields at apply

### DIFF
--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -242,12 +242,12 @@ This is the canonical parity table. Other pages link here rather than restate it
 | `command` health checks | **Supported** via in-guest `ring-agent` over AF_VSOCK port 2375. Requires the agent in the guest image. |
 | Custom `command: [...]` field | **Rejected at the API** — the VM boots whatever its image is configured to run |
 | Docker image references | **Rejected at the API** — `image:` must be an absolute path to a raw disk image |
-| `labels:` | Silently ignored — no equivalent of Docker container labels |
+| `labels:` | **Stored and usable.** Not applied to the VM (no container-label equivalent), but persisted as Ring metadata — shown in `inspect` and filterable with `ring deployment list --label key=value`, same as Docker |
 | `resources.limits.cpu` | Honored as **allocation, not cap**: rounded down to whole vCPU, floor 1 (`"500m"` → 1 vCPU) |
 | `resources.limits.memory` | Honored as **allocation, not cap**: VM RAM size, minimum 128 MiB |
-| `resources.requests.*` | Silently ignored |
-| `config.image_pull_policy` / `server` / `username` / `password` | Silently ignored — no image to pull |
-| `config.user` (privileged / id / group) | Silently ignored |
+| `resources.requests.*` | Ignored (VM is sized from `limits`) — a **warning event** is recorded at create so it isn't silent |
+| `config.image_pull_policy` / `server` / `username` / `password` | Ignored (no image to pull) — a **warning event** is recorded at create |
+| `config.user` (privileged / id / group) | Ignored — a **warning event** is recorded at create |
 | `kind: job` | **Supported, coarser signal.** Clean guest shutdown → `completed`. CH does not expose the workload's exit code — Ring sees VM state only. |
 | Inter-VM networking | Each VM is isolated — no shared bridge, no DNS between siblings. Cross-VM traffic goes through host-published ports |
 | Environment variables | **Supported** via cloud-init NoCloud (requires `xorriso` + cloud-init in guest) |

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -20,8 +20,8 @@ use crate::models::audit_log;
 use crate::models::deployment_event;
 use crate::models::deployments;
 use crate::models::deployments::{
-    DeploymentConfig, DeploymentPort, DeploymentStatus, EnvValue, NetworkConfig, NetworkMode,
-    Resource,
+    Deployment, DeploymentConfig, DeploymentPort, DeploymentStatus, EnvValue, NetworkConfig,
+    NetworkMode, Resource, default_image_pull_policy,
 };
 use crate::models::namespace;
 use crate::models::users::User;
@@ -305,6 +305,46 @@ fn validate_runtime_constraints(input: &DeploymentInput, errors: &mut ViolationL
             ));
         }
     }
+}
+
+/// Fields that are accepted by the API but have no effect on the
+/// cloud-hypervisor runtime, returned by their manifest path so the warning
+/// names exactly what the user wrote. CH sizes the VM from `resources.limits`
+/// only and never pulls from a registry, so `resources.requests` and the
+/// `config.*` registry/user knobs are dropped.
+fn cloud_hypervisor_ignored_fields(deployment: &Deployment) -> Vec<String> {
+    let mut ignored = Vec::new();
+
+    if deployment
+        .resources
+        .as_ref()
+        .is_some_and(|r| r.requests.is_some())
+    {
+        ignored.push("resources.requests".to_string());
+    }
+
+    if let Some(config) = &deployment.config {
+        // `image_pull_policy` has a default, so only flag it when it isn't the
+        // default — a user who explicitly set `Never`/`IfNotPresent` should
+        // know it does nothing here.
+        if config.image_pull_policy != default_image_pull_policy() {
+            ignored.push("config.image_pull_policy".to_string());
+        }
+        if config.server.is_some() {
+            ignored.push("config.server".to_string());
+        }
+        if config.username.is_some() {
+            ignored.push("config.username".to_string());
+        }
+        if config.password.is_some() {
+            ignored.push("config.password".to_string());
+        }
+        if config.user.is_some() {
+            ignored.push("config.user".to_string());
+        }
+    }
+
+    ignored
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -716,6 +756,29 @@ pub(crate) async fn create(
                 Some("deployment_created"),
             )
             .await;
+
+            // Cloud Hypervisor silently ignores some fields that Docker
+            // honours (no registry pull, sizing from `limits` only). Rather
+            // than drop them without a trace, surface a single warning event
+            // naming exactly what won't take effect, so an operator isn't left
+            // wondering why their `requests`/registry creds did nothing.
+            if deployment.runtime == "cloud-hypervisor" {
+                let ignored = cloud_hypervisor_ignored_fields(&deployment);
+                if !ignored.is_empty() {
+                    let _ = deployment_event::log_event(
+                        &pool,
+                        deployment.id.clone(),
+                        "warning",
+                        format!(
+                            "These fields are ignored by the cloud-hypervisor runtime and have no effect: {}",
+                            ignored.join(", ")
+                        ),
+                        "api",
+                        Some("cloud_hypervisor_ignored_fields"),
+                    )
+                    .await;
+                }
+            }
 
             // When a previous active deployment was wiped instead of
             // being kept as a rolling parent, surface the reason as a

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -188,7 +188,7 @@ pub(crate) struct NetworkConfig {
     pub(crate) mode: NetworkMode,
 }
 
-fn default_image_pull_policy() -> String {
+pub(crate) fn default_image_pull_policy() -> String {
     "Always".to_string()
 }
 

--- a/tests/e2e/cloud-hypervisor/t24_ignored_fields_warning.sh
+++ b/tests/e2e/cloud-hypervisor/t24_ignored_fields_warning.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# T24-CH: cloud-hypervisor silently ignores fields that Docker honours — it
+# sizes the VM from `resources.limits` only and never pulls from a registry.
+# Dropping `resources.requests` and the `config.*` registry/user knobs without
+# a trace leaves operators wondering why they had no effect. On create, Ring
+# now logs ONE warning event naming exactly which fields are ignored.
+#
+# The warning is emitted at apply time (before any boot), so this test doesn't
+# need a bootable image — it just inspects the event stream.
+#
+# Invariants:
+#   1. a `cloud_hypervisor_ignored_fields` warning event is recorded
+#   2. it names resources.requests and the config.* fields that were set
+#   3. it does NOT name a field that wasn't set (config.username here)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T24-CH: warning on silently-ignored fields =="
+
+setup_ch
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/ignored-fields.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  ignored-fields:
+    name: ignored-fields
+    namespace: ring-e2e
+    runtime: cloud-hypervisor
+    image: "/nonexistent/path/to/disk.raw"
+    replicas: 1
+    config:
+      image_pull_policy: Never
+      server: registry.example.com
+      password: hunter2
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+      requests:
+        memory: "128Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# The deployment row exists immediately; poll until we can resolve its id.
+DEP_ID=""
+for _ in $(seq 1 20); do
+  DEP_ID=$(get_deployment_id "ring-e2e" "ignored-fields" || true)
+  [ -n "$DEP_ID" ] && break
+  sleep 1
+done
+[ -n "$DEP_ID" ] || fail "could not resolve deployment id"
+log "deployment id: $DEP_ID"
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+# --- Invariant 1: the warning event exists ---
+MSG=""
+for _ in $(seq 1 15); do
+  MSG=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+    -H "Authorization: Bearer $TOKEN" \
+    | jq -r '.[] | select(.reason == "cloud_hypervisor_ignored_fields") | .message' \
+    | head -n1 || true)
+  [ -n "$MSG" ] && break
+  sleep 1
+done
+if [ -z "$MSG" ]; then
+  log "events seen:"
+  curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.[] | "\(.reason): \(.message)"' >&2 || true
+  fail "expected a cloud_hypervisor_ignored_fields warning event, got none"
+fi
+log "1 (warning present): $MSG"
+
+# --- Invariant 2: names the fields that were set ---
+for field in "resources.requests" "config.image_pull_policy" "config.server" "config.password"; do
+  echo "$MSG" | grep -qF "$field" || fail "2: warning should mention '$field' — got: $MSG"
+done
+log "2 (names set fields): ok"
+
+# --- Invariant 3: does not name a field that wasn't set ---
+if echo "$MSG" | grep -qF "config.username"; then
+  fail "3: warning mentions config.username which was not set — got: $MSG"
+fi
+log "3 (no false positive on unset field): ok"
+
+log "== T24-CH: all invariants passed =="


### PR DESCRIPTION
## What

Cloud Hypervisor accepts but silently drops several fields that Docker honours — it sizes the VM from `resources.limits` only and never pulls from a registry. A user who sets `resources.requests` or registry creds got no effect and no signal.

On create, Ring now logs **one warning event** (`cloud_hypervisor_ignored_fields`) naming exactly which set fields are ignored: `resources.requests`, `config.image_pull_policy` (when non-default), `config.server`, `config.username`, `config.password`, `config.user`. Visible via `ring deployment events` and the dashboard. The deployment is **not** rejected — it still works, the operator is just told what won't take effect.

Part of finishing the Cloud Hypervisor runtime (roadmap "silently ignored" item). `command` / Docker image refs stay hard rejections (they'd make the VM non-functional); these fields are softer (the deployment runs fine without them), so a warning fits better than a 422.

## Implementation

- `create.rs`: `cloud_hypervisor_ignored_fields()` returns the set-but-ignored fields by manifest path; emitted as a warning event right after a successful CH create.
- `models/deployments.rs`: `default_image_pull_policy` made `pub(crate)` so the helper can tell an explicit policy from the default.

## Validation

- New e2e `tests/e2e/cloud-hypervisor/t24_ignored_fields_warning.sh` (3 invariants vs the real server): the warning is recorded, it names the set fields, and it does not name an unset one.
- `cargo test` 444 passed, `clippy -D warnings` clean.

## Docs

- `how-to/deploy-on-cloud-hypervisor.md`: parity table updated — these fields are no longer "silently" ignored (warning recorded); labels row updated to reflect they're stored and filterable.