### PR TITLE
feat(runtimes): make runtimes opt-in via a [server] config table

### DIFF
--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -4,6 +4,17 @@ Ring is a state engine; the runtime is the thing that actually starts your workl
 
 This page covers the trade-offs and the mental model for each. For step-by-step setup, see the how-to guides; for exact manifest semantics, see the [manifest reference](/documentation/reference/manifest).
 
+## Enabling a runtime
+
+Runtimes are **opt-in**: none is enabled by default. You turn one on in `config.toml`, and a deployment can only target a runtime that's been enabled on the server:
+
+```toml
+[server.runtime.docker]
+enabled = true
+```
+
+Enable just the runtimes a host actually runs — Docker-only, Cloud-Hypervisor-only, or both. Ring registers exactly those, and refuses to start if none is enabled or if an enabled runtime is unreachable (an explicit-but-broken runtime is a configuration error, surfaced at startup rather than as a failed deployment later). See the [config.toml reference](/documentation/reference/config-toml#runtimes-are-opt-in) for the full rules.
+
 ## Quick comparison
 
 | Aspect | Docker | Cloud Hypervisor |
@@ -22,7 +33,7 @@ This page covers the trade-offs and the mental model for each. For step-by-step 
 
 ## Docker runtime
 
-The default. Containers, one per replica, attached to a per-namespace bridge network (`ring_<namespace>`). Same primitives as Docker Compose, just driven by Ring's state engine instead of a YAML file you re-apply by hand.
+The common choice. Containers, one per replica, attached to a per-namespace bridge network (`ring_<namespace>`). Same primitives as Docker Compose, just driven by Ring's state engine instead of a YAML file you re-apply by hand.
 
 **Good fit when:**
 - You already run Docker on the host

--- a/documentation/help/troubleshooting.md
+++ b/documentation/help/troubleshooting.md
@@ -72,7 +72,8 @@ stderr: ==== Possible seccomp violation ====
 Workaround:
 
 ```toml
-[contexts.default.runtime.cloud_hypervisor]
+[server.runtime.cloud_hypervisor]
+enabled = true
 seccomp = "false"      # disable filter
 # or
 seccomp = "log"        # keep filter, only log violations

--- a/documentation/how-to/deploy-on-cloud-hypervisor.md
+++ b/documentation/how-to/deploy-on-cloud-hypervisor.md
@@ -58,7 +58,7 @@ Run `ring doctor` to verify everything is in place — it checks each item and p
 
 ## Configure Ring
 
-Add a `runtime.cloud_hypervisor` section to `~/.config/kemeter/ring/config.toml`:
+Enable the Cloud Hypervisor runtime under the `[server]` table in `~/.config/kemeter/ring/config.toml` (runtimes are opt-in — `enabled = true` is required):
 
 ```toml
 [contexts.default]
@@ -67,14 +67,15 @@ host = "127.0.0.1"
 api.scheme = "http"
 api.port = 3030
 
-[contexts.default.runtime.cloud_hypervisor]
+[server.runtime.cloud_hypervisor]
+enabled = true
 firmware_path = "/path/to/hypervisor-fw"      # optional, defaults to ~/.config/kemeter/ring/cloud-hypervisor/vmlinux
 binary_path = "/usr/local/bin/cloud-hypervisor" # optional, defaults to $PATH lookup
 socket_dir = "/var/lib/ring/cloud-hypervisor/sockets"
 # seccomp = "false"                            # only if VMs die with SIGSYS on boot
 ```
 
-All fields under `runtime.cloud_hypervisor` are optional; the table shows the defaults Ring uses when omitted.
+Apart from `enabled`, all fields under `server.runtime.cloud_hypervisor` are optional; the table shows the defaults Ring uses when omitted. If `enabled = true` but the `cloud-hypervisor` binary can't be found, Ring fails fast at startup.
 
 ### Seccomp escape hatch
 

--- a/documentation/how-to/use-the-dashboard.md
+++ b/documentation/how-to/use-the-dashboard.md
@@ -7,7 +7,7 @@ There are **two ways to run it**, both serving the same bundled UI:
 | Mode | Command | Where the dashboard runs | Where the API runs |
 |---|---|---|---|
 | Local (proxy) | `ring dashboard` | On your laptop | Anywhere reachable via your `config.toml` context |
-| Embedded | `ring server start` with `[dashboard] enabled = true` | On the server itself | Same server |
+| Embedded | `ring server start` with `[server.dashboard] enabled = true` | On the server itself | Same server |
 
 Pick local when you want to monitor a remote cluster from your workstation. Pick embedded when you want a persistent dashboard URL for the whole team.
 
@@ -62,7 +62,7 @@ Accepted truthy values: `true`, `1`, `yes`, `on`.
 **3. `config.toml`** — persistent setup:
 
 ```toml
-[contexts.default.dashboard]
+[server.dashboard]
 enabled = true
 listen_address = "0.0.0.0:3031"
 ```

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -598,7 +598,7 @@ The default context (the one with `current = true`) is used when no `--context` 
 - `RING_DB_POOL_SIZE` — max SQLite connections (default: `5`)
 - `RING_CONFIG_DIR` — config directory (default: `~/.config/kemeter/ring`)
 - `RING_SECRET_KEY` — base64-encoded 32-byte key for secret encryption. **Required**: the server refuses to start without it (validated up front; see `ring doctor`).
-- `RING_SCHEDULER_INTERVAL` — scheduler tick in seconds (overrides `scheduler.interval` in `config.toml`)
+- `RING_SCHEDULER_INTERVAL` — scheduler tick in seconds (overrides `server.scheduler.interval` in `config.toml`)
 - `RING_APPLY_TIMEOUT` — single-deployment apply timeout in seconds (default: `300`)
 - `RUST_LOG` — log level (e.g. `info`, `debug`, `ring=debug`)
 

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -1,24 +1,39 @@
 # config.toml reference
 
-Ring reads `~/.config/kemeter/ring/config.toml` (or `$RING_CONFIG_DIR/config.toml`) at startup. It holds CLI and server settings for one or more **contexts**. A context is a named bundle of connection settings — the typical layout has just one (`default`) on a single-host install, with extra contexts for talking to remote Ring servers from a workstation.
+Ring reads `~/.config/kemeter/ring/config.toml` (or `$RING_CONFIG_DIR/config.toml`) at startup. It is split in two:
 
-`ring init` does **not** create this file. Ring falls back to a sensible `default` context if no file exists. Create the file only when you need to override something or define a second context.
+- **`[contexts.<name>]`** — *client* config: how a CLI reaches a server (host, API, auth). There can be several (e.g. `local`, `staging`, `prod`), like kubectl contexts.
+- **`[server]`** — *daemon* config: what the Ring **server** does (which runtimes it enables, scheduler interval, dashboard). One shared table, outside `[contexts.*]`.
+
+A context describes one client→server connection; it has no business deciding which runtimes that server enables — that's why daemon settings live under their own top-level `[server]` table.
+
+`ring init` writes this file with the runtimes you select enabled. Ring falls back to a sensible `default` context if no file exists.
 
 ## Top-level shape
 
 ```toml
-[contexts.<name>]
+[server]                                  # daemon config (shared)
+[server.scheduler]                        # optional
+[server.dashboard]                        # optional
+[server.runtime.docker]                   # opt-in: enabled = true
+[server.runtime.cloud_hypervisor]         # opt-in: enabled = true
+
+[contexts.<name>]                         # client config (one or more)
 current = true
 host    = "..."
 api     = { ... }
-user    = { ... }
-scheduler = { ... }                    # optional
-docker    = { ... }                    # optional
-[contexts.<name>.runtime.cloud_hypervisor]   # optional
-...
 ```
 
-You can declare multiple `[contexts.<name>]` tables in the same file. The one with `current = true` is the default; switch with the `--context` flag on most CLI commands.
+You can declare multiple `[contexts.<name>]` tables in the same file. The one with `current = true` is the default; switch with the `--context` flag on most CLI commands. The single `[server]` table applies whichever context is active.
+
+## Runtimes are opt-in
+
+No container runtime is enabled by default. Ring registers a runtime **only** when you turn it on with `enabled = true` under `[server.runtime.<runtime>]`. A runtime you don't enable is never touched, even if its socket or binary is present. This is what lets the same Ring build run Docker-only, Cloud-Hypervisor-only, or any mix.
+
+Two rules follow:
+
+- **At least one runtime must be enabled.** With none, Ring refuses to start (it could not deploy anything).
+- **An enabled-but-unreachable runtime is a hard error.** Enable Docker but the daemon doesn't answer, or enable Cloud Hypervisor but its binary can't be found, and Ring fails fast at startup with a clear message — rather than starting and returning a 500 on the first deployment.
 
 ## Fields
 
@@ -30,9 +45,8 @@ You can declare multiple `[contexts.<name>]` tables in the same file. The one wi
 | `host` | string | yes | — | The IP or hostname the server binds to. Set `"127.0.0.1"` for loopback-only; `"0.0.0.0"` to listen on every interface. The CLI uses the same value to reach the server |
 | `api` | inline table | yes | — | See [`api`](#contextsnameapi) |
 | `user` | inline table | yes | — | See [`user`](#contextsnameuser) |
-| `scheduler` | inline table | no | `{ interval = 10 }` | See [`scheduler`](#contextsnamescheduler) |
-| `docker` | inline table | no | `{ host = "unix:///var/run/docker.sock" }` | See [`docker`](#contextsnamedocker) |
-| `runtime` | sub-table | no | empty | See [`runtime.cloud_hypervisor`](#contextsnameruntimecloud_hypervisor) |
+
+> Daemon settings (runtimes, scheduler, dashboard) are **not** under the context — see [`[server]`](#server) below.
 
 ### `[contexts.<name>.api]`
 
@@ -44,24 +58,35 @@ You can declare multiple `[contexts.<name>]` tables in the same file. The one wi
 
 > **No password salt to configure.** Earlier versions required a `[contexts.<name>.user]` table with a global `salt`. Ring now generates a unique random salt for every password hash, so there is nothing to set or keep secret. A leftover `user.salt` line in an existing config is ignored.
 
-### `[contexts.<name>.scheduler]`
+### `[server]`
+
+The daemon's own configuration, shared by every context in the file. All subsections optional.
+
+### `[server.scheduler]`
 
 | Field | Type | Required | Default | Purpose |
 |---|---|---|---|---|
 | `interval` | int (seconds) | no | `10` | Reconciliation tick interval. Overridden by `RING_SCHEDULER_INTERVAL` if set |
 
-### `[contexts.<name>.docker]`
+### `[server.dashboard]`
 
 | Field | Type | Required | Default | Purpose |
 |---|---|---|---|---|
+| `enabled` | bool | no | `false` | Spawn the embedded dashboard. Also flippable via `--dashboard` / `RING_DASHBOARD` |
+| `listen_address` | string | no | `"127.0.0.1:3031"` | `host:port` the dashboard binds to. Override with `RING_DASHBOARD_LISTEN` |
+
+### `[server.runtime.docker]`
+
+| Field | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Register the Docker runtime. Must be `true` for Ring to use Docker. When `true` and the daemon is unreachable at startup, Ring fails fast |
 | `host` | string | no | `"unix:///var/run/docker.sock"` | Docker daemon URL. Use `tcp://host:2375` for a remote daemon, `tcp://host:2376` for TLS |
 
-### `[contexts.<name>.runtime.cloud_hypervisor]`
-
-All fields optional. Omitted fields fall back to the defaults in the table below.
+### `[server.runtime.cloud_hypervisor]`
 
 | Field | Type | Default | Purpose |
 |---|---|---|---|
+| `enabled` | bool | `false` | Register the Cloud Hypervisor runtime. Must be `true` for Ring to use it. When `true` and `binary_path` can't be resolved at startup, Ring fails fast |
 | `binary_path` | string | `cloud-hypervisor` (from `$PATH`) | Absolute path to the `cloud-hypervisor` binary |
 | `firmware_path` | string | `$RING_CONFIG_DIR/cloud-hypervisor/vmlinux` | Path to `hypervisor-fw` (the EFI firmware) |
 | `socket_dir` | string | `$RING_CONFIG_DIR/cloud-hypervisor/sockets` | Where Ring puts per-VM Unix sockets, console logs, volume shares |
@@ -69,7 +94,7 @@ All fields optional. Omitted fields fall back to the defaults in the table below
 
 ## Examples
 
-### Minimal single-host
+### Minimal single-host (Docker)
 
 ```toml
 [contexts.default]
@@ -78,9 +103,14 @@ host = "127.0.0.1"
 
 api.scheme = "http"
 api.port = 3030
+
+[server.runtime.docker]
+enabled = true
 ```
 
-### Production with Cloud Hypervisor and TLS-fronted API
+> Without an enabled runtime Ring refuses to start, so the `[server.runtime.docker]` block is the minimum to get a working server on a Docker host.
+
+### Production with Docker + Cloud Hypervisor and TLS-fronted API
 
 ```toml
 [contexts.default]
@@ -91,13 +121,15 @@ api.scheme = "https"                       # because nginx in front terminates T
 api.port = 3030
 api.cors_origins = ["https://dashboard.example.com"]
 
-[contexts.default.scheduler]
+[server.scheduler]
 interval = 5
 
-[contexts.default.docker]
+[server.runtime.docker]
+enabled = true
 host = "unix:///var/run/docker.sock"
 
-[contexts.default.runtime.cloud_hypervisor]
+[server.runtime.cloud_hypervisor]
+enabled = true
 binary_path = "/usr/local/bin/cloud-hypervisor"
 firmware_path = "/var/lib/ring/hypervisor-fw"
 socket_dir = "/var/lib/ring/cloud-hypervisor/sockets"

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -139,6 +139,7 @@ fn check_cloud_hypervisor(config: &Config) -> Vec<Check> {
     let mut checks = Vec::new();
 
     let binary = config
+        .server
         .runtime
         .cloud_hypervisor
         .binary_path
@@ -153,6 +154,7 @@ fn check_cloud_hypervisor(config: &Config) -> Vec<Check> {
 
     let default_firmware = format!("{}/cloud-hypervisor/vmlinux", get_config_dir());
     let firmware = config
+        .server
         .runtime
         .cloud_hypervisor
         .firmware_path

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -226,12 +226,29 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
     out.push('\n');
     out.push_str(&format!("user.salt = \"{}\"\n", salt));
 
-    if matches!(
+    // Runtimes are opt-in and live under the top-level `[server]` table (daemon
+    // config), separate from the client `[contexts.*]` above. Enable exactly
+    // the runtimes the operator selected; Ring refuses to start with none.
+    let docker = matches!(
+        settings.runtime,
+        RuntimeChoice::Docker | RuntimeChoice::Both
+    );
+    let cloud_hypervisor = matches!(
         settings.runtime,
         RuntimeChoice::CloudHypervisor | RuntimeChoice::Both
-    ) {
+    );
+
+    if docker {
         out.push('\n');
-        out.push_str("[contexts.default.runtime.cloud_hypervisor]\n");
+        out.push_str("[server.runtime.docker]\n");
+        out.push_str("enabled = true\n");
+        out.push_str("# host = \"unix:///var/run/docker.sock\"  # or tcp://host:2375\n");
+    }
+
+    if cloud_hypervisor {
+        out.push('\n');
+        out.push_str("[server.runtime.cloud_hypervisor]\n");
+        out.push_str("enabled = true\n");
         out.push_str("# Uncomment and adjust if cloud-hypervisor isn't on $PATH:\n");
         out.push_str("# binary_path = \"/usr/local/bin/cloud-hypervisor\"\n");
         out.push_str("# firmware_path = \"/var/lib/ring/cloud-hypervisor/vmlinux\"\n");
@@ -354,6 +371,9 @@ mod tests {
         let out = build_config_toml(&s);
         assert!(out.contains("[contexts.default]"));
         assert!(out.contains("api.port = 3030"));
+        // Docker runtime enabled under the [server] table.
+        assert!(out.contains("[server.runtime.docker]"));
+        assert!(out.contains("enabled = true"));
         // No CH block when Docker only.
         assert!(!out.contains("runtime.cloud_hypervisor"));
     }
@@ -365,19 +385,23 @@ mod tests {
             port: 3030,
         };
         let out = build_config_toml(&s);
-        assert!(out.contains("[contexts.default.runtime.cloud_hypervisor]"));
+        assert!(out.contains("[server.runtime.cloud_hypervisor]"));
+        assert!(out.contains("enabled = true"));
         assert!(out.contains("seccomp"));
+        // No Docker block when CH only.
+        assert!(!out.contains("[server.runtime.docker]"));
     }
 
     #[test]
-    fn build_config_both_emits_ch_section() {
+    fn build_config_both_emits_both_sections() {
         let s = InitSettings {
             runtime: RuntimeChoice::Both,
             port: 8080,
         };
         let out = build_config_toml(&s);
         assert!(out.contains("api.port = 8080"));
-        assert!(out.contains("[contexts.default.runtime.cloud_hypervisor]"));
+        assert!(out.contains("[server.runtime.docker]"));
+        assert!(out.contains("[server.runtime.cloud_hypervisor]"));
     }
 
     #[test]

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -34,21 +34,21 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // The env var lets operators flip the dashboard on without rewriting
     // the on-disk config — same spirit as `RING_TOKEN` / `RING_SECRET_KEY`.
     if args.get_flag("dashboard") {
-        configuration.dashboard.enabled = true;
+        configuration.server.dashboard.enabled = true;
     } else if let Ok(val) = std::env::var("RING_DASHBOARD")
         && matches!(
             val.trim().to_ascii_lowercase().as_str(),
             "1" | "true" | "yes" | "on"
         )
     {
-        configuration.dashboard.enabled = true;
+        configuration.server.dashboard.enabled = true;
     }
     // Optional override of the bind address; useful in containers where
     // the default `127.0.0.1:3031` is unreachable from the host.
     if let Ok(addr) = std::env::var("RING_DASHBOARD_LISTEN")
         && !addr.trim().is_empty()
     {
-        configuration.dashboard.listen_address = addr;
+        configuration.server.dashboard.listen_address = addr;
     }
 
     // Validate the encryption key up front. Anything that touches a
@@ -70,31 +70,86 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
         .await
         .expect("Could not execute database migrations.");
 
-    let docker = docker::connect().expect("Failed to connect to Docker");
-    info!("Connected to Docker");
-
     let intentional_shutdowns = IntentionalShutdowns::new();
 
+    // Runtimes are opt-in and explicit: each is registered ONLY when enabled in
+    // config.toml (`[server.runtime.<name>] enabled = true`). A runtime that
+    // isn't enabled is never touched, even if its socket/binary happens to
+    // exist. This is what lets Ring run Docker-only, CH-only, or any mix.
+    //
+    // Fail-fast: a runtime the operator explicitly enabled but that's
+    // unreachable at startup is a configuration error, not a silent skip — we
+    // refuse to start so the misconfiguration surfaces immediately rather than
+    // as a 500 on the first deployment.
     let mut runtimes_map: HashMap<String, Arc<dyn RuntimeLifecycle>> = HashMap::new();
-    runtimes_map.insert(
-        "docker".to_string(),
-        Arc::new(DockerLifecycle::new(docker, intentional_shutdowns.clone())),
-    );
 
-    let ch_runtime_config =
-        crate::runtime::cloud_hypervisor::CloudHypervisorRuntimeConfig::from_user_config(
-            &configuration.runtime.cloud_hypervisor,
+    // Docker: enabled in config → verify the daemon answers a `ping()` (client
+    // construction alone is lazy and always succeeds, so it can't gate this).
+    // Keep a second client for the event listener, only when Docker is on.
+    let docker_for_events = if configuration.server.runtime.docker.enabled {
+        let host = configuration.server.runtime.docker.host.clone();
+        match docker::connect_and_verify(&host).await {
+            Ok(docker) => {
+                info!("Connected to Docker at {}", host);
+                runtimes_map.insert(
+                    "docker".to_string(),
+                    Arc::new(DockerLifecycle::new(docker, intentional_shutdowns.clone())),
+                );
+                docker::connect_with_host(&host).ok()
+            }
+            Err(e) => {
+                error!(
+                    "Refusing to start: Docker runtime is enabled in config but unreachable: {}",
+                    e
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        info!("Docker runtime disabled in config, skipping");
+        None
+    };
+
+    // Cloud Hypervisor: enabled in config → its binary must resolve, else fail
+    // fast. The config/log-rotator are only built when we'll use it.
+    let mut _ch_log_rotator = None;
+    if configuration.server.runtime.cloud_hypervisor.enabled {
+        let ch_runtime_config =
+            crate::runtime::cloud_hypervisor::CloudHypervisorRuntimeConfig::from_user_config(
+                &configuration.server.runtime.cloud_hypervisor,
+            );
+        if !ch_runtime_config.is_available() {
+            error!(
+                "Refusing to start: Cloud Hypervisor runtime is enabled in config but its binary \
+                 '{}' could not be found",
+                ch_runtime_config.binary_path
+            );
+            std::process::exit(1);
+        }
+        info!(
+            "Cloud Hypervisor runtime: binary={}, firmware={}, socket_dir={}, seccomp={:?}",
+            ch_runtime_config.binary_path,
+            ch_runtime_config.firmware_path,
+            ch_runtime_config.socket_dir,
+            ch_runtime_config.seccomp,
         );
-    info!(
-        "Cloud Hypervisor runtime: binary={}, firmware={}, socket_dir={}, seccomp={:?}",
-        ch_runtime_config.binary_path,
-        ch_runtime_config.firmware_path,
-        ch_runtime_config.socket_dir,
-        ch_runtime_config.seccomp,
-    );
-    let ch_lifecycle = CloudHypervisorLifecycle::new(ch_runtime_config);
-    let _ch_log_rotator = ch_lifecycle.spawn_console_log_rotator();
-    runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
+        let ch_lifecycle = CloudHypervisorLifecycle::new(ch_runtime_config);
+        _ch_log_rotator = Some(ch_lifecycle.spawn_console_log_rotator());
+        runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
+    } else {
+        info!("Cloud Hypervisor runtime disabled in config, skipping");
+    }
+
+    // Hard floor: no runtime enabled means Ring can't deploy anything — fail
+    // loudly with an actionable message instead of starting a useless server.
+    if runtimes_map.is_empty() {
+        error!(
+            "Refusing to start: no container runtime is enabled. Enable at least one in \
+             config.toml, e.g. `[server.runtime.docker]` with `enabled = true`."
+        );
+        std::process::exit(1);
+    }
+
     info!(
         "Registered runtimes: {:?}",
         runtimes_map.keys().collect::<Vec<_>>()
@@ -103,9 +158,11 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     let runtimes = std::sync::Arc::new(runtimes_map);
 
     let (event_tx, event_rx) = mpsc::channel::<DockerEvent>(1024);
-    let docker_for_events =
-        docker::connect().expect("Failed to connect to Docker for event listener");
-    let event_listener_handler = task::spawn(start_event_listener(event_tx, docker_for_events));
+    // The Docker event listener only runs when Docker is present. Without it the
+    // scheduler still drains `event_rx` (it just never receives Docker events) —
+    // other runtimes don't depend on this stream.
+    let event_listener_handler =
+        docker_for_events.map(|docker| task::spawn(start_event_listener(event_tx, docker)));
 
     let api_server_handler = task::spawn(ApiServer::start(
         pool.clone(),
@@ -116,8 +173,8 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // Embedded dashboard — only spawned when explicitly enabled in config,
     // so the default surface stays unchanged for existing users. Proxies
     // to its own API over loopback so the browser sees a single origin.
-    if configuration.dashboard.enabled {
-        let listen = configuration.dashboard.listen_address.clone();
+    if configuration.server.dashboard.enabled {
+        let listen = configuration.server.dashboard.listen_address.clone();
         let api_port = configuration.api.port;
         task::spawn(async move {
             let mode = crate::dashboard::Mode::Embedded { api_port };
@@ -132,7 +189,7 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // stalls a reconciliation tick. Polls on the same interval as the
     // scheduler by default.
     let event_worker_pool = pool.clone();
-    let event_worker_interval = configuration.scheduler.interval;
+    let event_worker_interval = configuration.server.scheduler.interval;
     task::spawn(async move {
         crate::scheduler::event_worker::run(event_worker_pool, event_worker_interval).await;
     });
@@ -153,7 +210,9 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     if let Err(e) = scheduler_handler.await {
         eprintln!("Scheduler task failed: {}", e);
     }
-    if let Err(e) = event_listener_handler.await {
+    if let Some(handler) = event_listener_handler
+        && let Err(e) = handler.await
+    {
         eprintln!("Docker event listener task failed: {}", e);
     }
 }
@@ -204,10 +263,10 @@ fn print_startup_banner(
     } else if host == "0.0.0.0" {
         println!("  {}  Network:   (no LAN address detected)", arrow);
     }
-    if configuration.dashboard.enabled {
+    if configuration.server.dashboard.enabled {
         println!(
             "  {}  Dashboard: http://{}",
-            arrow, configuration.dashboard.listen_address
+            arrow, configuration.server.dashboard.listen_address
         );
     } else {
         println!("  {}  Dashboard: disabled (enable with --dashboard)", arrow);

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::config::server::ServerConfig;
 use local_ip_address::local_ip;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -9,105 +10,18 @@ use toml::de::Error as TomlError;
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct Contexts {
     pub(crate) contexts: HashMap<String, Config>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub(crate) struct Scheduler {
-    #[serde(default = "default_scheduler_interval")]
-    pub(crate) interval: u64,
-}
-
-fn default_scheduler_interval() -> u64 {
-    10
-}
-
-impl Default for Scheduler {
-    fn default() -> Self {
-        Scheduler { interval: 10 }
-    }
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub(crate) struct DockerConfig {
-    /// Docker host URL. Examples:
-    /// - "unix:///var/run/docker.sock" (default)
-    /// - "tcp://192.168.1.100:2375"
-    /// - "tcp://192.168.1.100:2376" (with TLS)
-    #[serde(default = "default_docker_host")]
-    #[allow(dead_code)] // Parsed from config.toml; consumed by the Docker client setup path.
-    pub(crate) host: String,
-}
-
-fn default_docker_host() -> String {
-    "unix:///var/run/docker.sock".to_string()
-}
-
-impl Default for DockerConfig {
-    fn default() -> Self {
-        DockerConfig {
-            host: default_docker_host(),
-        }
-    }
-}
-
-/// User-facing configuration for the Cloud Hypervisor runtime. Parsed from the
-/// `[contexts.<name>.runtime.cloud_hypervisor]` section of `config.toml`.
-///
-/// All fields are optional; when unset, `CloudHypervisorRuntimeConfig::default`
-/// falls back to `$RING_CONFIG_DIR/cloud-hypervisor/...` for backward
-/// compatibility.
-#[derive(Deserialize, Debug, Clone, Default)]
-pub(crate) struct CloudHypervisorConfig {
-    pub(crate) binary_path: Option<String>,
-    pub(crate) firmware_path: Option<String>,
-    pub(crate) socket_dir: Option<String>,
-    /// Forwarded to `cloud-hypervisor --seccomp <value>`. Accepts `true`
-    /// (default), `false` or `log`. Set to `false` on hosts where the kernel
-    /// uses syscalls not whitelisted by CH (otherwise VMs die with SIGSYS).
-    pub(crate) seccomp: Option<String>,
-    /// Maximum size (bytes) for a per-VM console log before rotation kicks
-    /// in. Defaults to 10 MiB. Set to 0 to disable rotation entirely.
-    pub(crate) max_console_log_bytes: Option<u64>,
-    /// How many rotated console log backups to keep alongside the live file
-    /// (`.console.log.1`, `.console.log.2`, ...). Defaults to 3.
-    pub(crate) max_console_log_backups: Option<u32>,
-}
-
-/// User-facing configuration for the embedded web dashboard. Off by default
-/// to keep the server surface minimal until an operator opts in.
-#[derive(Deserialize, Debug, Clone)]
-pub(crate) struct DashboardConfig {
-    /// When true, `ring server start` spawns the dashboard on
-    /// `listen_address`. When false (the default), the dashboard is not
-    /// served by this Ring instance — operators can still run
-    /// `ring dashboard` locally against any API.
+    /// The single, top-level `[server]` table. It is shared by the whole file
+    /// (a host runs one daemon, whatever client contexts point at it), so it is
+    /// parsed here and attached by `pick_context` to whichever context it
+    /// returns, rather than living inside each `[contexts.<name>]`.
     #[serde(default)]
-    pub(crate) enabled: bool,
-    /// `host:port` for the dashboard to bind to. Distinct from the API
-    /// port to keep concerns separated.
-    #[serde(default = "default_dashboard_listen_address")]
-    pub(crate) listen_address: String,
+    pub(crate) server: ServerConfig,
 }
 
-fn default_dashboard_listen_address() -> String {
-    "127.0.0.1:3031".to_string()
-}
-
-impl Default for DashboardConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            listen_address: default_dashboard_listen_address(),
-        }
-    }
-}
-
-#[derive(Deserialize, Debug, Clone, Default)]
-pub(crate) struct RuntimesConfig {
-    #[serde(default)]
-    pub(crate) cloud_hypervisor: CloudHypervisorConfig,
-}
-
+/// Per-context CLIENT configuration: how a CLI reaches one server. The daemon's
+/// own settings (runtimes, scheduler, dashboard) live in [`ServerConfig`] under
+/// the top-level `[server]` table, not here. `server` is populated by
+/// `pick_context` from the shared `[server]` table.
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct Config {
     pub(crate) current: bool,
@@ -115,15 +29,8 @@ pub(crate) struct Config {
     pub(crate) name: String,
     pub(crate) host: String,
     pub(crate) api: config::api::Api,
-    #[serde(default)]
-    pub(crate) scheduler: Scheduler,
-    #[serde(default)]
-    #[allow(dead_code)] // Parsed from config.toml; reserved for Docker host configuration.
-    pub(crate) docker: DockerConfig,
-    #[serde(default)]
-    pub(crate) runtime: RuntimesConfig,
-    #[serde(default)]
-    pub(crate) dashboard: DashboardConfig,
+    #[serde(skip_deserializing)]
+    pub(crate) server: ServerConfig,
 }
 
 impl Config {
@@ -148,10 +55,7 @@ impl Default for Config {
                 port: 3030,
                 cors_origins: Vec::new(),
             },
-            scheduler: Scheduler::default(),
-            docker: DockerConfig::default(),
-            runtime: RuntimesConfig::default(),
-            dashboard: DashboardConfig::default(),
+            server: ServerConfig::default(),
         }
     }
 }
@@ -215,9 +119,14 @@ pub(crate) fn load_config(context_current: &str) -> Config {
 /// explicit match the loader used to silently fall through to
 /// `Config::default()`, dropping any user-set runtime config.
 fn pick_context(contexts: Contexts, context_current: &str) -> Option<Config> {
+    // The `[server]` table is shared across all contexts in the file; attach it
+    // to whichever context we return so `configuration.server.*` is populated
+    // regardless of which client context was picked.
+    let server = contexts.server;
     let mut current_fallback: Option<Config> = None;
     for (context_name, mut config) in contexts.contexts {
         config.name = context_name.clone();
+        config.server = server.clone();
 
         if context_name == context_current {
             debug!("Switch to context from {}", context_name);
@@ -248,14 +157,14 @@ mod tests {
     }
 
     const SAMPLE: &str = r#"
+[server.runtime.cloud_hypervisor]
+seccomp = "false"
+
 [contexts.dev]
 host = "0.0.0.0"
 current = true
 api.scheme = "http"
 api.port = 3030
-
-[contexts.dev.runtime.cloud_hypervisor]
-seccomp = "false"
 
 [contexts.prod]
 host = "10.0.0.1"
@@ -277,15 +186,57 @@ api.port = 3030
         // This is the regression: the caller passes "default" but no context
         // is literally named "default". Before the fix, this returned None
         // (and load_config fell through to Config::default(), silently
-        // dropping runtime.cloud_hypervisor.seccomp).
+        // dropping the shared [server] config).
         let contexts = make_contexts(SAMPLE);
         let picked = pick_context(contexts, "default").expect("should fall back to current = true");
         assert_eq!(picked.name, "dev");
         assert_eq!(
-            picked.runtime.cloud_hypervisor.seccomp.as_deref(),
+            picked.server.runtime.cloud_hypervisor.seccomp.as_deref(),
             Some("false"),
-            "user-set runtime config must survive the fallback"
+            "shared [server] config must survive the fallback"
         );
+    }
+
+    #[test]
+    fn server_table_is_shared_across_contexts() {
+        // The top-level [server] table attaches to whichever context wins.
+        let contexts = make_contexts(SAMPLE);
+        let picked = pick_context(contexts, "prod").expect("prod should match");
+        assert_eq!(
+            picked.server.runtime.cloud_hypervisor.seccomp.as_deref(),
+            Some("false"),
+            "the shared [server] table applies to every context"
+        );
+    }
+
+    #[test]
+    fn runtimes_disabled_by_default() {
+        // Opt-in: a config that doesn't mention runtimes leaves them all off.
+        let contexts = make_contexts(SAMPLE);
+        let picked = pick_context(contexts, "dev").expect("dev should match");
+        assert!(!picked.server.runtime.docker.enabled);
+        assert!(!picked.server.runtime.cloud_hypervisor.enabled);
+    }
+
+    #[test]
+    fn runtimes_enabled_when_explicitly_set() {
+        let toml_str = r#"
+[server.runtime.docker]
+enabled = true
+
+[server.runtime.cloud_hypervisor]
+enabled = true
+
+[contexts.dev]
+host = "0.0.0.0"
+current = true
+api.scheme = "http"
+api.port = 3030
+"#;
+        let contexts = make_contexts(toml_str);
+        let picked = pick_context(contexts, "dev").expect("dev should match");
+        assert!(picked.server.runtime.docker.enabled);
+        assert!(picked.server.runtime.cloud_hypervisor.enabled);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod api;
 pub(crate) mod auth;
 pub(crate) mod config;
+pub(crate) mod server;

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -1,0 +1,134 @@
+//! Daemon-side configuration: everything the Ring *server* does, as opposed to
+//! how a CLI *reaches* a server (that's the per-context client config in
+//! [`crate::config::config`]). Parsed from the top-level `[server]` table of
+//! `config.toml`, which lives outside `[contexts.*]` — a context describes one
+//! client→server connection and has no business deciding which runtimes that
+//! server enables.
+//!
+//! The split (client `[contexts.*]` vs daemon `[server]`) mirrors Nomad's
+//! `client {}` / `server {}` stanzas: one tool, both roles, one file.
+
+use serde::Deserialize;
+
+/// Top-level `[server]` table. Shared by the whole file (a host runs one daemon,
+/// whatever client contexts point at it).
+#[derive(Deserialize, Debug, Clone, Default)]
+pub(crate) struct ServerConfig {
+    #[serde(default)]
+    pub(crate) scheduler: Scheduler,
+    #[serde(default)]
+    pub(crate) runtime: RuntimesConfig,
+    #[serde(default)]
+    pub(crate) dashboard: DashboardConfig,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct Scheduler {
+    #[serde(default = "default_scheduler_interval")]
+    pub(crate) interval: u64,
+}
+
+fn default_scheduler_interval() -> u64 {
+    10
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Scheduler { interval: 10 }
+    }
+}
+
+/// Container runtimes. All opt-in: a runtime is only registered when its
+/// `enabled` flag is `true`. See `commands::server` for the opt-in + fail-fast
+/// registration logic.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub(crate) struct RuntimesConfig {
+    #[serde(default)]
+    pub(crate) docker: DockerConfig,
+    #[serde(default)]
+    pub(crate) cloud_hypervisor: CloudHypervisorConfig,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct DockerConfig {
+    /// Whether to register the Docker runtime. Off by default: runtimes are
+    /// opt-in. When `true` and the daemon doesn't answer at startup, Ring fails
+    /// fast (a requested-but-unreachable runtime is a config error).
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// Docker host URL. Examples:
+    /// - "unix:///var/run/docker.sock" (default)
+    /// - "tcp://192.168.1.100:2375"
+    /// - "tcp://192.168.1.100:2376" (with TLS)
+    #[serde(default = "default_docker_host")]
+    pub(crate) host: String,
+}
+
+fn default_docker_host() -> String {
+    "unix:///var/run/docker.sock".to_string()
+}
+
+impl Default for DockerConfig {
+    fn default() -> Self {
+        DockerConfig {
+            enabled: false,
+            host: default_docker_host(),
+        }
+    }
+}
+
+/// User-facing configuration for the Cloud Hypervisor runtime. Parsed from the
+/// `[server.runtime.cloud_hypervisor]` section of `config.toml`.
+///
+/// All fields are optional; when unset, `CloudHypervisorRuntimeConfig::default`
+/// falls back to `$RING_CONFIG_DIR/cloud-hypervisor/...`.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub(crate) struct CloudHypervisorConfig {
+    /// Whether to register the Cloud Hypervisor runtime. Off by default
+    /// (runtimes are opt-in). When `true` and the `cloud-hypervisor` binary
+    /// can't be resolved at startup, Ring fails fast.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    pub(crate) binary_path: Option<String>,
+    pub(crate) firmware_path: Option<String>,
+    pub(crate) socket_dir: Option<String>,
+    /// Forwarded to `cloud-hypervisor --seccomp <value>`. Accepts `true`
+    /// (default), `false` or `log`. Set to `false` on hosts where the kernel
+    /// uses syscalls not whitelisted by CH (otherwise VMs die with SIGSYS).
+    pub(crate) seccomp: Option<String>,
+    /// Maximum size (bytes) for a per-VM console log before rotation kicks
+    /// in. Defaults to 10 MiB. Set to 0 to disable rotation entirely.
+    pub(crate) max_console_log_bytes: Option<u64>,
+    /// How many rotated console log backups to keep alongside the live file
+    /// (`.console.log.1`, `.console.log.2`, ...). Defaults to 3.
+    pub(crate) max_console_log_backups: Option<u32>,
+}
+
+/// User-facing configuration for the embedded web dashboard. Off by default
+/// to keep the server surface minimal until an operator opts in.
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct DashboardConfig {
+    /// When true, `ring server start` spawns the dashboard on
+    /// `listen_address`. When false (the default), the dashboard is not
+    /// served by this Ring instance — operators can still run
+    /// `ring dashboard` locally against any API.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// `host:port` for the dashboard to bind to. Distinct from the API
+    /// port to keep concerns separated.
+    #[serde(default = "default_dashboard_listen_address")]
+    pub(crate) listen_address: String,
+}
+
+fn default_dashboard_listen_address() -> String {
+    "127.0.0.1:3031".to_string()
+}
+
+impl Default for DashboardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_address: default_dashboard_listen_address(),
+        }
+    }
+}

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -2,8 +2,8 @@ use super::client::{
     CloudHypervisorClient, ConsoleConfig, CpuConfig, DiskConfig, FsConfig, MemoryConfig, NetConfig,
     PayloadConfig, VmConfig,
 };
-use crate::config::config::CloudHypervisorConfig;
 use crate::config::config::get_config_dir;
+use crate::config::server::CloudHypervisorConfig;
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::error::RuntimeError;
@@ -54,6 +54,22 @@ impl Default for CloudHypervisorRuntimeConfig {
 }
 
 impl CloudHypervisorRuntimeConfig {
+    /// Whether the cloud-hypervisor binary is actually present, so the runtime
+    /// can be registered only when it can run. Mirrors the Docker `ping()` gate:
+    /// no point advertising a runtime that fails on the first deployment.
+    ///
+    /// An absolute/relative path must exist on disk; a bare name (the default,
+    /// `cloud-hypervisor`) is looked up across `PATH`.
+    pub(crate) fn is_available(&self) -> bool {
+        let binary = &self.binary_path;
+        if binary.contains('/') {
+            return std::path::Path::new(binary).exists();
+        }
+        std::env::var_os("PATH")
+            .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(binary).exists()))
+            .unwrap_or(false)
+    }
+
     /// Merge a user-facing config section with the defaults. Any field left
     /// unset in `user` falls back to `CloudHypervisorRuntimeConfig::default`.
     pub(crate) fn from_user_config(user: &CloudHypervisorConfig) -> Self {
@@ -1431,6 +1447,29 @@ impl CloudHypervisorLifecycle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cfg_with_binary(binary_path: &str) -> CloudHypervisorRuntimeConfig {
+        CloudHypervisorRuntimeConfig {
+            binary_path: binary_path.to_string(),
+            ..CloudHypervisorRuntimeConfig::default()
+        }
+    }
+
+    #[test]
+    fn is_available_true_for_existing_absolute_path() {
+        assert!(cfg_with_binary("/bin/sh").is_available());
+    }
+
+    #[test]
+    fn is_available_false_for_missing_absolute_path() {
+        assert!(!cfg_with_binary("/nonexistent/cloud-hypervisor-xyz").is_available());
+    }
+
+    #[test]
+    fn is_available_resolves_bare_name_via_path() {
+        assert!(cfg_with_binary("sh").is_available());
+        assert!(!cfg_with_binary("definitely-not-a-real-binary-xyz").is_available());
+    }
 
     #[test]
     fn parse_resources_defaults() {

--- a/src/runtime/docker/mod.rs
+++ b/src/runtime/docker/mod.rs
@@ -122,11 +122,24 @@ impl From<bollard::errors::Error> for RuntimeError {
     }
 }
 
-pub(crate) fn connect() -> Result<Docker, RuntimeError> {
-    let host =
-        std::env::var("DOCKER_HOST").unwrap_or_else(|_| "unix:///var/run/docker.sock".to_string());
-
-    connect_with_host(&host)
+/// Connect to Docker at `host` *and confirm the daemon actually answers*,
+/// returning the client only if it does.
+///
+/// `connect`/`connect_with_host` merely build a bollard client — they succeed
+/// even when no daemon is listening, because the socket connection is lazy.
+/// That makes them unsuitable for a best-effort "is Docker available?" gate at
+/// startup: we'd register a runtime that 500s on the first deployment. A
+/// `ping()` round-trip is the cheapest call that proves the daemon is up and
+/// speaking the API, so it gates registering the runtime.
+pub(crate) async fn connect_and_verify(host: &str) -> Result<Docker, RuntimeError> {
+    let docker = connect_with_host(host)?;
+    docker.ping().await.map_err(|e| {
+        RuntimeError::Other(format!(
+            "Docker daemon at {} did not respond to ping: {}",
+            host, e
+        ))
+    })?;
+    Ok(docker)
 }
 
 pub(crate) fn connect_with_host(host: &str) -> Result<Docker, RuntimeError> {

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -1073,7 +1073,7 @@ pub(crate) async fn schedule(
     let interval_seconds = env::var("RING_SCHEDULER_INTERVAL")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(config.scheduler.interval);
+        .unwrap_or(config.server.scheduler.interval);
 
     let apply_timeout_secs = env::var("RING_APPLY_TIMEOUT")
         .ok()

--- a/tests/e2e/cloud-hypervisor/setup.sh
+++ b/tests/e2e/cloud-hypervisor/setup.sh
@@ -97,13 +97,16 @@ setup_ch() {
   # kernels (VMs die with SIGSYS otherwise). E2E only — production should leave
   # this unset to keep CH's default kill-on-violation policy.
   RING_EXTRA_CONFIG=$(cat <<EOF
-[contexts.default.runtime.cloud_hypervisor]
+[server.runtime.cloud_hypervisor]
+enabled = true
 firmware_path = "$RING_E2E_CH_FIRMWARE"
 socket_dir = "$RING_E2E_CH_SOCKET_DIR"
 seccomp = "false"
 EOF
 )
   export RING_EXTRA_CONFIG
+  # CH-only suite: don't require Docker to be present.
+  export RING_E2E_ENABLE_DOCKER=false
 
   # Chain cleanup_ch onto the existing cleanup_ring trap from lib.sh. We
   # cannot simply add a new trap because bash traps are not stacked.

--- a/tests/e2e/cloud-hypervisor/t12_firmware_missing.sh
+++ b/tests/e2e/cloud-hypervisor/t12_firmware_missing.sh
@@ -30,13 +30,15 @@ ensure_ch_image
 RING_E2E_CH_SOCKET_DIR="${RING_E2E_CH_SOCKET_DIR:-$(mktemp -d -t ring-e2e-ch-sockets-XXXXXX)}"
 export RING_E2E_CH_SOCKET_DIR
 RING_EXTRA_CONFIG=$(cat <<EOF
-[contexts.default.runtime.cloud_hypervisor]
+[server.runtime.cloud_hypervisor]
+enabled = true
 firmware_path = "$BOGUS_FW"
 socket_dir = "$RING_E2E_CH_SOCKET_DIR"
 seccomp = "false"
 EOF
 )
 export RING_EXTRA_CONFIG
+export RING_E2E_ENABLE_DOCKER=false
 trap 'cleanup_ch; cleanup_ring' EXIT
 
 start_ring

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -56,8 +56,21 @@ api.port = ${RING_PORT}
 
 user.salt = "e2e-test-salt"
 
-scheduler.interval = 1
+[server.scheduler]
+interval = 1
 EOF
+
+  # Runtimes are opt-in. Docker is enabled by default (the docker/ suite needs
+  # it); a runtime-specific suite (e.g. cloud-hypervisor) sets
+  # RING_E2E_ENABLE_DOCKER=false and enables its own runtime via
+  # RING_EXTRA_CONFIG. Ring refuses to start with zero runtimes enabled.
+  if [ "${RING_E2E_ENABLE_DOCKER:-true}" = "true" ]; then
+    cat >> "$RING_TEST_DIR/config.toml" <<EOF
+
+[server.runtime.docker]
+enabled = true
+EOF
+  fi
 
   # Optional per-test config snippet injected via RING_EXTRA_CONFIG (multi-line
   # TOML). Useful to enable runtime-specific settings like the Cloud Hypervisor

--- a/tests/e2e/server/t8_init_non_interactive.sh
+++ b/tests/e2e/server/t8_init_non_interactive.sh
@@ -5,9 +5,9 @@
 #
 # Invariants:
 #   1. `init --runtime cloud-hypervisor --port 4030` writes api.port = 4030
-#      and a [contexts.default.runtime.cloud_hypervisor] block, with no prompt.
+#      and a [server.runtime.cloud_hypervisor] block, with no prompt.
 #   2. `init --port 9090` (no --runtime, no TTY) → custom port, Docker default
-#      (no cloud_hypervisor block).
+#      (a [server.runtime.docker] block, no cloud_hypervisor block).
 #   3. an invalid `--runtime` value is rejected (non-zero exit, lists the
 #      accepted values).
 #   4. re-running without --force refuses to overwrite (non-zero exit).
@@ -29,7 +29,7 @@ D1=$(mktemp -d -t ring-e2e-init-XXXXXX)
 RING_CONFIG_DIR="$D1" "$RING_BIN" init --runtime cloud-hypervisor --port 4030 >/dev/null 2>&1 \
   || fail "1: init with flags exited non-zero"
 grep -qF "api.port = 4030" "$D1/config.toml" || { cat "$D1/config.toml" >&2; fail "1: api.port = 4030 missing"; }
-grep -qF "[contexts.default.runtime.cloud_hypervisor]" "$D1/config.toml" \
+grep -qF "[server.runtime.cloud_hypervisor]" "$D1/config.toml" \
   || { cat "$D1/config.toml" >&2; fail "1: cloud_hypervisor block missing"; }
 log "1 (scripted CH init): config.toml correct"
 
@@ -38,6 +38,8 @@ D2=$(mktemp -d -t ring-e2e-init-XXXXXX)
 RING_CONFIG_DIR="$D2" "$RING_BIN" init --port 9090 </dev/null >/dev/null 2>&1 \
   || fail "2: init --port exited non-zero"
 grep -qF "api.port = 9090" "$D2/config.toml" || fail "2: api.port = 9090 missing"
+grep -qF "[server.runtime.docker]" "$D2/config.toml" \
+  || { cat "$D2/config.toml" >&2; fail "2: expected [server.runtime.docker] block for Docker default"; }
 if grep -qF "cloud_hypervisor" "$D2/config.toml"; then
   fail "2: expected Docker default (no cloud_hypervisor block) when --runtime omitted"
 fi


### PR DESCRIPTION
## Why

Two coupled problems:

1. **Docker was mandatory.** `server.rs` did `docker::connect().expect(...)`, so Ring could not run Podman-only, Cloud-Hypervisor-only, or any Docker-less setup. No runtime should be a hard dependency.
2. **Daemon config lived under the client context.** `scheduler`, `dashboard`, and `runtime` were fields of a `[contexts.<name>]` (a client→server connection). Deciding which runtimes a *server* enables has nothing to do with how a *client* reaches it.

## What

### Config split — `[contexts.*]` (client) vs `[server]` (daemon)
- New top-level `[server]` table (shared by all contexts), holding `scheduler`, `dashboard`, and `runtime`. Mirrors Nomad's `client {}` / `server {}` split: one tool, both roles, one file.
- `[contexts.<name>]` is now purely client config (host, api).

### Runtimes are opt-in + fail-fast
- Each runtime registers **only** when `enabled = true` under `[server.runtime.<name>]`. Not enabled = never touched, even if its socket/binary exists.
- A runtime enabled but unreachable at startup is a **hard error** (config error, surfaced immediately) — Docker via a `ping()` round-trip, Cloud Hypervisor via binary resolution.
- **Guard**: zero runtimes enabled → Ring refuses to start with an actionable message.
- The Docker event listener only runs when Docker is enabled.

### `ring init`
- Generates `[server.runtime.docker]` / `[server.runtime.cloud_hypervisor]` with `enabled = true` per chosen runtime.

### Docs + e2e
- `config-toml.md` and `runtimes.md` document the opt-in model; CH how-to, dashboard how-to, troubleshooting and CLI reference migrated to the `[server]` shape.
- e2e harness (`lib.sh`) enables Docker by default; the CH suite opts out of Docker and enables CH explicitly.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --bin ring` — 546 passing.
- `ring --help` smoke test OK.
- e2e (real Docker): `t1_create_delete` deploys nginx and reaches `running` with the new `[server.runtime.docker]` config.
- Fail-fast verified manually: a config with no runtime enabled exits with "Refusing to start: no container runtime is enabled".

## Notes

Not in scope (separate branches later): Podman runtime, splitting client/server into two files.