### PR TITLE
feat(ports): UDP forwarding via protocol field (docker + cloud-hypervisor)

### DIFF
--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -186,13 +186,14 @@ volumes:
 ports:
   - { published: 8080, target: 80 }
   - { published: 5432, target: 5432 }
+  - { published: 5353, target: 53, protocol: udp }
 ```
 
 Each entry spawns one `socat` userspace process forwarding `0.0.0.0:<published>` → `<guest_ip>:<target>`. The guest IP is a deterministic /30 under `10.42.0.0/16` derived from the instance ID.
 
 If `published` is already taken on the host, Ring **refuses to start the VM** and emits a `PortAllocationFailed` event. After `MAX_RESTART_COUNT` failed attempts, the deployment lands in `crash_loop_back_off`.
 
-TCP only — UDP is not wired up.
+Both `tcp` (default) and `udp` are supported via the port's `protocol` field — `socat` uses a `UDP4-LISTEN`/`UDP4` pair for UDP.
 
 ## Health checks
 
@@ -252,7 +253,7 @@ This is the canonical parity table. Other pages link here rather than restate it
 | Inter-VM networking | Each VM is isolated — no shared bridge, no DNS between siblings. Cross-VM traffic goes through host-published ports |
 | Environment variables | **Supported** via cloud-init NoCloud (requires `xorriso` + cloud-init in guest) |
 | Volumes (bind / volume / config) | **Supported** via virtio-fs (requires `virtiofsd` + `CONFIG_VIRTIO_FS=y` guest kernel) |
-| Port mapping | **Supported** via `socat` userspace forwarders |
+| Port mapping | **Supported** via `socat` userspace forwarders — both `tcp` and `udp` |
 | Deployment logs | **Supported** via serial console with size-based rotation (10 MiB × 3 backups by default, configurable) |
 | Deployment metrics | **Supported.** CPU% and memory from `/proc/<vmm-pid>/{stat,status}`, network from `/sys/class/net/<tap>/statistics/*` (swapped host↔guest), threads from `/proc/<vmm-pid>/status`. Disk I/O reads `/proc/<vmm-pid>/io` when accessible but reports zeros on hardened hosts: CH clears `PR_SET_DUMPABLE` and `kernel.yama.ptrace_scope >= 1` then denies even the parent. PID `limit` reports as 0 (CH has no equivalent of cgroup `pids.max`) |
 | Runtime event stream | None — CH has no live event stream; crash detection is tick-bound |

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -198,8 +198,9 @@ ports:
 | `published` | integer | Host port |
 | `target` | integer | Container port |
 | `host_ip` | string | Optional. Host interface to bind `published` on. Defaults to `0.0.0.0` (all interfaces). Set to `127.0.0.1` to expose the port on loopback only — useful for a database that should reach a local reverse proxy but stay off the public network. Must be a valid IP address or `ring apply` rejects it. |
+| `protocol` | string | Optional. `tcp` (default) or `udp`. The same `published` port may be declared once for each protocol. |
 
-Ring forwards these to Docker's `HostConfig.PortBindings` (Docker runtime) or to a `socat` forwarder (Cloud Hypervisor runtime); `host_ip` is honored by both runtimes. If `published` is already in use on the host, the start fails — the conflict is surfaced as an `error` event on the deployment, not at `ring apply` time. Note that the same `published` port number on two **different** `host_ip` values is a valid, non-conflicting pair (e.g. `0.0.0.0:8080` and `127.0.0.1:8080` are distinct bindings to the kernel).
+Ring forwards these to Docker's `HostConfig.PortBindings` (Docker runtime) or to a `socat` forwarder (Cloud Hypervisor runtime); `host_ip` and `protocol` are honored by both runtimes. If `published` is already in use on the host, the start fails — the conflict is surfaced as an `error` event on the deployment, not at `ring apply` time. Note that the same `published` port number is a valid, non-conflicting pair across two **different** `host_ip` values (e.g. `0.0.0.0:8080` and `127.0.0.1:8080`) or across the two **protocols** (`8080/tcp` and `8080/udp`) — both are distinct bindings to the kernel.
 
 If you do **not** publish a port, the container is reachable only from inside its namespace. See [how-to: isolate namespaces and route traffic](/documentation/how-to/isolate-namespaces-network).
 

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -168,7 +168,11 @@ fn validate_config(input: &DeploymentInput, errors: &mut ViolationList) {
 fn validate_ports(input: &DeploymentInput, errors: &mut ViolationList) {
     use std::collections::HashMap;
 
-    let mut published_seen: HashMap<u16, usize> = HashMap::new();
+    // Keyed by (published port, protocol): the same host port may be bound
+    // once for TCP and once for UDP — those are separate namespaces — but not
+    // twice for the same protocol.
+    let mut published_seen: HashMap<(u16, crate::models::deployments::PortProtocol), usize> =
+        HashMap::new();
 
     for (idx, port) in input.ports.iter().enumerate() {
         if port.published == 0 {
@@ -200,17 +204,20 @@ fn validate_ports(input: &DeploymentInput, errors: &mut ViolationList) {
         }
 
         if port.published != 0 {
-            if let Some(prev_idx) = published_seen.get(&port.published) {
+            let key = (port.published, port.protocol);
+            if let Some(prev_idx) = published_seen.get(&key) {
                 errors.push(Violation::new(
                     format!("ports[{}].published", idx),
                     format!(
-                        "duplicates ports[{}].published = {}; each host port can only be bound once",
-                        prev_idx, port.published
+                        "duplicates ports[{}].published = {}/{}; each host port can only be bound once per protocol",
+                        prev_idx,
+                        port.published,
+                        port.protocol.as_str()
                     ),
                     "deployment.ports.published.duplicate",
                 ));
             } else {
-                published_seen.insert(port.published, idx);
+                published_seen.insert(key, idx);
             }
         }
     }

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -107,6 +107,10 @@ struct Port {
     /// server's `#[serde(default)]` fills in the default unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     host_ip: Option<String>,
+    /// Transport protocol, `tcp` (default) or `udp`. Omitted from the payload
+    /// when unset so the wire shape is unchanged for TCP-only manifests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    protocol: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -142,6 +142,25 @@ pub(crate) struct DeploymentConfig {
     pub(crate) user: Option<UserConfig>,
 }
 
+/// Transport protocol for a published port. TCP is the default, preserving the
+/// shape of manifests written before UDP forwarding existed.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PortProtocol {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl PortProtocol {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            PortProtocol::Tcp => "tcp",
+            PortProtocol::Udp => "udp",
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct DeploymentPort {
     pub(crate) published: u16,
@@ -151,6 +170,9 @@ pub(crate) struct DeploymentPort {
     /// `127.0.0.1` to expose the port on loopback only.
     #[serde(default)]
     pub(crate) host_ip: Option<String>,
+    /// Transport protocol (`tcp` by default, or `udp`).
+    #[serde(default)]
+    pub(crate) protocol: PortProtocol,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -706,6 +706,7 @@ impl CloudHypervisorLifecycle {
                     p.published,
                     p.target,
                     p.host_ip.as_deref(),
+                    p.protocol,
                 )
                 .await
                 {

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -397,7 +397,7 @@ pub(crate) async fn create_container(
         .ports
         .iter()
         .map(|p| {
-            let key = format!("{}/tcp", p.target);
+            let key = format!("{}/{}", p.target, p.protocol.as_str());
             let binding = PortBinding {
                 host_ip: Some(p.host_ip.clone().unwrap_or_else(|| "0.0.0.0".to_string())),
                 host_port: Some(p.published.to_string()),

--- a/src/runtime/port_forwarder.rs
+++ b/src/runtime/port_forwarder.rs
@@ -21,6 +21,7 @@
 //! negligible. A future iteration may switch to `iptables`/`nftables` DNAT
 //! rules; documented in ROADMAP.
 
+use crate::models::deployments::PortProtocol;
 use crate::runtime::error::RuntimeError;
 use std::net::TcpListener;
 use std::process::Stdio;
@@ -74,6 +75,7 @@ pub(crate) async fn spawn_forwarder(
     published_port: u16,
     target_port: u16,
     host_ip: Option<&str>,
+    protocol: PortProtocol,
 ) -> Result<PortForwarder, RuntimeError> {
     let host_ip = host_ip.unwrap_or(DEFAULT_HOST_IP);
 
@@ -88,20 +90,24 @@ pub(crate) async fn spawn_forwarder(
     // -d -d gives info-level diagnostics to stderr (handy when this fails
     // because the host port is already bound). `reuseaddr` lets us restart
     // a forwarder fast across deployment recreations without TIME_WAIT.
-    // `fork` spawns a child per accepted connection — without it, socat
-    // serves a single client and exits.
-    // socat's TCP4-LISTEN binds 0.0.0.0 by default; `bind=<ip>` scopes it to
-    // a single interface. We only emit `bind=` for a non-default host_ip so
-    // the common case stays byte-for-byte the prior command line.
+    // `fork` spawns a child per accepted connection (UDP: per source peer) —
+    // without it, socat serves a single client and exits.
+    // The LISTEN address binds 0.0.0.0 by default; `bind=<ip>` scopes it to a
+    // single interface. We only emit `bind=` for a non-default host_ip so the
+    // common case stays byte-for-byte the prior command line.
+    let proto = match protocol {
+        PortProtocol::Tcp => "TCP4",
+        PortProtocol::Udp => "UDP4",
+    };
     let listen = if host_ip == DEFAULT_HOST_IP {
-        format!("TCP4-LISTEN:{},reuseaddr,fork", published_port)
+        format!("{}-LISTEN:{},reuseaddr,fork", proto, published_port)
     } else {
         format!(
-            "TCP4-LISTEN:{},reuseaddr,fork,bind={}",
-            published_port, host_ip
+            "{}-LISTEN:{},reuseaddr,fork,bind={}",
+            proto, published_port, host_ip
         )
     };
-    let connect = format!("TCP4:{}:{}", guest_ip, target_port);
+    let connect = format!("{}:{}:{}", proto, guest_ip, target_port);
 
     let child = Command::new("socat")
         .arg("-d")
@@ -165,7 +171,7 @@ mod tests {
         // The "guest" side is unreachable; that's fine — we only check that
         // socat actually binds the listening port and that Drop tears it
         // down. A connection attempt is the cheapest signal of "bound".
-        let fw = spawn_forwarder("127.0.0.99", host_port, 9999, None)
+        let fw = spawn_forwarder("127.0.0.99", host_port, 9999, None, PortProtocol::Tcp)
             .await
             .unwrap();
 
@@ -199,7 +205,7 @@ mod tests {
             return;
         }
         let host_port = pick_free_port();
-        let fw = spawn_forwarder("10.0.0.1", host_port, 5432, None)
+        let fw = spawn_forwarder("10.0.0.1", host_port, 5432, None, PortProtocol::Tcp)
             .await
             .unwrap();
         assert_eq!(fw.published_port, host_port);
@@ -216,7 +222,7 @@ mod tests {
         let _holder = TcpListener::bind(format!("0.0.0.0:{}", host_port))
             .expect("test setup: holder must bind the port");
 
-        let err = spawn_forwarder("10.0.0.1", host_port, 5432, None)
+        let err = spawn_forwarder("10.0.0.1", host_port, 5432, None, PortProtocol::Tcp)
             .await
             .expect_err("spawn_forwarder should refuse a bound port");
 
@@ -236,9 +242,15 @@ mod tests {
         }
 
         let host_port = pick_free_port();
-        let fw = spawn_forwarder("127.0.0.99", host_port, 9999, Some("127.0.0.1"))
-            .await
-            .unwrap();
+        let fw = spawn_forwarder(
+            "127.0.0.99",
+            host_port,
+            9999,
+            Some("127.0.0.1"),
+            PortProtocol::Tcp,
+        )
+        .await
+        .unwrap();
 
         // socat holds 127.0.0.1:<port> — a fresh bind there must fail.
         let busy = TcpListener::bind(format!("127.0.0.1:{}", host_port));

--- a/tests/e2e/docker/t34_udp_ports.sh
+++ b/tests/e2e/docker/t34_udp_ports.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# T34: published ports carry a `protocol` (tcp default, or udp). Docker port
+# bindings must reflect it, and the same host port may be published once for
+# TCP and once for UDP (separate namespaces) without a duplicate error.
+#
+# Invariants:
+#   1. a `protocol: udp` port is bound as <target>/udp on the host
+#   2. a port without `protocol` stays tcp (default preserved)
+#   3. the same host port published for both tcp and udp is accepted and both
+#      bindings appear
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T34: docker udp / mixed-protocol ports =="
+
+start_ring
+ring_login
+
+PORT_UDP=$((20000 + RANDOM % 2000))
+PORT_TCP=$((22000 + RANDOM % 2000))
+PORT_BOTH=$((24000 + RANDOM % 2000))
+
+FIXTURE="$RING_TEST_DIR/udp.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  udp-svc:
+    name: udp-svc
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3
+    replicas: 1
+    command: ["sleep", "600"]
+    ports:
+      - { published: $PORT_UDP, target: 53, protocol: udp }
+      - { published: $PORT_TCP, target: 80 }
+      - { published: $PORT_BOTH, target: 9000, protocol: tcp }
+      - { published: $PORT_BOTH, target: 9000, protocol: udp }
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "udp-svc" "running" 60
+DEP_ID=$(get_deployment_id "ring-e2e" "udp-svc")
+[ -z "$DEP_ID" ] && fail "could not resolve deployment id"
+
+CID=$(docker ps --filter "label=ring_deployment=$DEP_ID" --format '{{.ID}}' | head -n1)
+[ -z "$CID" ] && fail "no container for deployment $DEP_ID"
+PORTS=$(docker port "$CID")
+log "docker port mappings:"
+echo "$PORTS" | sed 's/^/    /'
+
+# --- Invariant 1: udp port bound as 53/udp ---
+echo "$PORTS" | grep -qE "^53/udp -> .*:$PORT_UDP\$" \
+  || fail "1: expected '53/udp -> :$PORT_UDP', not found"
+log "1 (udp binding): ok"
+
+# --- Invariant 2: default stays tcp ---
+echo "$PORTS" | grep -qE "^80/tcp -> .*:$PORT_TCP\$" \
+  || fail "2: expected '80/tcp -> :$PORT_TCP' (default tcp), not found"
+log "2 (default tcp): ok"
+
+# --- Invariant 3: same host port for tcp AND udp, both present ---
+echo "$PORTS" | grep -qE "^9000/tcp -> .*:$PORT_BOTH\$" \
+  || fail "3: expected '9000/tcp -> :$PORT_BOTH', not found"
+echo "$PORTS" | grep -qE "^9000/udp -> .*:$PORT_BOTH\$" \
+  || fail "3: expected '9000/udp -> :$PORT_BOTH', not found"
+log "3 (same host port tcp+udp): both bound"
+
+# Cleanup
+"$RING_BIN" deployment delete "$DEP_ID" >/dev/null 2>&1 || true
+wait_docker_container_gone "$DEP_ID" 30 || true
+
+log "== T34: all invariants passed =="


### PR DESCRIPTION
## What

Adds UDP support to published ports via a new `protocol` field, wired across both runtimes. Closes the last actionable Cloud Hypervisor roadmap item ("UDP forwarding").

```yaml
ports:
  - { published: 5353, target: 53, protocol: udp }
  - { published: 8080, target: 80 }                  # tcp (default)
  - { published: 9000, target: 9000, protocol: tcp }
  - { published: 9000, target: 9000, protocol: udp } # same host port, both protocols
```

- `protocol` defaults to `tcp`, so existing manifests are unchanged (wire shape identical — the CLI omits it when unset).
- **Docker**: the PortBindings key is now `<target>/<protocol>` instead of hard-coded `/tcp`.
- **Cloud Hypervisor**: `socat` uses a `UDP4-LISTEN`/`UDP4` pair for UDP.
- **Validation**: duplicate detection is keyed on `(published, protocol)` — the same host port may be bound once per protocol (TCP and UDP are separate namespaces), but not twice for the same one.

## Validation

- Live test on Docker: `53/udp`, default `80/tcp`, and the same host port published for both tcp and udp all bind correctly.
- New e2e `tests/e2e/docker/t34_udp_ports.sh` (3 invariants).
- `cargo test` 444 passed, `clippy -D warnings` clean.

## Docs

- `reference/manifest.md`: `protocol` field documented; same-port-different-protocol noted as valid.
- `how-to/deploy-on-cloud-hypervisor.md`: port mapping now shows udp; parity table updated.