### PR TITLE
feat(runtimes): add Podman runtime (Docker-compatible, opt-in)

### DIFF
--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -1,6 +1,6 @@
 # Runtimes
 
-Ring is a state engine; the runtime is the thing that actually starts your workload. Two implementations sit behind the same trait: **Docker** (production-ready) and **Cloud Hypervisor** (alpha). A deployment picks one with `runtime: docker` or `runtime: cloud-hypervisor`.
+Ring is a state engine; the runtime is the thing that actually starts your workload. Three implementations sit behind the same trait: **Docker** (production-ready), **Podman** (Docker-compatible, rootless-friendly), and **Cloud Hypervisor** (alpha). A deployment picks one with `runtime: docker`, `runtime: podman`, or `runtime: cloud-hypervisor`.
 
 This page covers the trade-offs and the mental model for each. For step-by-step setup, see the how-to guides; for exact manifest semantics, see the [manifest reference](/documentation/reference/manifest).
 
@@ -13,23 +13,24 @@ Runtimes are **opt-in**: none is enabled by default. You turn one on in `config.
 enabled = true
 ```
 
-Enable just the runtimes a host actually runs — Docker-only, Cloud-Hypervisor-only, or both. Ring registers exactly those, and refuses to start if none is enabled or if an enabled runtime is unreachable (an explicit-but-broken runtime is a configuration error, surfaced at startup rather than as a failed deployment later). See the [config.toml reference](/documentation/reference/config-toml#runtimes-are-opt-in) for the full rules.
+Enable just the runtimes a host actually runs — Docker-only, Podman-only, Cloud-Hypervisor-only, or any mix. Ring registers exactly those, and refuses to start if none is enabled or if an enabled runtime is unreachable (an explicit-but-broken runtime is a configuration error, surfaced at startup rather than as a failed deployment later). See the [config.toml reference](/documentation/reference/config-toml#runtimes-are-opt-in) for the full rules.
 
 ## Quick comparison
 
-| Aspect | Docker | Cloud Hypervisor |
-|---|---|---|
-| Status | Production | Alpha |
-| Isolation | Linux namespaces + cgroups | Full kernel, KVM-backed VM |
-| Boot time | ~1 s | ~3–5 s (cloud-init, kernel boot) |
-| Memory overhead per workload | ~10 MB | ~80–150 MB (kernel + guest userland) |
-| Image format | Docker image (`nginx:1.25`) | Raw disk image on the host filesystem |
-| Networking | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` |
-| Live event stream | Yes (sub-second crash detection) | No (tick-bound) |
-| `command` health checks | `docker exec` | In-guest `ring-agent` over AF_VSOCK |
-| `kind: job` | Exit code visible | Clean shutdown = success (no exit code from host) |
-| Labels (`labels:`) | Forwarded to container | Silently ignored |
-| Private registry creds | Supported | N/A (no image pull) |
+| Aspect | Docker | Podman | Cloud Hypervisor |
+|---|---|---|---|
+| Status | Production | Beta | Alpha |
+| Isolation | Linux namespaces + cgroups | Linux namespaces + cgroups (rootless by default) | Full kernel, KVM-backed VM |
+| Boot time | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) |
+| Memory overhead per workload | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) |
+| Image format | Docker image (`nginx:1.25`) | Docker/OCI image | Raw disk image on the host filesystem |
+| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` |
+| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) |
+| `command` health checks | `docker exec` | `podman exec` (same API) | In-guest `ring-agent` over AF_VSOCK |
+| `kind: job` | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) |
+| Labels (`labels:`) | Forwarded to container | Forwarded to container | Silently ignored |
+| Host networking | Supported | Not supported by Ring yet | N/A |
+| Private registry creds | Supported | Supported | N/A (no image pull) |
 
 ## Docker runtime
 
@@ -44,6 +45,30 @@ The common choice. Containers, one per replica, attached to a per-namespace brid
 **Caveats:**
 - Isolation boundary is the Linux kernel — a kernel exploit in one container can affect the host and other containers
 - The Docker socket gives Ring full control; treat the Ring host as privileged
