### PR TITLE
feat(cloud-hypervisor): actionable error when command health check can't reach ring-agent

### DIFF
--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -196,7 +196,7 @@ TCP only — UDP is not wired up.
 
 ## Health checks
 
-`tcp`, `http`, `command` all work. `tcp` and `http` probe from the host against the guest IP (no agent required). `command` goes through the in-guest `ring-agent` over AF_VSOCK port 2375 — install the agent in the guest image.
+`tcp`, `http`, `command` all work. `tcp` and `http` probe from the host against the guest IP (no agent required). `command` goes through the in-guest `ring-agent` over AF_VSOCK port 2375 — install the agent in the guest image. If the agent isn't reachable (missing from the image, or not started yet), the `command` probe fails with an explicit message naming ring-agent rather than a bare connection error.
 
 The readiness gate (`readiness: true`) works exactly as on Docker — the scheduler-side drain logic is runtime-agnostic. **But there is no CH equivalent of the native Docker `HEALTHCHECK` translation**, so a `readiness: true` check gates the Ring drain but is not exposed to external proxies.
 

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -1325,6 +1325,20 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
                     resp.stderr.trim()
                 )),
             ),
+            // A connect failure almost always means the guest image doesn't
+            // ship `ring-agent` listening on AF_VSOCK port 2375 (or it hasn't
+            // started yet) — the single most common `command` health-check
+            // pitfall on this runtime. Point the operator straight at it
+            // instead of leaving them with a bare io error.
+            Err(crate::runtime::vsock_client::VsockError::Connect { cid, source }) => (
+                HealthCheckStatus::Failed,
+                Some(format!(
+                    "cannot reach ring-agent in the guest (CID {cid}): {source}. \
+                     `command` health checks on cloud-hypervisor require ring-agent \
+                     running in the guest image on AF_VSOCK port 2375 — see the \
+                     cloud-hypervisor runtime docs"
+                )),
+            ),
             Err(e) => (
                 HealthCheckStatus::Failed,
                 Some(format!("vsock probe failed: {}", e)),

--- a/tests/e2e/cloud-hypervisor/t17_command_health_check.sh
+++ b/tests/e2e/cloud-hypervisor/t17_command_health_check.sh
@@ -76,6 +76,25 @@ if ! echo "$INFO" | grep -q '"vsock"'; then
 fi
 log "vm.info reports a vsock device"
 
+# === probe message points at ring-agent when the guest lacks it ===
+# The test image (cirros) ships no ring-agent, so the command probe's vsock
+# connect fails. The recorded probe message must name ring-agent explicitly —
+# not leave the operator with a bare io error. (Regression for the
+# "cannot reach ring-agent" message.)
+log "waiting for a probe row..."
+PROBE_MSG=""
+for _ in $(seq 1 40); do
+  PROBE_MSG=$("$RING_BIN" deployment health-checks "$DEPLOYMENT_ID" --output json 2>/dev/null \
+    | jq -r '.[0].message // ""')
+  [ -n "$PROBE_MSG" ] && break
+  sleep 2
+done
+log "first probe message: $PROBE_MSG"
+if ! echo "$PROBE_MSG" | grep -qi "ring-agent"; then
+  fail "command probe message should name ring-agent when the guest can't be reached, got: $PROBE_MSG"
+fi
+log "probe message is actionable (mentions ring-agent)"
+
 # === delete teardown ===
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 


### PR DESCRIPTION
## What

A `command` health check on cloud-hypervisor goes through `ring-agent` in the guest over AF_VSOCK. When the agent is missing from the image (or not started yet) — the single most common pitfall — the probe failed with a bare `vsock probe failed: connect to CID N failed: <io error>`, leaving the operator guessing.

The connect-failure case now produces an explicit message:

```
cannot reach ring-agent in the guest (CID 3913348148): No such device (os error 19). `command` health checks on cloud-hypervisor require ring-agent running in the guest image on AF_VSOCK port 2375 — see the cloud-hypervisor runtime docs
```

Only the `Connect` variant gets this treatment; other vsock errors (agent-reported, malformed response) keep their existing message. Behaviour is unchanged — the check still fails — only the message improves.

## Validation

- Extended `tests/e2e/cloud-hypervisor/t17_command_health_check.sh`: the test image (cirros) ships no agent, so the probe's vsock connect fails; the test asserts the recorded probe message names ring-agent. Verified against the real runtime.
- `cargo test` 444 passed, `clippy -D warnings` clean.

## Docs

- `how-to/deploy-on-cloud-hypervisor.md`: note that a missing agent surfaces an explicit message.

Part of finishing the Cloud Hypervisor runtime (roadmap: "CH sans ring-agent → documenter le fallback").