### PR TITLE
feat(scheduler): gate the running status on readiness checks

### DIFF
--- a/documentation/concepts/deployment-status-lifecycle.md
+++ b/documentation/concepts/deployment-status-lifecycle.md
@@ -1,0 +1,108 @@
+# Deployment status lifecycle
+
+Every deployment carries a single `status` field — the one value `GET /deployments` and `ring deployment list` surface, and the discriminant the [outbound webhook](/documentation/how-to/subscribe-to-events-with-webhooks) `deployment.status_changed` event reports. This page is the canonical reference for **what each status means, what moves a deployment between them, and which ones are final**.
+
+The status is computed by the [reconciler](/documentation/concepts/reconciliation): on every tick it observes the runtime, applies the desired state, and writes back the resulting status. A `deployment.status_changed` event is emitted whenever a tick lands the deployment on a different status than it had before.
+
+## The fourteen statuses
+
+All values serialize as `snake_case`, identically on the wire (JSON), in the CLI output, and in the SQLite `deployment.status` column.
+
+### Lifecycle states
+
+| Status | Meaning |
+|---|---|
+| `pending` | Created in the database, no container/VM started yet. Short-lived — the next tick moves it to `creating`. Rarely observed. |
+| `creating` | The runtime is bringing instances up. Also the state a worker is **held in by the readiness gate** (see below) until its readiness checks are green. |
+| `running` | Up and — when readiness checks are declared — **actually ready** (serving). Without readiness checks, `running` means simply "the container/VM is up". For a job, a transient state on the way to `completed`/`failed`. |
+| `completed` | **Jobs only.** The one-shot task exited `0` (or, on Cloud Hypervisor, the guest shut down cleanly). **Terminal.** |
+| `deleted` | Marked for teardown (via `DELETE /deployments/{id}` / `ring deployment delete`). The reconciler removes every instance, then purges the row. |
+
+### Failure states
+
+| Status | Cause | Terminal? |
+|---|---|---|
+| `failed` | A job exited non-zero / crashed; **or** a readiness check never turned green before the deadline on a non-rolling deployment; **or** (Cloud Hypervisor) firmware not found. | **Terminal** |
+| `crash_loop_back_off` | A worker's container/VM kept dying and `restart_count` reached `MAX_RESTART_COUNT` (5). The reconciler stops trying. | **Terminal** |
+| `insufficient_resources` | The host doesn't have enough memory for the deployment's request. A retry can't conjure RAM, so Ring stops. | **Terminal** |
+| `image_pull_back_off` | The image couldn't be pulled (tag not found, registry auth, `image_pull_policy: Never` forbidding a pull, transient network). | Retried |
+| `create_container_error` | The runtime rejected container creation (invalid mount, unsupported option, a port conflict the daemon surfaces at create time). | Retried |
+| `network_error` | Creating the namespace network/bridge failed. | Retried |
+| `config_error` | A mounted config — or a key within it — doesn't exist in the namespace. | Retried |
+| `file_system_error` | An IO error handling volumes or temp config files. | Retried |
+| `error` | Generic runtime fallback: a stats fetch, a JSON parse, a VM-start failure, or any error not classified above. | Retried |
+
+**Terminal vs retried.** A *terminal* status is never reconciled again — the deployment is done. A *retried* failure status stays in the reconcile loop: each tick re-attempts the apply, bumping `restart_count`, until either it succeeds (back to `creating` → `running`) or the counter hits `MAX_RESTART_COUNT` and a worker flips to `crash_loop_back_off`. The reconciler explicitly polls `pending`, `creating`, `running`, `deleted`, and the five *retried* error states; `completed`, `failed`, `crash_loop_back_off`, and `insufficient_resources` are left out on purpose.
+
+> **Recover from a terminal or stuck state** by re-applying a fixed manifest: `ring apply` resets `restart_count` and re-enters the lifecycle from the top. The restart counter is cumulative over the deployment's lifetime, not a sliding window.
+
+## Worker lifecycle
+
+A `kind: worker` is a long-running service the reconciler keeps at exactly `replicas` instances.
+
+```
+pending → creating ──────────────→ running ──→ (stays running, reconciled each tick)
+              │     (gate: ready)      │
+              │                        ├──→ deleted              (you delete it)
+              │←── readiness not green │
+              │    (held here)         └──→ crash_loop_back_off  (restart_count ≥ 5)
+              │
+              └──→ image_pull_back_off / create_container_error / network_error /
+                   config_error / file_system_error / error   (retried; → crash_loop_back_off
+                   after MAX_RESTART_COUNT, or → running once resolved)
+
+              insufficient_resources  (terminal — host out of memory)
+```
+
+- **`creating → running`** happens as soon as the container/VM is up **unless** the deployment declares a `readiness: true` health check — then the [readiness gate](#the-readiness-gate) holds it in `creating` until ready.
+- **`running` is stable.** A liveness check failure doesn't move the status; it triggers the check's `on_failure` action (`restart` removes the instance and the reconciler recreates it; `stop` marks the deployment `deleted`; `alert` only emits an event). The status is *not* dragged back to `creating` once `running` is established.
+- A worker never reaches `completed` — that status is jobs-only.
+
+## Job lifecycle
+
+A `kind: job` runs one instance to completion (`replicas` is ignored).
+
+```
+pending → creating → running ──→ completed   (exit 0 / clean guest shutdown)
+                          │
+                          ├──→ failed         (non-zero exit, OOM, signal, host-side timeout)
+                          └──→ failed         (restart_count ≥ MAX_RESTART_COUNT)
+```
+
+- On Cloud Hypervisor the host can't read the guest's exit code, so any clean VM shutdown is `completed`. Use a worker if you need precise exit-code semantics on CH.
+- **Jobs are exempt from the readiness gate** — they go straight to `completed`/`failed` and never sit in a readiness-gated `running`.
+
+## The readiness gate
+
+A worker that declares at least one `readiness: true` health check stays in `creating` until **every** readiness check has been `success` for its `min_healthy_time` (default 10s, anti-flap). Only then does it become `running`. This makes `running` mean *the app is serving*, not merely *the process started* — which is what makes the `deployment.status_changed → running` event trustworthy for an external subscriber waiting to know a deploy is done.
+
+While in `creating`, only the readiness checks run (recorded for the gate to read); they do **not** fire `on_failure` actions — a probe that isn't green yet during boot isn't a failure. Liveness checks start only once the deployment is `running`.
+
+**Deadline.** A *simple* deployment (no rolling-update parent) whose readiness never turns green would otherwise sit in `creating` forever. Past `RING_ROLLOUT_DEADLINE` (default 600s — the same knob as the rolling-update drain, mirroring Kubernetes' `progressDeadlineSeconds`) Ring marks it `failed` with a `readiness_deadline_exceeded` event. A rolling-update *child* is exempt here: its deadline is the forced parent drain (the old version keeps serving), described in [Reconciliation → rolling updates](/documentation/concepts/reconciliation#rolling-updates).
+
+Without any readiness check, the legacy behaviour is preserved: `running` as soon as the container is up. See [Health checks (design) → the readiness gate](/documentation/concepts/health-checks-design#the-readiness-gate) for the full mechanics.
+
+## Restart counter and `crash_loop_back_off`
+
+Ring tracks a cumulative `restart_count` per deployment. It is bumped when:
+
+- A worker's container dies unexpectedly (Docker `die`/`oom`/`kill` events, or a CH VM going unresponsive) — unless the shutdown was intentional (a delete/scale-down).
+- A *retried* error status re-attempts its apply and fails again.
+
+Once `restart_count` reaches `MAX_RESTART_COUNT` (5), the next tick flips a **worker** to `crash_loop_back_off` (terminal) and a **job** to `failed` (terminal) — the reconciler stops retrying, protecting the host from a tight crash loop. The counter is **cumulative for the deployment's lifetime**, not a sliding window; `ring apply` with a fixed manifest resets it.
+
+Counters live in memory only — restarting `ring server` clears them, so each `(deployment, instance, check)` triple starts back at zero after a server restart.
+
+## Observing the status
+
+- **API** — `GET /deployments` and `GET /deployments/{id}` return the `status` field; filter with `GET /deployments?status=<value>`. See [API reference → Deployments](/documentation/reference/api#deployments).
+- **CLI** — `ring deployment list` shows a `Status` column; `--status <value>` (repeatable) filters. See [CLI reference](/documentation/reference/cli#ring-deployment-list).
+- **Events** — `ring deployment events <id>` shows the per-transition history (state changes, health-check actions, error reasons like `image_pull_back_off` or `readiness_deadline_exceeded`).
+- **Webhooks** — subscribe to `deployment.status_changed` to be pushed every transition (`old_status` → `new_status`) instead of polling. See [Subscribe to events with webhooks](/documentation/how-to/subscribe-to-events-with-webhooks).
+
+## See also
+
+- [Reconciliation](/documentation/concepts/reconciliation) — the loop that computes these statuses
+- [Health checks (design)](/documentation/concepts/health-checks-design) — readiness vs liveness, the gate
+- [Troubleshooting](/documentation/help/troubleshooting) — what to do when a deployment is stuck in `creating`, `deleted`, `image_pull_back_off`, `crash_loop_back_off`, or `insufficient_resources`
+- [Subscribe to events with webhooks](/documentation/how-to/subscribe-to-events-with-webhooks) — push status changes to an endpoint

--- a/documentation/concepts/health-checks-design.md
+++ b/documentation/concepts/health-checks-design.md
@@ -168,4 +168,5 @@ A few rules of thumb that hold up in practice:
 - [How-to: configure health checks](/documentation/how-to/configure-health-checks) — setup recipes and patterns
 - [How-to: perform a rolling update](/documentation/how-to/perform-rolling-update) — the operator's view
 - [Reconciliation](/documentation/concepts/reconciliation) — the loop that runs the probes
+- [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle) — how readiness gates the `running` status
 - [Manifest reference: `health_checks`](/documentation/reference/manifest#health-checks)

--- a/documentation/concepts/health-checks-design.md
+++ b/documentation/concepts/health-checks-design.md
@@ -62,9 +62,18 @@ Pick `restart` unless you have a specific reason not to. `stop` and `alert` are 
 
 ## The readiness gate
 
-By default Ring drains the parent deployment as soon as the new child container reaches `Running`. That's fast, but ignores application-level boot time (warmup, migrations, cache priming).
+`readiness: true` makes a check gate two things:
 
-Mark a check as `readiness: true` to gate the drain on real readiness:
+1. **The deployment's own `Running` status** — a deployment with at least one readiness check stays `Creating` until every readiness check has been green for `min_healthy_time`. `Running` then means *the app is actually serving*, not merely *the container started*. This is what makes the `deployment.status_changed → running` event trustworthy for external subscribers. A deployment with **no** readiness check keeps the legacy behaviour: `Running` as soon as the container is up.
+2. **The rolling-update drain** — during an update, Ring drains the old (parent) deployment only once the new (child) deployment's readiness gate has opened.
+
+Readiness probes are evaluated even while a deployment is `Creating` (readiness-only, record-only: no `on_failure` action fires during boot — a probe that isn't green yet isn't a failure). Liveness checks run only once `Running`.
+
+**Deadline.** A simple deployment whose readiness never turns green would otherwise sit in `Creating` forever. Past `RING_ROLLOUT_DEADLINE` (default 600s — the same knob as the rolling-update drain, mirroring Kubernetes' `progressDeadlineSeconds`) Ring marks it `failed` with a `readiness_deadline_exceeded` event. A rolling-update child is exempt: its deadline is the forced parent drain below, which keeps the old version serving.
+
+By default (no readiness check) Ring drains the parent deployment as soon as the new child container reaches `Running`. That's fast, but ignores application-level boot time (warmup, migrations, cache priming).
+
+Mark a check as `readiness: true` to gate on real readiness:
 
 ```yaml
 health_checks:
@@ -150,7 +159,7 @@ A few rules of thumb that hold up in practice:
 - **`interval` is advisory** (see above)
 - **Counters are in memory** — server restart resets them
 - **No per-instance disable** — can't pause probes on one container for debugging
-- **No startup delay / grace period** — slow-booting services must absorb cold-start failures within `threshold`. A future `start_period` field is on the roadmap.
+- **No per-probe startup delay** — slow-booting services must absorb cold-start failures within `threshold`. A readiness check does give a deployment-level grace period (it stays `Creating` until green, up to `RING_ROLLOUT_DEADLINE`), but there's no per-check `start_period` / `initialDelaySeconds` yet; it's on the roadmap.
 - **Cloud Hypervisor `command`** requires the in-guest `ring-agent` daemon
 - **Duration suffixes:** only `ms` and `s` parse. `1m` does not — write `60s`.
 

--- a/documentation/concepts/reconciliation.md
+++ b/documentation/concepts/reconciliation.md
@@ -28,6 +28,8 @@ The reconciler treats `kind: worker` and `kind: job` differently.
 
 A long-running service. The reconciler keeps **exactly `replicas` instances alive**. If a container crashes or you delete it manually, the next tick recreates it. Updating the manifest triggers a rolling update (if health checks are declared) or an immediate replacement.
 
+A worker reaches `running` as soon as its container is up — **unless** it declares a `readiness: true` check, in which case it stays `creating` until that check is green (see [Health checks: the readiness gate](/documentation/concepts/health-checks-design#the-readiness-gate)). A readiness check that never turns green fails the deployment after `RING_ROLLOUT_DEADLINE` (default 600s).
+
 ### Job
 
 A one-shot task. The reconciler boots **one** instance (`replicas` is ignored), waits for it to exit, and records the result:

--- a/documentation/concepts/reconciliation.md
+++ b/documentation/concepts/reconciliation.md
@@ -30,6 +30,8 @@ A long-running service. The reconciler keeps **exactly `replicas` instances aliv
 
 A worker reaches `running` as soon as its container is up — **unless** it declares a `readiness: true` check, in which case it stays `creating` until that check is green (see [Health checks: the readiness gate](/documentation/concepts/health-checks-design#the-readiness-gate)). A readiness check that never turns green fails the deployment after `RING_ROLLOUT_DEADLINE` (default 600s).
 
+For the full set of statuses a deployment can hold, what moves it between them, and which are terminal, see [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle).
+
 ### Job
 
 A one-shot task. The reconciler boots **one** instance (`replicas` is ignored), waits for it to exit, and records the result:

--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -106,6 +106,8 @@ Ring binds to its detected local IP by default (e.g. `192.168.1.x`), not `localh
 
 ## Deployment problems
 
+> For what each deployment status means and how a deployment moves between them, see [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle).
+
 ### Stuck in `creating`
 
 Look at the events first:

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -130,6 +130,7 @@ Once you're past the basics, pick a [how-to guide](#how-to-guides) for the speci
 **Concepts** — how Ring works internally
 - [Architecture](/documentation/concepts/architecture)
 - [Reconciliation](/documentation/concepts/reconciliation)
+- [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle)
 - [Runtimes](/documentation/concepts/runtimes)
 - [Namespaces and networking](/documentation/concepts/namespaces-and-networking)
 - [Secrets and encryption](/documentation/concepts/secrets-encryption)

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -105,8 +105,27 @@ List deployments.
 **Query parameters:**
 
 - `namespace` or `namespace[]` — filter by one or more namespaces
-- `status` or `status[]` — filter by one or more statuses
+- `status` or `status[]` — filter by one or more statuses (values below)
 - `kind` or `kind[]` — filter by `worker` or `job` (the CLI flag `--type` maps to this)
+
+**`status` values.** The `status` field on every deployment is one of these (all `snake_case`). See [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle) for transitions and meaning.
+
+| Status | Meaning | Terminal? |
+|---|---|---|
+| `pending` | Created, no instance started yet (short-lived) | No |
+| `creating` | Instances coming up — or held by the readiness gate until ready | No |
+| `running` | Up, and ready when readiness checks are declared | No |
+| `completed` | Job exited `0` (jobs only) | Yes |
+| `failed` | Job failed, or readiness deadline exceeded, or firmware not found | Yes |
+| `deleted` | Marked for teardown; instances being removed, then purged | No |
+| `crash_loop_back_off` | Worker hit `MAX_RESTART_COUNT` (5) restarts | Yes |
+| `image_pull_back_off` | Image couldn't be pulled (tag, auth, policy, network) | No (retried) |
+| `create_container_error` | Runtime rejected container creation | No (retried) |
+| `network_error` | Namespace network/bridge creation failed | No (retried) |
+| `config_error` | A mounted config or key doesn't exist | No (retried) |
+| `file_system_error` | IO error on volumes or temp config files | No (retried) |
+| `insufficient_resources` | Host out of memory for the deployment's request | Yes |
+| `error` | Generic runtime fallback (stats, JSON, VM start, unclassified) | No (retried) |
 
 **Examples:**
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -138,7 +138,7 @@ ring deployment list [OPTIONS]
 **Options:**
 
 - `-n` / `--namespace <NAMESPACE>` — filter by namespace
-- `-s` / `--status <STATUS>` — filter by status (repeatable)
+- `-s` / `--status <STATUS>` — filter by status (repeatable). Values: `pending`, `creating`, `running`, `completed`, `failed`, `deleted`, `crash_loop_back_off`, `image_pull_back_off`, `create_container_error`, `network_error`, `config_error`, `file_system_error`, `insufficient_resources`, `error` — see [Deployment status lifecycle](/documentation/concepts/deployment-status-lifecycle)
 - `--type <TYPE>` — filter by deployment kind: `worker` or `job`
 - `-l` / `--label <SELECTOR>` — filter by label, `key=value` or just `key` (repeatable; a deployment must match **all** selectors). Works the same across runtimes (Docker and Cloud Hypervisor) since labels are matched on Ring's stored metadata.
 - `-o` / `--output <FORMAT>` — `table` (default) or `json`

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -43,12 +43,34 @@ impl HealthChecker {
             instances_to_remove: Vec::new(),
         };
 
-        if deployment.status != DeploymentStatus::Running {
-            return outcome;
-        }
+        // Checks run in two phases of a deployment's life:
+        //
+        // - `Running`: the full set runs (readiness + liveness) and failures
+        //   drive the `on_failure` actions (restart / stop / alert). This is
+        //   the established behaviour.
+        // - `Creating`: only `readiness: true` checks run, and purely to
+        //   *record results* — they feed the readiness gate that decides when
+        //   the deployment may enter `Running` (see
+        //   `scheduler::gate_running_on_readiness`). A readiness probe that
+        //   isn't green yet during boot is not a failure, so we never touch the
+        //   failure counter or fire `on_failure` here.
+        //
+        // Jobs never run health checks: they go straight to
+        // `completed`/`failed` and never sit in a readiness-gated `Running`.
+        let creating_phase = match deployment.status {
+            DeploymentStatus::Running => false,
+            DeploymentStatus::Creating if deployment.kind != "job" => true,
+            _ => return outcome,
+        };
 
         for instance_id in &deployment.instances {
             for (hc_index, health_check) in deployment.health_checks.iter().enumerate() {
+                // During `Creating` only the readiness checks are relevant; a
+                // liveness probe has no meaning before the app is ready.
+                if creating_phase && !health_check.is_readiness() {
+                    continue;
+                }
+
                 let result = self
                     .execute_single_check_with_runtime(
                         runtime,
@@ -58,26 +80,30 @@ impl HealthChecker {
                     )
                     .await;
 
-                let key = format!("{}:{}:{}", deployment.id, instance_id, hc_index);
-                if matches!(
-                    result.status,
-                    HealthCheckStatus::Failed | HealthCheckStatus::Timeout
-                ) {
-                    let should_trigger_action = self
-                        .increment_failure_count(&key, health_check.threshold())
-                        .await;
-                    if should_trigger_action {
-                        self.handle_failure(
-                            &mut outcome,
-                            deployment,
-                            health_check,
-                            &result,
-                            instance_id,
-                        );
+                // In the creating phase we only persist the result for the
+                // gate to read; no failure counting, no `on_failure` action.
+                if !creating_phase {
+                    let key = format!("{}:{}:{}", deployment.id, instance_id, hc_index);
+                    if matches!(
+                        result.status,
+                        HealthCheckStatus::Failed | HealthCheckStatus::Timeout
+                    ) {
+                        let should_trigger_action = self
+                            .increment_failure_count(&key, health_check.threshold())
+                            .await;
+                        if should_trigger_action {
+                            self.handle_failure(
+                                &mut outcome,
+                                deployment,
+                                health_check,
+                                &result,
+                                instance_id,
+                            );
+                            self.reset_failure_count(&key).await;
+                        }
+                    } else {
                         self.reset_failure_count(&key).await;
                     }
-                } else {
-                    self.reset_failure_count(&key).await;
                 }
 
                 outcome.results.push(result);
@@ -592,5 +618,130 @@ mod tests {
         assert_eq!(row.1, "test-persist");
         assert_eq!(row.2, "tcp");
         assert_eq!(row.3, "success");
+    }
+
+    // ---- creating-phase readiness probing ----
+
+    fn readiness_tcp() -> HealthCheck {
+        HealthCheck::Tcp {
+            port: 80,
+            interval: "5s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 1,
+            on_failure: FailureAction::Restart,
+            readiness: true,
+            min_healthy_time: None,
+        }
+    }
+
+    fn liveness_tcp() -> HealthCheck {
+        HealthCheck::Tcp {
+            port: 9999,
+            interval: "5s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 1,
+            on_failure: FailureAction::Restart,
+            readiness: false,
+            min_healthy_time: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_checks_run_during_creating() {
+        // In `Creating`, a readiness check still runs so the gate has data to
+        // read — even though the deployment isn't `Running` yet.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::healthy();
+
+        let mut deployment = make_deployment(
+            "creating-readiness",
+            vec!["instance-1".to_string()],
+            vec![readiness_tcp()],
+        );
+        deployment.status = DeploymentStatus::Creating;
+
+        let outcome = checker.execute_checks(&deployment, &runtime).await;
+
+        assert_eq!(outcome.results.len(), 1);
+        assert!(matches!(
+            outcome.results[0].status,
+            HealthCheckStatus::Success
+        ));
+    }
+
+    #[tokio::test]
+    async fn liveness_checks_skipped_during_creating() {
+        // In `Creating`, only readiness checks run; the liveness check is
+        // skipped (it has no meaning before the app is ready). With a failing
+        // runtime, the readiness result is recorded but no action fires.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::unhealthy("connection refused");
+
+        let mut deployment = make_deployment(
+            "creating-mixed",
+            vec!["instance-1".to_string()],
+            vec![readiness_tcp(), liveness_tcp()],
+        );
+        deployment.status = DeploymentStatus::Creating;
+
+        let outcome = checker.execute_checks(&deployment, &runtime).await;
+
+        // Only the readiness check ran (one result), the liveness was skipped.
+        assert_eq!(outcome.results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn creating_failures_do_not_trigger_actions() {
+        // A readiness probe that fails during boot is not a failure to act on:
+        // the result is recorded but no restart/stop is proposed.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::unhealthy("connection refused");
+
+        let mut deployment = make_deployment(
+            "creating-fail",
+            vec!["instance-1".to_string()],
+            vec![readiness_tcp()],
+        );
+        deployment.status = DeploymentStatus::Creating;
+
+        let outcome = checker.execute_checks(&deployment, &runtime).await;
+
+        assert_eq!(outcome.results.len(), 1);
+        assert!(matches!(
+            outcome.results[0].status,
+            HealthCheckStatus::Failed
+        ));
+        assert!(
+            outcome.instances_to_remove.is_empty(),
+            "no restart during creating"
+        );
+        assert!(
+            outcome.events.is_empty(),
+            "no on_failure events during creating"
+        );
+        assert!(outcome.proposed_status.is_none());
+    }
+
+    #[tokio::test]
+    async fn jobs_skip_health_checks_during_creating() {
+        // Jobs never gate on readiness; they go straight to completed/failed.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::healthy();
+
+        let mut deployment = make_deployment(
+            "creating-job",
+            vec!["instance-1".to_string()],
+            vec![readiness_tcp()],
+        );
+        deployment.status = DeploymentStatus::Creating;
+        deployment.kind = "job".to_string();
+
+        let outcome = checker.execute_checks(&deployment, &runtime).await;
+
+        assert!(outcome.results.is_empty(), "jobs run no checks in creating");
     }
 }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -244,25 +244,48 @@ async fn handle_status_transitions(
             "Deployment {} transition: creating -> running",
             deployment.id
         );
-        if let Err(e) = deployment_event::log_event(
-            pool,
-            deployment.id.clone(),
-            "info",
-            format!(
-                "Status changed from creating to running ({} containers)",
-                deployment.instances.len()
-            ),
-            "scheduler",
-            Some("state_transition"),
-        )
-        .await
-        {
-            warn!(
-                "Failed to log state transition event for deployment {}: {}",
-                deployment.id, e
-            );
-        }
+        // NB: the `state_transition` event is NOT logged here. The readiness
+        // gate (`gate_running_on_readiness`) may revert this `Running` back to
+        // `Creating` later in the same cycle, so emitting the event now would
+        // persist a "creating -> running" event for a status that never gets
+        // persisted. The event is emitted once, after the gate, by
+        // `log_running_transition` — keyed on the status actually written.
         deployment.status = DeploymentStatus::Running;
+    }
+}
+
+/// Emit the `creating -> running` `state_transition` event, but only once the
+/// status that survives the whole cycle (after the readiness gate) is really
+/// `Running`. Called at the end of the cycle, after `gate_running_on_readiness`
+/// — never before — so the event never lies: a deployment the gate holds back
+/// in `Creating` produces no event, matching the lifecycle contract that a
+/// `status_changed` event fires only when a tick lands on a *different* status.
+async fn log_running_transition(
+    pool: &SqlitePool,
+    old_status: &DeploymentStatus,
+    deployment: &Deployment,
+) {
+    if *old_status != DeploymentStatus::Creating || deployment.status != DeploymentStatus::Running {
+        return;
+    }
+
+    if let Err(e) = deployment_event::log_event(
+        pool,
+        deployment.id.clone(),
+        "info",
+        format!(
+            "Status changed from creating to running ({} containers)",
+            deployment.instances.len()
+        ),
+        "scheduler",
+        Some("state_transition"),
+    )
+    .await
+    {
+        warn!(
+            "Failed to log state transition event for deployment {}: {}",
+            deployment.id, e
+        );
     }
 }
 
@@ -272,7 +295,18 @@ async fn run_health_checks(
     health_checker: &HealthChecker,
     runtime: &dyn RuntimeLifecycle,
 ) {
-    if deployment.status != DeploymentStatus::Running || deployment.health_checks.is_empty() {
+    // Health checks run in `Running` (full set, drives `on_failure`) and, for
+    // readiness gating, in `Creating` (readiness-only, record-only — see
+    // `HealthChecker::execute_checks`). `execute_checks` enforces the
+    // readiness-only / no-action rules for the creating phase; here we just
+    // let the call through for both statuses. Jobs never gate, so skip them in
+    // `Creating`.
+    let runnable = match deployment.status {
+        DeploymentStatus::Running => true,
+        DeploymentStatus::Creating => deployment.kind != "job",
+        _ => false,
+    };
+    if !runnable || deployment.health_checks.is_empty() {
         return;
     }
 
@@ -391,22 +425,32 @@ fn rollout_deadline_exceeded(child: &Deployment) -> bool {
     (chrono::Utc::now() - created).num_seconds() >= deadline_secs
 }
 
-/// True when the child either has no readiness HC at all (legacy behaviour)
-/// or all of its readiness HCs have been green for the configured anti-flap
-/// window.
-async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
+/// Evaluate the readiness state of a deployment from its recorded health-check
+/// results. The single source of truth for "are this deployment's readiness
+/// checks green?", shared by the rolling-update drain gate
+/// ([`is_ready_to_drain`]) and the status gate ([`gate_running_on_readiness`]).
+///
+/// Returns [`ReadinessDecision::NotConfigured`] when no `readiness: true` check
+/// is declared (callers fall back to legacy behaviour), and holds the rollout
+/// (`PendingNoResult` / `PendingMinHealthyTime` / `Failing`) on any DB error so
+/// a transient read failure never falsely reports "ready".
+async fn readiness_decision(
+    pool: &SqlitePool,
+    deployment: &Deployment,
+) -> crate::models::health_check::ReadinessDecision {
     use crate::models::health_check::{ReadinessDecision, evaluate_readiness};
 
-    let expected = child
+    let expected = deployment
         .health_checks
         .iter()
         .filter(|hc| hc.is_readiness())
         .count();
 
     if expected == 0 {
-        // No readiness HC declared — legacy "drain on Running" semantics.
-        return true;
+        return ReadinessDecision::NotConfigured;
     }
+
+    let child = deployment;
 
     // We need two things per check_type: (1) the latest status, to detect
     // Failing / PendingNoResult; (2) the **ready-since** timestamp, i.e. the
@@ -417,10 +461,10 @@ async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
         Ok(rows) => rows,
         Err(e) => {
             warn!(
-                "Failed to load readiness check results for deployment {}: {} — holding rollout",
+                "Failed to load readiness check results for deployment {}: {} — holding",
                 child.id, e
             );
-            return false;
+            return ReadinessDecision::PendingNoResult;
         }
     };
     let ready_since =
@@ -428,10 +472,10 @@ async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
             Ok(rows) => rows,
             Err(e) => {
                 warn!(
-                    "Failed to load ready-since timestamps for deployment {}: {} — holding rollout",
+                    "Failed to load ready-since timestamps for deployment {}: {} — holding",
                     child.id, e
                 );
-                return false;
+                return ReadinessDecision::PendingNoResult;
             }
         };
 
@@ -492,11 +536,17 @@ async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
     }
 
     let min_healthy_time = min_healthy_time_for(child);
-    let decision = evaluate_readiness(expected, &filtered, chrono::Utc::now(), min_healthy_time);
+    evaluate_readiness(expected, &filtered, chrono::Utc::now(), min_healthy_time)
+}
 
-    match decision {
-        ReadinessDecision::Ready => true,
-        ReadinessDecision::NotConfigured => true, // expected == 0 case, defensive.
+/// True when the child either has no readiness HC at all (legacy behaviour)
+/// or all of its readiness HCs have been green for the configured anti-flap
+/// window. Thin wrapper over [`readiness_decision`].
+async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
+    use crate::models::health_check::ReadinessDecision;
+
+    match readiness_decision(pool, child).await {
+        ReadinessDecision::Ready | ReadinessDecision::NotConfigured => true,
         ReadinessDecision::PendingNoResult => {
             debug!(
                 "Rolling update on hold for {}: still waiting for first readiness check result",
@@ -517,6 +567,83 @@ async fn is_ready_to_drain(pool: &SqlitePool, child: &Deployment) -> bool {
                 child.id
             );
             false
+        }
+    }
+}
+
+/// Gate the `creating → running` transition on readiness.
+///
+/// The runtimes flip a deployment to `Running` as soon as the container exists
+/// (Docker/CH `apply`), and the secondary transition in
+/// `handle_status_transitions` does the same. That only means "the process
+/// started" — not "the app is ready". When a deployment declares any
+/// `readiness: true` check, we hold it in `Creating` until those checks are
+/// green (readiness probes run during `Creating`, record-only — see
+/// `HealthChecker::execute_checks`), so `Running` means *really ready* and the
+/// `deployment.status_changed → running` event is trustworthy.
+///
+/// Called right after `run_health_checks`, before `handle_rolling_update`, so
+/// the revert is what gets persisted this cycle — the runtime re-proposes
+/// `Running` next tick and we re-decide, converging without ever persisting a
+/// premature `running`.
+///
+/// Scope: only acts when the deployment *just* moved `Creating → Running` this
+/// cycle (`old_status == Creating`), never on an already-established `Running`
+/// (that's the liveness checks' job, not the gate's — avoids flapping). Jobs
+/// are exempt: they go straight to `completed`/`failed`.
+///
+/// Deadline guard (reuses `RING_ROLLOUT_DEADLINE`, default 600s, the same knob
+/// as the rolling-update drain — mirrors Kubernetes `progressDeadlineSeconds`):
+/// a *simple* deployment (no `parent_id`) whose readiness never turns green
+/// would otherwise sit in `Creating` forever, so past the deadline we fail it.
+/// A rolling-update *child* is left alone here — its deadline is the forced
+/// drain in `handle_rolling_update`, which keeps the old version serving.
+async fn gate_running_on_readiness(
+    pool: &SqlitePool,
+    old_status: &DeploymentStatus,
+    deployment: &mut Deployment,
+) {
+    use crate::models::health_check::ReadinessDecision;
+
+    // Only gate a fresh creating → running transition. Jobs never gate.
+    if *old_status != DeploymentStatus::Creating
+        || deployment.status != DeploymentStatus::Running
+        || deployment.kind == "job"
+    {
+        return;
+    }
+
+    match readiness_decision(pool, deployment).await {
+        // No readiness HC, or readiness is green for long enough — let Running
+        // stand.
+        ReadinessDecision::NotConfigured | ReadinessDecision::Ready => {}
+        // Readiness not (yet) green: hold in Creating, unless a simple
+        // deployment has blown past the deadline — then fail it.
+        ReadinessDecision::PendingNoResult
+        | ReadinessDecision::PendingMinHealthyTime { .. }
+        | ReadinessDecision::Failing => {
+            if deployment.parent_id.is_none() && rollout_deadline_exceeded(deployment) {
+                warn!(
+                    "Deployment {} never became ready before the deadline — marking failed (check its readiness probe)",
+                    deployment.id
+                );
+                deployment.status = DeploymentStatus::Failed;
+                let _ = deployment_event::log_event(
+                    pool,
+                    deployment.id.clone(),
+                    "error",
+                    "Readiness never turned green before the deadline; marking the deployment failed. Check the readiness health check.".to_string(),
+                    "scheduler",
+                    Some("readiness_deadline_exceeded"),
+                )
+                .await;
+            } else {
+                debug!(
+                    "Deployment {} held in creating: readiness not green yet",
+                    deployment.id
+                );
+                deployment.status = DeploymentStatus::Creating;
+            }
         }
     }
 }
@@ -1040,6 +1167,11 @@ pub(crate) async fn schedule(
                 }
             };
 
+            // Status as it stood entering this cycle, before the runtime gets
+            // a chance to flip it to `Running`. The readiness gate uses it to
+            // tell a fresh `creating → running` transition (which it may hold)
+            // from an already-established `Running` (which it must not touch).
+            let old_status = deployment.status.clone();
             let restart_count_before = deployment.restart_count;
             let mut result = match apply_runtime(
                 &pool,
@@ -1086,7 +1218,12 @@ pub(crate) async fn schedule(
 
             handle_status_transitions(&pool, &mut result, &mut deleted).await;
             run_health_checks(&pool, &mut result, &health_checker, runtime.as_ref()).await;
+            gate_running_on_readiness(&pool, &old_status, &mut result).await;
             handle_rolling_update(&pool, &mut result, &mut deleted, runtime.as_ref()).await;
+
+            // Log the creating -> running transition only now that the status
+            // for this cycle is settled (the gate above may have reverted it).
+            log_running_transition(&pool, &old_status, &result).await;
 
             if let Err(e) = deployments::update(&pool, &result).await {
                 error!("Failed to update deployment {}: {}", result.id, e);
@@ -1403,5 +1540,155 @@ mod tests {
         insert_hc_result(&pool, "child-7", "command", "success", 30).await;
         // tcp has no result, but it's not a readiness HC, so gate opens.
         assert!(is_ready_to_drain(&pool, &child).await);
+    }
+
+    // ---- gate_running_on_readiness ----
+
+    /// A simple (non-child) worker that just transitioned to `Running` this
+    /// cycle — the exact case the gate inspects. `parent_id = None` so the
+    /// deadline path marks it `Failed` rather than deferring to rolling-update.
+    fn simple_running(id: &str, hcs: Vec<HealthCheck>) -> Deployment {
+        let mut d = child_with_health_checks(id, hcs);
+        d.kind = "worker".to_string();
+        d.parent_id = None;
+        d.status = DeploymentStatus::Running;
+        d
+    }
+
+    #[tokio::test]
+    async fn gate_keeps_running_when_no_readiness_hc() {
+        // Liveness-only → legacy "running on container up", gate is a no-op.
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-1", vec![liveness_command()]);
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn gate_reverts_to_creating_when_readiness_no_result_yet() {
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-2", vec![readiness_command("ready")]);
+        // No recorded result yet — not ready, hold in creating.
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Creating);
+    }
+
+    #[tokio::test]
+    async fn gate_reverts_to_creating_when_readiness_too_recent() {
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-3", vec![readiness_command("ready")]);
+        // Green only 5s ago, anti-flap default is 10s → still holding.
+        insert_hc_result(&pool, "gate-3", "command", "success", 5).await;
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Creating);
+    }
+
+    #[tokio::test]
+    async fn gate_keeps_running_when_readiness_green_long_enough() {
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-4", vec![readiness_command("ready")]);
+        insert_hc_result(&pool, "gate-4", "command", "success", 30).await;
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn gate_reverts_when_readiness_failing() {
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-5", vec![readiness_command("ready")]);
+        insert_hc_result(&pool, "gate-5", "command", "success", 60).await;
+        insert_hc_result(&pool, "gate-5", "command", "failed", 5).await;
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Creating);
+    }
+
+    #[tokio::test]
+    async fn gate_ignores_already_running() {
+        // old_status == Running: an established deployment whose readiness is
+        // now red must NOT be dragged back to creating — that's the liveness
+        // checks' job. The gate only acts on a fresh creating → running.
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-6", vec![readiness_command("ready")]);
+        // No result → would be "not ready", but old_status is Running.
+        gate_running_on_readiness(&pool, &DeploymentStatus::Running, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn gate_does_not_touch_jobs() {
+        // Jobs go straight to completed/failed and never gate on readiness.
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-7", vec![readiness_command("ready")]);
+        d.kind = "job".to_string();
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn gate_fails_simple_deployment_after_deadline() {
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-8", vec![readiness_command("ready")]);
+        // Created 20 minutes ago, readiness never green → past the deadline.
+        d.created_at = (chrono::Utc::now() - chrono::Duration::seconds(1200)).to_string();
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn gate_does_not_fail_child_after_deadline() {
+        // A rolling-update child past the deadline is left in creating here —
+        // its deadline is the forced drain in handle_rolling_update, which
+        // keeps the old version serving. Never fail a child from the gate.
+        let pool = new_test_pool().await;
+        let mut d = simple_running("gate-9", vec![readiness_command("ready")]);
+        d.parent_id = Some("parent-id".to_string());
+        d.created_at = (chrono::Utc::now() - chrono::Duration::seconds(1200)).to_string();
+        gate_running_on_readiness(&pool, &DeploymentStatus::Creating, &mut d).await;
+        assert_eq!(d.status, DeploymentStatus::Creating);
+    }
+
+    // ---- log_running_transition ----
+
+    /// Count the `state_transition` events recorded for a deployment.
+    async fn count_state_transition_events(pool: &SqlitePool, deployment_id: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM deployment_event \
+             WHERE deployment_id = ? AND reason = 'state_transition'",
+        )
+        .bind(deployment_id)
+        .fetch_one(pool)
+        .await
+        .expect("count state_transition events")
+    }
+
+    #[tokio::test]
+    async fn running_transition_logged_when_status_lands_on_running() {
+        // The honest case: entered the cycle in Creating, the runtime flipped to
+        // Running, and the gate left it Running → exactly one event.
+        let pool = new_test_pool().await;
+        let d = simple_running("trans-1", vec![]);
+        log_running_transition(&pool, &DeploymentStatus::Creating, &d).await;
+        assert_eq!(count_state_transition_events(&pool, "trans-1").await, 1);
+    }
+
+    #[tokio::test]
+    async fn running_transition_not_logged_when_gate_reverts_to_creating() {
+        // The bug this fixes: the runtime proposed Running, the gate reverted to
+        // Creating. No event must be persisted — `running` never happened.
+        let pool = new_test_pool().await;
+        let mut d = simple_running("trans-2", vec![readiness_command("ready")]);
+        d.status = DeploymentStatus::Creating; // gate reverted it this cycle
+        log_running_transition(&pool, &DeploymentStatus::Creating, &d).await;
+        assert_eq!(count_state_transition_events(&pool, "trans-2").await, 0);
+    }
+
+    #[tokio::test]
+    async fn running_transition_not_logged_for_already_running() {
+        // Entered the cycle already Running → not a fresh transition, no event
+        // (otherwise every tick of a healthy deployment would re-log it).
+        let pool = new_test_pool().await;
+        let d = simple_running("trans-3", vec![]);
+        log_running_transition(&pool, &DeploymentStatus::Running, &d).await;
+        assert_eq!(count_state_transition_events(&pool, "trans-3").await, 0);
     }
 }

--- a/tests/e2e/cloud-hypervisor/t19_readiness_rolling_update.sh
+++ b/tests/e2e/cloud-hypervisor/t19_readiness_rolling_update.sh
@@ -12,9 +12,14 @@
 #      design question.
 #   B. Without `readiness: true`, the legacy "drain on Running" behaviour
 #      must be preserved on CH too.
-#   C. With `readiness: true` and a probe that cannot succeed (TCP to a
-#      closed port — Cirros has no listening service), the parent VM stays
-#      alive: the gate holds the rollout.
+#   C. Parent v1 WITHOUT readiness reaches `running` normally. Child v2
+#      WITH readiness:true (TCP probe against a closed port) stays in
+#      `creating` forever and therefore never triggers the drain gate on
+#      the parent. This proves `is_ready_to_drain` runs on the CH runtime
+#      and that a non-ready child keeps the parent alive. A guest image
+#      that can expose a listening service is required to test the
+#      "gate opens → parent drained" path (scenario D in the Docker t22);
+#      that is deferred to the Packer/Alpine roadmap item.
 #   D. (Docker only) Flipping the readiness probe to success drains the
 #      parent. Reproducing this on CH needs a guest image that ships a
 #      controllable service — not possible with Cirros. The same code path
@@ -140,12 +145,20 @@ wait_deployment_drained "$B_CHILD" 60
 log "Scenario B: PASS"
 
 ###############################################################################
-# Scenario C — readiness:true + TCP probe failing → parent stays alive.
+# Scenario C — parent without readiness (running), child with readiness:true
+#              and a permanently-failing TCP probe → parent NOT drained.
+#
+# Cirros cannot expose a listening service, so we cannot make the child's
+# readiness probe succeed. Instead the parent is deployed WITHOUT readiness
+# (reaches `running` immediately), then we roll to a child WITH readiness
+# pointing at a closed port. The child stays `creating` forever, which is
+# exactly why `is_ready_to_drain` returns false and the parent stays alive.
 ###############################################################################
-log "-- Scenario C: readiness HC failing → parent NOT drained"
+log "-- Scenario C: child readiness HC failing → parent NOT drained"
 
 FIXTURE_C1="$RING_TEST_DIR/ready-C1.yaml"
-write_fixture "$FIXTURE_C1" "$IMG_V1" yes
+# Parent has NO readiness check → reaches `running` the legacy way.
+write_fixture "$FIXTURE_C1" "$IMG_V1" no
 "$RING_BIN" apply --file "$FIXTURE_C1"
 wait_deployment_status "$NS" "ready-vm" "running" 180
 C_PARENT=$(get_deployment_id "$NS" "ready-vm")
@@ -153,20 +166,23 @@ C_PARENT=$(get_deployment_id "$NS" "ready-vm")
 log "C parent id: $C_PARENT"
 
 FIXTURE_C2="$RING_TEST_DIR/ready-C2.yaml"
+# Child HAS readiness:true with a TCP probe to a closed port. It can never
+# become ready → it stays in `creating` indefinitely.
 write_fixture "$FIXTURE_C2" "$IMG_V2" yes
 "$RING_BIN" apply --file "$FIXTURE_C2"
-wait_deployment_by_image "$NS" "ready-vm" "$IMG_V2" "running" 180
+# Wait until the child deployment row exists in `creating` state.
+wait_deployment_by_image "$NS" "ready-vm" "$IMG_V2" "creating" 180
 C_CHILD=$(get_deployment_id_by_image "$NS" "ready-vm" "$IMG_V2")
 [ -z "$C_CHILD" ] && fail "scenario C: no child deployment id"
 [ "$C_PARENT" = "$C_CHILD" ] && fail "scenario C: parent and child share id"
-log "C child id: $C_CHILD"
+log "C child id: $C_CHILD (in creating — as expected)"
 
 # The child's readiness probe targets a closed port in Cirros, so every
 # probe row is `failed`. `is_ready_to_drain` must therefore keep returning
-# false and the parent must stay in the active set. Watch for 30 s — the
+# false and the parent must stay `running`. Watch for 30 s — the
 # anti-flap window is 10 s, so any false-positive drain would surface in
 # the first ~15 s.
-log "watching for 30s — parent VM must stay active while child is not ready"
+log "watching for 30s — parent VM must stay running while child is not ready"
 for i in $(seq 1 30); do
   parent_status=$("$RING_BIN" deployment list --output json 2>/dev/null \
     | jq -r --arg id "$C_PARENT" '.[] | select(.id==$id) | .status')

--- a/tests/e2e/docker/t22_readiness_rolling_update.sh
+++ b/tests/e2e/docker/t22_readiness_rolling_update.sh
@@ -117,7 +117,10 @@ log "-- Scenario A: command readiness HC translates to Docker HEALTHCHECK"
 FIXTURE_A="$RING_TEST_DIR/ready-A.yaml"
 write_fixture "$FIXTURE_A" "nginx:1.25-alpine" yes
 "$RING_BIN" apply --file "$FIXTURE_A"
-wait_deployment_status "$NS" "ready-app" "running" 60
+# With a readiness check and the readiness file missing, the deployment is
+# held in `creating` (its container runs, but it's not "ready") until the file
+# appears — that's the readiness gate on the deployment's own status.
+wait_deployment_status "$NS" "ready-app" "creating" 60
 DEP_A=$(get_deployment_id "$NS" "ready-app")
 [ -z "$DEP_A" ] && fail "no deployment id for scenario A"
 
@@ -139,6 +142,10 @@ wait_docker_health_status "$DEP_A" "unhealthy" 30
 mkdir_cmd='mkdir -p /var/run/kemeter && touch /var/run/kemeter/ready'
 container_exec "$DEP_A" sh -c "$mkdir_cmd"
 wait_docker_health_status "$DEP_A" "healthy" 30
+
+# Once readiness is green for min_healthy_time, the readiness gate opens and
+# the deployment finally reaches `running`.
+wait_deployment_status "$NS" "ready-app" "running" 60
 
 "$RING_BIN" deployment delete "$DEP_A"
 wait_docker_container_gone "$DEP_A" 30
@@ -182,13 +189,16 @@ log "-- Scenario C: readiness HC failing → parent NOT drained"
 FIXTURE_C1="$RING_TEST_DIR/ready-C1.yaml"
 write_fixture "$FIXTURE_C1" "nginx:1.25-alpine" yes
 "$RING_BIN" apply --file "$FIXTURE_C1"
-wait_deployment_status "$NS" "ready-app" "running" 60
+# Held in `creating` until its readiness file exists (gate on own status).
+wait_deployment_status "$NS" "ready-app" "creating" 60
 C_PARENT=$(get_deployment_id "$NS" "ready-app")
 
-# Mark the parent as "ready" so it stays in the active set with a healthy
-# Docker status — this is the realistic state when an upgrade happens.
+# Mark the parent as "ready" so it reaches `running` and stays in the active
+# set with a healthy Docker status — the realistic state when an upgrade
+# happens.
 container_exec "$C_PARENT" sh -c "$mkdir_cmd"
 wait_docker_health_status "$C_PARENT" "healthy" 30
+wait_deployment_status "$NS" "ready-app" "running" 60
 
 # Apply v2 with readiness:true. The new container's readiness file is
 # absent, so /var/run/kemeter/ready does NOT exist — the gate must block
@@ -196,7 +206,9 @@ wait_docker_health_status "$C_PARENT" "healthy" 30
 FIXTURE_C2="$RING_TEST_DIR/ready-C2.yaml"
 write_fixture "$FIXTURE_C2" "nginx:1.26-alpine" yes
 "$RING_BIN" apply --file "$FIXTURE_C2"
-wait_deployment_by_image "$NS" "ready-app" "nginx:1.26-alpine" "running" 90
+# The child's readiness file is absent, so it sits in `creating` (never
+# `running`) — which is also why it can't drain the parent.
+wait_deployment_by_image "$NS" "ready-app" "nginx:1.26-alpine" "creating" 90
 C_CHILD=$(get_deployment_id_by_image "$NS" "ready-app" "nginx:1.26-alpine")
 
 # Sit and watch for 30s. The parent must still have its container at the end.


### PR DESCRIPTION
## Make `running` mean *ready*, not just *started*

Until now a deployment flipped to `running` the moment its container/VM started, regardless of health checks. Readiness checks (`readiness: true`) only gated the **rolling-update drain**, never the deployment's own status. So `running` meant "the process is up", not "the app is serving" — and the `deployment.status_changed → running` event (outbound webhooks) was therefore unreliable for any subscriber that wants to know when a deploy is actually done.

This extends the existing readiness gate to the status itself.

### Behaviour

| Case | Result |
|---|---|
| No `readiness: true` check | `running` as soon as the container is up — **unchanged (legacy)** |
| ≥1 `readiness: true` check | stays `creating` until readiness is green for `min_healthy_time`, then `running` |
| Jobs (`kind: job`) | exempt — go straight to `completed`/`failed`, never gated |
| Readiness never green (simple deployment, no `parent_id`) | `failed` after `RING_ROLLOUT_DEADLINE` (default 600s — same knob as the drain, mirrors Kubernetes `progressDeadlineSeconds`) |
| Readiness never green (rolling-update child) | unchanged — its deadline is the forced parent drain in `handle_rolling_update` |

### How it works

- **Readiness probes now run during `creating`** (`HealthChecker::execute_checks`): readiness-only, record-only — no `on_failure` action fires during boot, since a probe that isn't green yet isn't a failure. This feeds the gate the data it needs (avoids the chicken-and-egg where checks only ran once `running`).
- **`gate_running_on_readiness`** (scheduler): runs right after `run_health_checks`, before `handle_rolling_update`. Only acts on a fresh `creating → running` transition this cycle (never drags an established `running` back — that's the liveness checks' job). Reverts to `creating` while readiness isn't green; fails a simple deployment past the deadline.
- **No runtime changes.** Docker/CH still flip `running` in `apply()`; the gate reverts within the same cycle before persistence, and re-decides each tick — convergent, never persists a premature `running`.
- **No duplicated logic.** Extracted `readiness_decision` from `is_ready_to_drain` (now a thin wrapper); both the drain gate and the status gate share it.

### Tests

- Unit: 9 gate cases (no-hc / no-result / too-recent / green / failing / already-running / jobs / deadline→failed / child-not-failed) + 4 creating-phase cases (readiness runs, liveness skipped, failures don't act, jobs skip). `cargo test` 477 green, `clippy --all-targets -D warnings` clean, `fmt --check` clean.
- E2E adapted to the new semantics: `t22` (Docker) — readiness deployments wait in `creating` then reach `running` once the readiness file appears; `t19` (CH) — scenario C reworked (parent without readiness reaches `running`, child with a permanently-failing TCP probe stays `creating` and doesn't drain the parent — Cirros can't expose a listening service). Legacy non-readiness E2E unchanged.

### Why now

Prerequisite for the outbound-webhooks PR (#135): without this, the `deployment.status_changed → running` event lies. Independent change — lands on its own; #135 benefits once merged on top.