+
+## Podman runtime (beta)
+
+Podman exposes a **Docker-compatible REST API** (`podman system service`), so Ring drives it with the same client it uses for Docker — same containers, images, exec-based health checks, labels, registry auth. The headline difference is **rootless by default**: containers run under your user namespace, no root daemon required.
+
+Enable it and point Ring at the socket (rootless-first resolution is the default):
+
+```toml
+[server.runtime.podman]
+enabled = true
+# host = "unix:///run/user/1000/podman/podman.sock"   # rootless default
+```
+
+The socket must be running — start it once with `systemctl --user start podman.socket` (rootless) or `systemctl start podman.socket` (root). Ring pings it at startup and fails fast if it's unreachable.
+
+**Good fit when:**
+- You want rootless containers (no privileged daemon on the host)
+- You're on a Podman-first distro (RHEL/Fedora) and don't run Docker
+- You want Docker semantics without the Docker daemon
+
+**Caveats:**
+- **Event stream**: Podman only emits events while `podman system service` is up. Ring does not yet consume Podman events (the orphan-volume reaper stays Docker-only), so crash detection is tick-bound for now.
+- **Host networking** (`network.mode: host`) is not yet allowed on Podman — Docker only.
+- Rootless remaps UID/GID; bind-mount and named-volume ownership behave differently than Docker-root — mind file permissions on mounts.
 
 ## Cloud Hypervisor runtime (alpha)
 

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -82,6 +82,15 @@ The daemon's own configuration, shared by every context in the file. All subsect
 | `enabled` | bool | no | `false` | Register the Docker runtime. Must be `true` for Ring to use Docker. When `true` and the daemon is unreachable at startup, Ring fails fast |
 | `host` | string | no | `"unix:///var/run/docker.sock"` | Docker daemon URL. Use `tcp://host:2375` for a remote daemon, `tcp://host:2376` for TLS |
 
+### `[server.runtime.podman]`
+
+Podman speaks the Docker-compatible API (`podman system service`), so Ring drives it with the same client.
+
+| Field | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Register the Podman runtime. Must be `true` for Ring to use Podman. When `true` and the socket is unreachable at startup, Ring fails fast |
+| `host` | string | no | rootless-first resolution | Podman API socket. Default resolution: `RING_PODMAN_HOST` → `DOCKER_HOST` → `unix:///run/user/$UID/podman/podman.sock` → `unix:///run/podman/podman.sock`. Start it with `systemctl --user start podman.socket` (rootless) |
+
 ### `[server.runtime.cloud_hypervisor]`
 
 | Field | Type | Default | Purpose |

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -32,10 +32,10 @@ fn default_replicas() -> u32 {
 
 fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
     match runtime {
-        "docker" | "cloud-hypervisor" => Ok(()),
+        "docker" | "podman" | "cloud-hypervisor" => Ok(()),
         _ => Err(
             ValidationError::new("deployment.runtime.unsupported").with_message(Cow::Borrowed(
-                "runtime must be one of: docker, cloud-hypervisor",
+                "runtime must be one of: docker, podman, cloud-hypervisor",
             )),
         ),
     }

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -248,9 +248,12 @@ impl Deployment {
             ));
         }
 
