### PR TITLE
fix(deploy): recreate instead of rolling for host-port deployments

### DIFF
--- a/documentation/how-to/perform-rolling-update.md
+++ b/documentation/how-to/perform-rolling-update.md
@@ -12,8 +12,13 @@ For the underlying mechanism (parent/child deployments, readiness gate, drain lo
 | `--force` is set | Immediate replacement |
 | No health checks declared | Immediate replacement |
 | Multiple active deployments share `name`+`namespace` | Immediate replacement (clean up duplicates first) |
+| Manifest publishes a host port (`ports[].published`) | Immediate replacement (**recreate**) — see below |
 
 Immediate replacement stops every old instance before starting the new ones — brief downtime. Rolling update keeps traffic flowing.
+
+### Why a published host port forces recreate
+
+A host port can be bound by only one container at a time. A rolling update creates the new container *before* stopping the old one, so the new bind would collide with the old (`port is already allocated`) and the deployment would loop in `instance_creation_failed`. To avoid that, Ring automatically **recreates** any deployment that publishes a host port: it stops the old container first, then starts the new one. This means a **brief downtime** during the swap — unavoidable while a single host port is shared. The switch is logged as a warning event on the new deployment so it's visible in `ring deployment inspect`.
 
 ## Trigger a rollout
 

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -696,8 +696,21 @@ pub(crate) async fn create(
                     .map(|hc| !hc.is_empty())
                     .unwrap_or(false);
 
+                // A published host port can be bound by only one container at a
+                // time. Rolling update creates the new container *before*
+                // draining the old one, so the new bind collides with the old
+                // ("port is already allocated") and the deployment loops in
+                // instance_creation_failed. For these deployments we must
+                // recreate (drop old, then create new) instead — a brief
+                // downtime, but deterministic and loop-free.
+                let publishes_host_port = input.ports.iter().any(|p| p.published > 0);
+
                 // Rolling update: keep old deployment running if conditions are met
-                if !params.force && has_health_checks && deployments_list.len() == 1 {
+                if !params.force
+                    && has_health_checks
+                    && deployments_list.len() == 1
+                    && !publishes_host_port
+                {
                     let existing = &deployments_list[0];
                     info!(
                         "Rolling update: keeping deployment {} running as parent",
@@ -707,13 +720,16 @@ pub(crate) async fn create(
                 } else {
                     // Immediate replace. Pick the most specific reason so
                     // operators can fix the root cause: `force=true` is a
-                    // deliberate caller choice, the others are config gaps.
+                    // deliberate caller choice, the others are config gaps,
+                    // and `host_port_published` is the rolling-incompatible case.
                     replace_reason = Some(if params.force {
                         "force"
                     } else if !has_health_checks {
                         "no_health_checks"
-                    } else {
+                    } else if deployments_list.len() > 1 {
                         "multiple_active_deployments"
+                    } else {
+                        "host_port_published"
                     });
                     for mut deployment in deployments_list {
                         info!("Marking deployment {} as deleted", deployment.id);
@@ -846,6 +862,10 @@ pub(crate) async fn create(
                     "multiple_active_deployments" => format!(
                         "Replaced {} immediately because more than one active deployment was found for {}/{} — rolling update only applies when exactly one parent exists",
                         replaced, deployment.namespace, deployment.name
+                    ),
+                    "host_port_published" => format!(
+                        "Replaced {} immediately because it publishes a host port — rolling update would collide on the port (it creates the new container before stopping the old), so Ring recreated it instead (brief downtime)",
+                        replaced
                     ),
                     other => format!("Replaced {} immediately ({})", replaced, other),
                 };
@@ -2360,6 +2380,139 @@ mod tests {
         .expect("ForceReplace event must be logged");
         assert_eq!(event.0, "warning");
         assert!(event.1.contains("force=true"), "got message: {}", event.1);
+    }
+
+    #[tokio::test]
+    async fn host_port_forces_recreate_instead_of_rolling() {
+        let (pool, app) = new_test_app_with_pool().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // Initial deployment: health checks AND a published host port. Rolling
+        // would normally apply (HC present, single active), but the host port
+        // makes it rolling-incompatible.
+        let response = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "edge-app",
+                "namespace": "edge-ns",
+                "image": "nginx:1.0",
+                "ports": [{"published": 18080, "target": 80}],
+                "health_checks": [{"type": "tcp", "port": 80, "interval": "10s", "timeout": "5s", "on_failure": "restart"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let first: serde_json::Value = response.json();
+        let first_id = first["id"].as_str().unwrap().to_string();
+
+        sqlx::query("UPDATE deployment SET status = 'running' WHERE id = ?")
+            .bind(&first_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Re-apply (same name, new image, same host port). Must recreate, not roll.
+        let response = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "edge-app",
+                "namespace": "edge-ns",
+                "image": "nginx:2.0",
+                "ports": [{"published": 18080, "target": 80}],
+                "health_checks": [{"type": "tcp", "port": 80, "interval": "10s", "timeout": "5s", "on_failure": "restart"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+
+        // Parent must be wiped (recreate), not kept running as a rolling parent.
+        let parent: serde_json::Value = server
+            .get(&format!("/deployments/{}", first_id))
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await
+            .json();
+        assert_eq!(
+            parent["status"], "deleted",
+            "host-port deployment must recreate, not roll"
+        );
+
+        // The new deployment carries the host_port_published reason.
+        let deployments: Vec<serde_json::Value> = server
+            .get("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await
+            .json();
+        let new_id = deployments
+            .iter()
+            .find(|d| d["name"] == "edge-app" && d["id"].as_str() != Some(&first_id))
+            .expect("new deployment must exist")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let event: (String, String) = sqlx::query_as(
+            "SELECT level, message FROM deployment_event WHERE deployment_id = ? AND reason = 'force_replace'",
+        )
+        .bind(&new_id)
+        .fetch_one(&pool)
+        .await
+        .expect("recreate event must be logged");
+        assert_eq!(event.0, "warning");
+        assert!(event.1.contains("host port"), "got message: {}", event.1);
+    }
+
+    #[tokio::test]
+    async fn rolling_update_without_host_port_still_rolls() {
+        let (pool, app) = new_test_app_with_pool().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // Non-regression: HC present, single active, NO host port → still rolling.
+        let response = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "noport-app",
+                "namespace": "noport-ns",
+                "image": "nginx:1.0",
+                "health_checks": [{"type": "tcp", "port": 80, "interval": "10s", "timeout": "5s", "on_failure": "restart"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let first_id = response.json::<serde_json::Value>()["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        sqlx::query("UPDATE deployment SET status = 'running' WHERE id = ?")
+            .bind(&first_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "noport-app",
+                "namespace": "noport-ns",
+                "image": "nginx:2.0",
+                "health_checks": [{"type": "tcp", "port": 80, "interval": "10s", "timeout": "5s", "on_failure": "restart"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+
+        // Parent kept running → rolling, not recreate.
+        let parent: serde_json::Value = server
+            .get(&format!("/deployments/{}", first_id))
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await
+            .json();
+        assert_eq!(parent["status"], "running");
     }
 
     #[tokio::test]

--- a/tests/e2e/docker/t36_rolling_update_host_port.sh
+++ b/tests/e2e/docker/t36_rolling_update_host_port.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# T36: rolling update of a deployment that publishes a fixed host port.
+#
+# A published host port can be bound by only one container at a time. A naive
+# rolling update creates the new container before stopping the old one, so the
+# new bind collides ("port is already allocated") and the deployment loops in
+# instance_creation_failed forever (observed in prod 2026-05-20 on Vector).
+#
+# Ring must instead recreate (drop old, then create new) for these deployments:
+# the old container is gone BEFORE the new one is created, the port is free, no
+# loop. This test proves it — without the fix, v2 never reaches Running.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T36: rolling update with fixed host port =="
+
+start_ring
+ring_login
+
+# Apply v1 (host port 18080 + health checks)
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-hostport-v1.yaml"
+wait_deployment_by_image "ring-e2e" "nginx-hostport" "nginx:1.25-alpine" "running" 90
+
+V1_ID=$(get_deployment_id_by_image "ring-e2e" "nginx-hostport" "nginx:1.25-alpine")
+[ -n "$V1_ID" ] || fail "could not find v1 deployment id"
+log "v1 id: $V1_ID"
+assert_docker_container_exists "$V1_ID"
+
+# Apply v2 (same name, same host port, new image). Ring must recreate: drop v1
+# first, then create v2 — so v2 reaches Running without a port collision loop.
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/nginx-hostport-v2.yaml"
+wait_deployment_by_image "ring-e2e" "nginx-hostport" "nginx:1.26-alpine" "running" 90
+
+V2_ID=$(get_deployment_id_by_image "ring-e2e" "nginx-hostport" "nginx:1.26-alpine")
+[ -n "$V2_ID" ] || fail "could not find v2 deployment id — recreate likely looped on the host port"
+log "v2 id: $V2_ID"
+
+[ "$V1_ID" != "$V2_ID" ] || fail "v1 and v2 share the same deployment id"
+
+# v1 must be gone (recreate stops it before creating v2; not a slow drain).
+wait_docker_container_gone "$V1_ID" 30
+assert_docker_container_exists "$V2_ID"
+
+# Guard against the bug signature: v2 must not have looped on port allocation.
+if "$RING_BIN" deployment inspect "$V2_ID" 2>/dev/null | grep -qiE "already allocated|instance_creation_failed"; then
+  fail "v2 shows a port-allocation/creation-failure — recreate did not free the host port first"
+fi
+log "v2 reached running on the host port with no allocation loop"
+
+# Cleanup
+"$RING_BIN" deployment delete "$V2_ID"
+wait_docker_container_gone "$V2_ID" 30
+
+log "== T36: PASS =="

--- a/tests/e2e/fixtures/nginx-hostport-v1.yaml
+++ b/tests/e2e/fixtures/nginx-hostport-v1.yaml
@@ -1,0 +1,18 @@
+deployments:
+  nginx-hostport:
+    name: nginx-hostport
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:1.25-alpine
+    replicas: 1
+    ports:
+      - published: 18080
+        target: 80
+        host_ip: 127.0.0.1
+    health_checks:
+      - type: tcp
+        port: 80
+        interval: 2s
+        timeout: 1s
+        threshold: 2
+        on_failure: restart

--- a/tests/e2e/fixtures/nginx-hostport-v2.yaml
+++ b/tests/e2e/fixtures/nginx-hostport-v2.yaml
@@ -1,0 +1,18 @@
+deployments:
+  nginx-hostport:
+    name: nginx-hostport
+    namespace: ring-e2e
+    runtime: docker
+    image: nginx:1.26-alpine
+    replicas: 1
+    ports:
+      - published: 18080
+        target: 80
+        host_ip: 127.0.0.1
+    health_checks:
+      - type: tcp
+        port: 80
+        interval: 2s
+        timeout: 1s
+        threshold: 2
+        on_failure: restart


### PR DESCRIPTION
## Why

Production bug (observed 2026-05-20 on Vector, `host_ip: 127.0.0.1` port 5514). A deployment that publishes a host port (`ports[].published`) cannot be rolling-updated: the scheduler creates the new container **before** stopping the old one, Docker rejects the bind (`port is already allocated`), and the deployment loops in `instance_creation_failed` every ~15s while the old container stays up. Any "edge" service (reverse proxy, log bus, exposed DB) was stuck without a manual `docker stop`.

## What

When a deployment publishes a host port, Ring now **recreates** it (drop old → create new) instead of rolling — the old container is gone before the new one is created, so the port is free and there's no loop. Brief downtime, but deterministic.

- `create.rs`: the rolling decision now also requires *no published host port*; otherwise it takes the existing immediate-replace path with a new `host_port_published` reason.
- The switch is surfaced as a warning event on the new deployment (reuses the existing `replace_reason` / `force_replace` event mechanism) so operators see why their rolling became a recreate.
- No new manifest field, no migration — detection is automatic from `ports[].published`.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --bin ring` — 555 passing (2 new unit tests: recreate-when-host-port, still-rolls-without-host-port).
- **e2e (real Docker)**: new `tests/e2e/docker/t36_rolling_update_host_port.sh` — applies v1 then v2 sharing host port 18080; v2 reaches Running with no allocation loop, v1 is gone. Without the fix, v2 loops forever (so the test pins the bug).
- Non-regression: `tests/e2e/docker/t4_rolling_update.sh` (rolling without a host port) still passes.

## Notes

Out of scope (separate ROADMAP items): explicit `strategy` manifest field, blue/green, Docker-side port pre-check (recreate already eliminates the collision for this case).