-        if self.runtime != "docker" && self.runtime != "cloud-hypervisor" {
+        if self.runtime != "docker"
+            && self.runtime != "podman"
+            && self.runtime != "cloud-hypervisor"
+        {
             return Err(ApplyError::Validation(format!(
-                "Runtime '{}' not supported. Supported runtimes: docker, cloud-hypervisor.",
+                "Runtime '{}' not supported. Supported runtimes: docker, podman, cloud-hypervisor.",
                 self.runtime
             )));
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -36,7 +36,7 @@ pub(crate) fn command_config() -> Command {
                 .long("runtime")
                 .value_name("RUNTIME")
                 .help(
-                    "Runtime to configure, skipping the prompt: docker, cloud-hypervisor, or both",
+                    "Runtime to configure, skipping the prompt: docker, podman, cloud-hypervisor, or both",
                 )
                 .value_parser(clap::value_parser!(RuntimeChoice)),
         )
@@ -62,6 +62,7 @@ pub(crate) struct InitSettings {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum RuntimeChoice {
     Docker,
+    Podman,
     CloudHypervisor,
     Both,
 }
@@ -70,6 +71,7 @@ impl RuntimeChoice {
     fn label(self) -> &'static str {
         match self {
             RuntimeChoice::Docker => "Docker",
+            RuntimeChoice::Podman => "Podman",
             RuntimeChoice::CloudHypervisor => "Cloud Hypervisor",
             RuntimeChoice::Both => "Both",
         }
@@ -172,6 +174,7 @@ fn collect_settings(args: &ArgMatches) -> InitSettings {
             "Which runtime do you want to use?",
             vec![
                 RuntimeChoice::Docker,
+                RuntimeChoice::Podman,
                 RuntimeChoice::CloudHypervisor,
                 RuntimeChoice::Both,
             ],
@@ -233,6 +236,7 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         settings.runtime,
         RuntimeChoice::Docker | RuntimeChoice::Both
     );
+    let podman = matches!(settings.runtime, RuntimeChoice::Podman);
     let cloud_hypervisor = matches!(
         settings.runtime,
         RuntimeChoice::CloudHypervisor | RuntimeChoice::Both
@@ -243,6 +247,14 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         out.push_str("[server.runtime.docker]\n");
         out.push_str("enabled = true\n");
         out.push_str("# host = \"unix:///var/run/docker.sock\"  # or tcp://host:2375\n");
+    }
+
+    if podman {
+        out.push('\n');
+        out.push_str("[server.runtime.podman]\n");
+        out.push_str("enabled = true\n");
+        // Default is rootless-first; uncomment to pin a specific socket.
+        out.push_str("# host = \"unix:///run/user/1000/podman/podman.sock\"  # rootless\n");
     }
 
     if cloud_hypervisor {
@@ -348,10 +360,19 @@ mod tests {
         );
         assert_eq!(*m.get_one::<u16>("port").unwrap(), 4030u16);
 
+        // podman is a valid runtime choice.
+        let m = command_config()
+            .try_get_matches_from(["init", "--runtime", "podman"])
+            .expect("podman must parse");
+        assert_eq!(
+            *m.get_one::<RuntimeChoice>("runtime").unwrap(),
+            RuntimeChoice::Podman
+        );
+
         // Unknown runtime is rejected by ValueEnum.
         assert!(
             command_config()
-                .try_get_matches_from(["init", "--runtime", "podman"])
+                .try_get_matches_from(["init", "--runtime", "lxc"])
                 .is_err()
         );
         // Port 0 is out of the 1.. range.
@@ -375,6 +396,20 @@ mod tests {
         assert!(out.contains("[server.runtime.docker]"));
         assert!(out.contains("enabled = true"));
         // No CH block when Docker only.
+        assert!(!out.contains("runtime.cloud_hypervisor"));
+    }
+
+    #[test]
+    fn build_config_podman_only_emits_podman_section() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Podman,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("[server.runtime.podman]"));
+        assert!(out.contains("enabled = true"));
+        // Podman is exclusive — no Docker or CH block.
+        assert!(!out.contains("[server.runtime.docker]"));
         assert!(!out.contains("runtime.cloud_hypervisor"));
     }
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -110,6 +110,34 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
         None
     };
 
+    // Podman: enabled in config → verify the daemon answers a `ping()` over its
+    // Docker-compatible API. Podman speaks the same wire protocol, so we reuse
+    // `DockerLifecycle` (no PodmanLifecycle) and register it under the "podman"
+    // key. Same fail-fast contract as Docker. No event listener yet: Podman's
+    // event stream only flows while `podman system service` is up (see
+    // runtime::podman docs) — the orphan reaper stays Docker-only for now.
+    if configuration.server.runtime.podman.enabled {
+        let host = configuration.server.runtime.podman.host.clone();
+        match docker::connect_and_verify(&host).await {
+            Ok(podman) => {
+                info!("Connected to Podman at {}", host);
+                runtimes_map.insert(
+                    "podman".to_string(),
+                    Arc::new(DockerLifecycle::new(podman, intentional_shutdowns.clone())),
+                );
+            }
+            Err(e) => {
+                error!(
+                    "Refusing to start: Podman runtime is enabled in config but unreachable: {}",
+                    e
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        info!("Podman runtime disabled in config, skipping");
+    }
+
     // Cloud Hypervisor: enabled in config → its binary must resolve, else fail
     // fast. The config/log-rotator are only built when we'll use it.
     let mut _ch_log_rotator = None;

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -46,6 +46,8 @@ pub(crate) struct RuntimesConfig {
     #[serde(default)]
     pub(crate) docker: DockerConfig,
     #[serde(default)]
+    pub(crate) podman: PodmanConfig,
+    #[serde(default)]
     pub(crate) cloud_hypervisor: CloudHypervisorConfig,
 }
 
@@ -73,6 +75,34 @@ impl Default for DockerConfig {
         DockerConfig {
             enabled: false,
             host: default_docker_host(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct PodmanConfig {
+    /// Whether to register the Podman runtime. Off by default (runtimes are
+    /// opt-in). Podman exposes a Docker-compatible API via `podman system
+    /// service`, so Ring drives it with the same `bollard` client. When `true`
+    /// and the socket doesn't answer at startup, Ring fails fast.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// Podman API socket. Defaults to the rootless-first resolution
+    /// (`RING_PODMAN_HOST` → `DOCKER_HOST` → `unix:///run/user/$UID/podman/podman.sock`
+    /// → `unix:///run/podman/podman.sock`). Override here to pin a specific socket.
+    #[serde(default = "default_podman_host")]
+    pub(crate) host: String,
+}
+
+fn default_podman_host() -> String {
+    crate::runtime::podman::resolve_socket_host()
+}
+
+impl Default for PodmanConfig {
+    fn default() -> Self {
+        PodmanConfig {
+            enabled: false,
+            host: default_podman_host(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ mod runtime {
     pub(crate) mod lifecycle_trait;
     #[cfg(test)]
     pub(crate) mod mock;
+    pub(crate) mod podman;
     pub(crate) mod port_forwarder;
     pub(crate) mod resources;
     pub(crate) mod types;

--- a/src/runtime/podman/mod.rs
+++ b/src/runtime/podman/mod.rs
@@ -1,0 +1,185 @@
+//! Podman runtime support.
+//!
+//! Podman exposes a Docker-compatible REST API via `podman system service`,
+//! which means the existing `bollard`-based `DockerLifecycle` can drive it
+//! almost unchanged — the transport and most of the request/response shapes
+//! are identical. This module's job is therefore narrow: resolve the right
+//! socket (rootless-first) and hand a connected `bollard::Docker` to
+//! `DockerLifecycle`. There is intentionally no parallel `PodmanLifecycle`
+//! struct; duplicating the container/logs/stats/health code would be pure
+//! drift waiting to happen.
+//!
+//! # Why rootless-first
+//!
+//! Rootless is Podman's default and headline mode, and it's the case that
+//! actually exercises Ring's volume abstraction: user namespaces remap the
+//! container's UID/GID, so a file written inside the container has a
+//! different owner on the host. Bind mounts, named-volume ownership, and the
+//! `o=sync` durability story all behave differently than under Docker-root.
+//! If volumes work rootless, root falls out almost for free; the reverse is
+//! not true.
+//!
+//! # Known semantic deltas (where bollard does NOT save us)
+//!
+//! These are tracked here as the real work, to be validated against a live
+//! Podman by a `tests/e2e/t*.sh` harness (cargo tests can't catch them):
+//!
+//! 1. **Events require a running service.** Unlike the always-present Docker
+//!    daemon, Podman's event stream only flows while `podman system service`
+//!    is up. The orphan-volume reaper (which consumes container `die`/`remove`
+//!    events) silently stops reaping if the service is down — we must detect
+//!    and surface that rather than appear healthy.
+//! 2. **No central daemon / fork-exec lifecycle.** Containers can outlive any
+//!    supervising process, so "is this instance actually running?" may need a
+//!    reconcile pass rather than trusting daemon-held state.
+//! 3. **Partial API compatibility.** Some endpoints/fields bollard expects in
+//!    Docker's shape are a subset or slightly different under Podman's
+//!    emulated API version. To be discovered endpoint-by-endpoint at runtime.
+
+/// Resolve the Podman API socket host, rootless-first.
+///
+/// Resolution order:
+///   1. `RING_PODMAN_HOST` — explicit override (`unix://…` or `tcp://…`).
+///   2. `DOCKER_HOST` — honoured because `podman system service` users
+///      frequently point it at the Podman socket for tooling compatibility.
+///   3. Rootless default: `unix:///run/user/$UID/podman/podman.sock`.
+///   4. Root default: `unix:///run/podman/podman.sock`.
+///
+/// Used as the default for `[server.runtime.podman] host`. The connection
+/// itself is made by `commands/server.rs` via `docker::connect_and_verify`,
+/// since Podman speaks the Docker wire protocol.
+pub(crate) fn resolve_socket_host() -> String {
+    if let Ok(explicit) = std::env::var("RING_PODMAN_HOST") {
+        let trimmed = explicit.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    if let Ok(docker_host) = std::env::var("DOCKER_HOST") {
+        let trimmed = docker_host.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    // Rootless default. `XDG_RUNTIME_DIR` is the canonical source for the
+    // per-user runtime dir; fall back to `/run/user/$UID` when it's unset
+    // (common under bare systemd user sessions and cron).
+    if let Some(rootless) = rootless_socket_path() {
+        return rootless;
+    }
+
+    // Root default — last resort, matches Podman's system-wide service.
+    "unix:///run/podman/podman.sock".to_string()
+}
+
+/// Build the rootless socket host string from the environment, or `None` if
+/// neither `XDG_RUNTIME_DIR` nor `UID` can be determined.
+fn rootless_socket_path() -> Option<String> {
+    if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+        let trimmed = xdg.trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Some(format!("unix://{}/podman/podman.sock", trimmed));
+        }
+    }
+
+    if let Ok(uid) = std::env::var("UID") {
+        let trimmed = uid.trim();
+        if !trimmed.is_empty() {
+            return Some(format!("unix:///run/user/{}/podman/podman.sock", trimmed));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests mutate process-global env vars, so they must not run
+    // concurrently with each other. A shared mutex serialises them.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_clean_env<F: FnOnce()>(f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved: Vec<(&str, Option<String>)> =
+            ["RING_PODMAN_HOST", "DOCKER_HOST", "XDG_RUNTIME_DIR", "UID"]
+                .iter()
+                .map(|k| (*k, std::env::var(k).ok()))
+                .collect();
+        for (k, _) in &saved {
+            unsafe { std::env::remove_var(k) };
+        }
+        f();
+        for (k, v) in saved {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("RING_PODMAN_HOST", "tcp://10.0.0.1:8080") };
+            unsafe { std::env::set_var("DOCKER_HOST", "unix:///should/be/ignored.sock") };
+            assert_eq!(resolve_socket_host(), "tcp://10.0.0.1:8080");
+        });
+    }
+
+    #[test]
+    fn docker_host_used_when_no_explicit() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock") };
+            assert_eq!(
+                resolve_socket_host(),
+                "unix:///run/user/1000/podman/podman.sock"
+            );
+        });
+    }
+
+    #[test]
+    fn rootless_default_from_xdg_runtime_dir() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000") };
+            assert_eq!(
+                resolve_socket_host(),
+                "unix:///run/user/1000/podman/podman.sock"
+            );
+        });
+    }
+
+    #[test]
+    fn rootless_default_from_uid_fallback() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("UID", "1234") };
+            assert_eq!(
+                resolve_socket_host(),
+                "unix:///run/user/1234/podman/podman.sock"
+            );
+        });
+    }
+
+    #[test]
+    fn root_default_as_last_resort() {
+        with_clean_env(|| {
+            assert_eq!(resolve_socket_host(), "unix:///run/podman/podman.sock");
+        });
+    }
+
+    #[test]
+    fn empty_override_is_ignored() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("RING_PODMAN_HOST", "   ") };
+            unsafe { std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000") };
+            assert_eq!(
+                resolve_socket_host(),
+                "unix:///run/user/1000/podman/podman.sock"
+            );
+        });
+    }
+}

--- a/tests/e2e/fixtures/nginx-podman.yaml
+++ b/tests/e2e/fixtures/nginx-podman.yaml
@@ -1,0 +1,7 @@
+deployments:
+  nginx:
+    name: nginx
+    namespace: ring-e2e
+    runtime: podman
+    image: docker.io/library/nginx:alpine
+    replicas: 1

--- a/tests/e2e/podman/t1_podman_deploy.sh
+++ b/tests/e2e/podman/t1_podman_deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# T1-podman: prove Ring drives Podman end-to-end. Boots Ring with ONLY the
+# Podman runtime enabled (Docker off), deploys nginx via Podman's
+# Docker-compatible API, asserts it reaches Running with a real Podman
+# container, then deletes it and asserts the container is gone.
+#
+# Skips cleanly (exit 0) if Podman or its rootless socket isn't available, so
+# the test never breaks a CI host without Podman — it only runs where it can
+# actually prove the runtime.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T1-podman: create / delete via Podman =="
+
+# --- Prerequisites: podman binary + a reachable rootless socket ---
+if ! command -v podman > /dev/null 2>&1; then
+  log "podman not installed — SKIP"
+  exit 0
+fi
+
+PODMAN_SOCK="${RING_PODMAN_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+SOCK_PATH="${PODMAN_SOCK#unix://}"
+if [ ! -S "$SOCK_PATH" ]; then
+  # Try to start the rootless socket service; skip if we can't.
+  systemctl --user start podman.socket 2>/dev/null || true
+  if [ ! -S "$SOCK_PATH" ]; then
+    log "podman socket $SOCK_PATH not available — SKIP"
+    exit 0
+  fi
+fi
+log "podman socket: $SOCK_PATH"
+
+# Boot Ring with Podman only (no Docker), pointing at the rootless socket.
+export RING_E2E_ENABLE_DOCKER=false
+export RING_EXTRA_CONFIG="[server.runtime.podman]
+enabled = true
+host = \"$PODMAN_SOCK\""
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-podman.yaml"
+
+wait_deployment_status "ring-e2e" "nginx" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+# Assert a real Podman container exists for this deployment.
+count=$(podman ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+if [ "$count" -lt 1 ]; then
+  podman ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" >&2
+  fail "expected a Podman container for deployment $DEPLOYMENT_ID, found none"
+fi
+log "podman container exists for deployment $DEPLOYMENT_ID (count=$count)"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# Wait for the container to disappear from Podman.
+for _ in $(seq 1 30); do
+  left=$(podman ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+  if [ "$left" -eq 0 ]; then
+    log "no podman container left for deployment $DEPLOYMENT_ID"
+    log "== T1-podman: PASS =="
+    exit 0
+  fi
+  sleep 1
+done
+
+podman ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" >&2
+fail "podman container for $DEPLOYMENT_ID still present after delete"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   tests/e2e/run.sh                    # run every suite
 #   tests/e2e/run.sh docker             # run only Docker tests
+#   tests/e2e/run.sh podman             # run only Podman tests
 #   tests/e2e/run.sh cloud-hypervisor   # run only Cloud Hypervisor tests
 #
 # The script doesn't `set -e` on the loop so a single failing test does not
@@ -15,7 +16,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SUITES=("server" "docker" "cloud-hypervisor")
+SUITES=("server" "docker" "podman" "cloud-hypervisor")
 
 # Restrict to the suite the user named, if any.
 if [ "$#" -gt 0 ]; then

--- a/tests/e2e/server/t8_init_non_interactive.sh
+++ b/tests/e2e/server/t8_init_non_interactive.sh
@@ -8,9 +8,11 @@
 #      and a [server.runtime.cloud_hypervisor] block, with no prompt.
 #   2. `init --port 9090` (no --runtime, no TTY) → custom port, Docker default
 #      (a [server.runtime.docker] block, no cloud_hypervisor block).
-#   3. an invalid `--runtime` value is rejected (non-zero exit, lists the
-#      accepted values).
+#   3. an invalid `--runtime` value (e.g. lxc) is rejected (non-zero exit, lists
+#      the accepted values).
 #   4. re-running without --force refuses to overwrite (non-zero exit).
+#   5. `init --runtime podman --port 4040` writes a [server.runtime.podman]
+#      block (exclusive: no docker block).
 
 set -euo pipefail
 
@@ -48,14 +50,25 @@ log "2 (--port only → Docker default): correct"
 # --- Invariant 3: invalid runtime rejected ---
 D3=$(mktemp -d -t ring-e2e-init-XXXXXX)
 set +e
-OUT=$(RING_CONFIG_DIR="$D3" "$RING_BIN" init --runtime podman 2>&1)
+OUT=$(RING_CONFIG_DIR="$D3" "$RING_BIN" init --runtime lxc 2>&1)
 RC=$?
 set -e
 [ "$RC" -ne 0 ] || fail "3: invalid --runtime must exit non-zero"
-echo "$OUT" | grep -qiE "docker, cloud-hypervisor, both" \
+echo "$OUT" | grep -qiE "docker, podman, cloud-hypervisor, both" \
   || { echo "$OUT" >&2; fail "3: expected accepted runtime values in the error"; }
 [ -f "$D3/config.toml" ] && fail "3: no config.toml should be written on rejection"
 log "3 (invalid runtime rejected): exit $RC, no config written"
+
+# --- Invariant 5: scripted Podman init ---
+D5=$(mktemp -d -t ring-e2e-init-XXXXXX)
+RING_CONFIG_DIR="$D5" "$RING_BIN" init --runtime podman --port 4040 >/dev/null 2>&1 \
+  || fail "5: init --runtime podman exited non-zero"
+grep -qF "[server.runtime.podman]" "$D5/config.toml" \
+  || { cat "$D5/config.toml" >&2; fail "5: podman block missing"; }
+if grep -qF "[server.runtime.docker]" "$D5/config.toml"; then
+  fail "5: podman is exclusive, no docker block expected"
+fi
+log "5 (scripted Podman init): config.toml correct"
 
 # --- Invariant 4: refuse to overwrite without --force ---
 set +e
@@ -66,5 +79,5 @@ set -e
 echo "$OUT" | grep -qiF "already exists" || { echo "$OUT" >&2; fail "4: expected 'already exists'"; }
 log "4 (no clobber without --force): refused"
 
-rm -rf "$D1" "$D2" "$D3"
+rm -rf "$D1" "$D2" "$D3" "$D5"
 log "== T8-server: all invariants passed =="


### PR DESCRIPTION
## Why

Ring already orchestrates Docker and Cloud Hypervisor, and since #138 runtimes are opt-in under `[server.runtime.<name>]`. A Podman scaffold existed but was never wired in. Podman exposes a **Docker-compatible REST API** (`podman system service`), so it slots into the same `bollard`-based `DockerLifecycle` with no duplicate runtime code — and it gives operators a rootless, daemonless option (RHEL/Fedora first-class).

## What

- **Config**: `[server.runtime.podman]` with `enabled` + `host` (rootless-first default resolution: `RING_PODMAN_HOST` → `DOCKER_HOST` → `unix:///run/user/$UID/podman/podman.sock` → `unix:///run/podman/podman.sock`).
- **Runtime**: `podman` module wired into `main.rs`; scaffold cleaned (dropped `#[allow(dead_code)]`, `connect()`; kept rootless socket resolution + tests). Reuses `DockerLifecycle` — no `PodmanLifecycle`.
- **Server**: opt-in registration under key `"podman"` via `connect_and_verify` (ping), fail-fast if enabled-but-unreachable. Mirrors the Docker branch. Covered by the existing zero-runtime guard.
- **Validation + init**: `validate_runtime` and `ring apply` accept `podman`; `ring init --runtime podman` generates the `[server.runtime.podman]` block; interactive menu gains Podman.
- **Docs**: `concepts/runtimes.md` (3rd runtime, comparison table, dedicated section) + `reference/config-toml.md`.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --bin ring` — 553 passing.
- **e2e (real Podman 5.7, rootless)**: new `tests/e2e/podman/t1_podman_deploy.sh` boots Ring with **only** Podman enabled, deploys nginx via the Podman API, asserts a real `podman ps` container reaches Running, then deletes it — **PASS**. Skips cleanly if Podman/socket is absent (CI-safe).
- `ring init --runtime podman` generates the expected TOML.
- Fail-fast verified: bogus podman socket → "Refusing to start: Podman runtime is enabled in config but unreachable".

## Notes (out of scope, tracked)

- **Podman event listener** (orphan reaper) — Podman events only flow while `podman system service` runs; the reaper stays Docker-only for now.
- **Host networking** stays docker-only; Podman supports it with different semantics, to validate separately.