### PR TITLE
feat(firecracker): microVM runtime — boot, networking, restart reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,7 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "inquire",
+ "libc",
  "local-ip-address",
  "log",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ shell-words = "1.1"
 inquire = "0.7"
 
 sysinfo = "0.35.1"
+# Used by the Firecracker runtime to create/configure the host TAP device via
+# syscalls (ioctl TUNSETIFF + socket ioctls). Direct ioctls are required
+# because shelling out to `ip` loses CAP_NET_ADMIN across the fork-exec.
+libc = "0.2"
 thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -91,6 +91,16 @@ export interface DeploymentResources {
 /** Either a literal string or a `{ secretRef: "name" }` reference. */
 export type EnvValue = string | { secretRef: string };
 
+/**
+ * One running instance of a deployment. Mirrors `DeploymentInstance` from
+ * `src/api/dto/deployment.rs`: `address` is the routable guest IP, omitted
+ * when the instance has no reachable address (e.g. no published ports).
+ */
+export interface DeploymentInstance {
+  id: string;
+  address?: string;
+}
+
 export interface DeploymentDetail extends Deployment {
   created_at: string;
   updated_at: string;
@@ -99,7 +109,7 @@ export interface DeploymentDetail extends Deployment {
   command: string[];
   ports: DeploymentPort[];
   labels: Record<string, string>;
-  instances: string[];
+  instances: DeploymentInstance[];
   environment: Record<string, EnvValue>;
   volumes: DeploymentVolume[];
   health_checks: HealthCheck[];

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -427,8 +427,10 @@
       <p class="muted pad">No running instances.</p>
     {:else}
       <ul class="instance-list">
-        {#each detail.instances as inst (inst)}
-          <li class="mono">{inst}</li>
+        {#each detail.instances as inst (inst.id)}
+          <li class="mono">
+            {inst.id}{#if inst.address}<span class="muted"> ({inst.address})</span>{/if}
+          </li>
         {/each}
       </ul>
     {/if}

--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -24,7 +24,7 @@ Enable just the runtimes a host actually runs — Docker-only, Podman-only, Clou
 | Boot time | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) | ~1 s (minimal microVM) |
 | Memory overhead per workload | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) | ~5–50 MB (minimal device model) |
 | Image format | Docker image (`nginx:1.25`) | Docker/OCI image | Raw disk image on the host filesystem | Kernel (`vmlinux`) + ext4 rootfs on the host filesystem |
-| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` | Not yet (boot-only) |
+| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` | Per-VM /30 subnet, host-port forwarding via `socat` (Ring-owned host TAP) |
 | Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) | No (tick-bound) |
 | `command` health checks | `docker exec` | `podman exec` (same API) | In-guest `ring-agent` over AF_VSOCK | Not yet |
 | `kind: job` | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) | Not yet (runs as worker) |
@@ -113,17 +113,18 @@ deployments:
 
 Ring copies the rootfs per instance (so replicas and reboots don't share guest state), spawns one `firecracker` process per VM bound to a private API socket, then drives Firecracker's REST API — `boot-source`, `drives`, `machine-config`, `actions` — to configure and boot the microVM.
 
+**Networking.** A deployment that publishes `ports` gets a per-VM `/30` subnet (the same `10.42.x.y` scheme as Cloud Hypervisor), with host-port forwarding via `socat`. Unlike Cloud Hypervisor — which creates its own TAP — Firecracker expects the host TAP to already exist, so **Ring owns the TAP's whole lifecycle**: it creates the interface (via direct `ioctl`s, so the `CAP_NET_ADMIN` capability stays in-process), assigns the host side an IP, hands the device name to Firecracker, and deletes it on teardown. The guest IP is configured by cloud-init from a NoCloud datasource. Running `ring-server` therefore needs `CAP_NET_ADMIN` (or root) for any deployment with ports — grant it with `setcap cap_net_admin+ep $(command -v ring)`.
+
 **Good fit when:**
 - You want VM-grade isolation with a smaller footprint and faster boot than Cloud Hypervisor
 - You can ship a kernel + rootfs pair (the Firecracker CI artifacts are a good starting point)
 - You're building short-lived or high-density workloads where microVM overhead matters
 
-**Current limitations (experimental — boot-only):**
-- **No networking yet** — VMs boot without a TAP interface; `ports`, host networking, and inter-VM traffic are not wired (the shared `host_net`/`socat` plumbing used by Cloud Hypervisor lands in a later cut)
+**Current limitations (experimental):**
 - **No volumes** — `volumes:` are not mounted yet (virtio-fs reuse is planned)
 - **No `command` health checks** — needs an in-guest agent over vsock, like Cloud Hypervisor
 - **No metrics** and **no `kind: job`** — a `job` deployment is treated as a worker
-- **No resource limits applied** — every microVM boots with 1 vCPU / 128 MiB regardless of `resources`
+- **No reconciliation across `ring-server` restarts** — instances tracked in-process are not re-adopted after a restart
 - Crash detection is tick-bound (no event stream), and `labels` are silently ignored
 
 ## Choosing

--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -1,6 +1,6 @@
 # Runtimes
 
-Ring is a state engine; the runtime is the thing that actually starts your workload. Three implementations sit behind the same trait: **Docker** (production-ready), **Podman** (Docker-compatible, rootless-friendly), and **Cloud Hypervisor** (alpha). A deployment picks one with `runtime: docker`, `runtime: podman`, or `runtime: cloud-hypervisor`.
+Ring is a state engine; the runtime is the thing that actually starts your workload. Four implementations sit behind the same trait: **Docker** (production-ready), **Podman** (Docker-compatible, rootless-friendly), **Cloud Hypervisor** (alpha), and **Firecracker** (experimental). A deployment picks one with `runtime: docker`, `runtime: podman`, `runtime: cloud-hypervisor`, or `runtime: firecracker`.
 
 This page covers the trade-offs and the mental model for each. For step-by-step setup, see the how-to guides; for exact manifest semantics, see the [manifest reference](/documentation/reference/manifest).
 
@@ -17,20 +17,20 @@ Enable just the runtimes a host actually runs — Docker-only, Podman-only, Clou
 
 ## Quick comparison
 
-| Aspect | Docker | Podman | Cloud Hypervisor |
-|---|---|---|---|
-| Status | Production | Beta | Alpha |
-| Isolation | Linux namespaces + cgroups | Linux namespaces + cgroups (rootless by default) | Full kernel, KVM-backed VM |
-| Boot time | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) |
-| Memory overhead per workload | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) |
-| Image format | Docker image (`nginx:1.25`) | Docker/OCI image | Raw disk image on the host filesystem |
-| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` |
-| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) |
-| `command` health checks | `docker exec` | `podman exec` (same API) | In-guest `ring-agent` over AF_VSOCK |
-| `kind: job` | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) |
-| Labels (`labels:`) | Forwarded to container | Forwarded to container | Silently ignored |
-| Host networking | Supported | Not supported by Ring yet | N/A |
-| Private registry creds | Supported | Supported | N/A (no image pull) |
+| Aspect | Docker | Podman | Cloud Hypervisor | Firecracker |
+|---|---|---|---|---|
+| Status | Production | Beta | Alpha | Experimental |
+| Isolation | Linux namespaces + cgroups | Linux namespaces + cgroups (rootless by default) | Full kernel, KVM-backed VM | Full kernel, KVM-backed microVM |
+| Boot time | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) | ~1 s (minimal microVM) |
+| Memory overhead per workload | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) | ~5–50 MB (minimal device model) |
+| Image format | Docker image (`nginx:1.25`) | Docker/OCI image | Raw disk image on the host filesystem | Kernel (`vmlinux`) + ext4 rootfs on the host filesystem |
+| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` | Not yet (boot-only) |
+| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) | No (tick-bound) |
+| `command` health checks | `docker exec` | `podman exec` (same API) | In-guest `ring-agent` over AF_VSOCK | Not yet |
+| `kind: job` | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) | Not yet (runs as worker) |
+| Labels (`labels:`) | Forwarded to container | Forwarded to container | Silently ignored | Silently ignored |
+| Host networking | Supported | Not supported by Ring yet | N/A | N/A |
+| Private registry creds | Supported | Supported | N/A (no image pull) | N/A (no image pull) |
 
 ## Docker runtime
 
@@ -87,6 +87,44 @@ The trade-off: the VM model has no native primitive for several things Docker gi
 - No inter-VM networking — each VM is on its own /30, cross-VM traffic goes through host-published ports
 - Crash detection is tick-bound (no event stream from CH)
 - Some manifest fields are silently ignored — see [Cloud Hypervisor limitations](/documentation/how-to/deploy-on-cloud-hypervisor#limitations)
+
+## Firecracker runtime (experimental)
+
+Like Cloud Hypervisor, each deployment runs as a dedicated KVM-backed microVM with its own kernel — same isolation story, but a different VMM. Firecracker is the minimalist VMM behind AWS Lambda and Fargate: a tiny device model, a fast boot path, and a low memory footprint, at the cost of a smaller feature set than Cloud Hypervisor.
+
+The headline difference from Cloud Hypervisor is the image model. Firecracker boots an **uncompressed kernel** (`vmlinux`) directly — there is no firmware step — and mounts a **rootfs ext4 image** as the root device. Both live on the host filesystem:
+
+```toml
+[server.runtime.firecracker]
+enabled = true
+kernel_path = "/var/lib/ring/firecracker/vmlinux"   # uncompressed kernel
+# socket_dir = "/var/lib/ring/firecracker/sockets"  # per-VM API sockets + rootfs copies
+```
+
+A deployment's `image` is the **host path to the rootfs** (not an OCI reference — there is no image pull):
+
+```yaml
+deployments:
+  api:
+    runtime: firecracker
+    image: "/var/lib/ring/firecracker/ubuntu-22.04.ext4"
+    replicas: 2
+```
+
+Ring copies the rootfs per instance (so replicas and reboots don't share guest state), spawns one `firecracker` process per VM bound to a private API socket, then drives Firecracker's REST API — `boot-source`, `drives`, `machine-config`, `actions` — to configure and boot the microVM.
+
+**Good fit when:**
+- You want VM-grade isolation with a smaller footprint and faster boot than Cloud Hypervisor
+- You can ship a kernel + rootfs pair (the Firecracker CI artifacts are a good starting point)
+- You're building short-lived or high-density workloads where microVM overhead matters
+
+**Current limitations (experimental — boot-only):**
+- **No networking yet** — VMs boot without a TAP interface; `ports`, host networking, and inter-VM traffic are not wired (the shared `host_net`/`socat` plumbing used by Cloud Hypervisor lands in a later cut)
+- **No volumes** — `volumes:` are not mounted yet (virtio-fs reuse is planned)
+- **No `command` health checks** — needs an in-guest agent over vsock, like Cloud Hypervisor
+- **No metrics** and **no `kind: job`** — a `job` deployment is treated as a worker
+- **No resource limits applied** — every microVM boots with 1 vCPU / 128 MiB regardless of `resources`
+- Crash detection is tick-bound (no event stream), and `labels` are silently ignored
 
 ## Choosing
 

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -160,13 +160,20 @@ curl -H "Authorization: Bearer $TOKEN" \
     "replicas": 1,
     "ports": [],
     "labels": { "app": "nginx" },
-    "instances": ["abc123def456..."],
+    "instances": [{ "id": "abc123def456...", "address": "10.42.1.6" }],
     "environment": { "ENV": "production" },
     "volumes": [],
     "image_digest": "sha256:..."
   }
 ]
 ```
+
+Each entry in `instances` is an object with the instance `id` and, when the
+instance has a reachable network, its routable guest `address`. The `address`
+field is **omitted** when the instance has no reachable endpoint — for example a
+deployment with no published ports, where no network is allocated. This mirrors
+the Nomad/Consul "service instance = address" model, so service-discovery
+providers and proxies can route to a specific instance.
 
 ### `POST /deployments`
 
@@ -276,7 +283,7 @@ Retrieve a deployment by UUID.
   "replicas": 1,
   "ports": [],
   "labels": { "app": "nginx" },
-  "instances": ["abc123def456..."],
+  "instances": [{ "id": "abc123def456..." }],
   "environment": { "ENV": "production" },
   "volumes": [
     {

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -101,6 +101,16 @@ Podman speaks the Docker-compatible API (`podman system service`), so Ring drive
 | `socket_dir` | string | `$RING_CONFIG_DIR/cloud-hypervisor/sockets` | Where Ring puts per-VM Unix sockets, console logs, volume shares |
 | `seccomp` | string | unset (CH default: kill on violation) | Forwarded to `cloud-hypervisor --seccomp`. Accepts `"true"`, `"false"`, `"log"`. Set to `"false"` only on hosts where the kernel uses syscalls not whitelisted by CH (otherwise VMs die with `SIGSYS`) |
 
+### `[server.runtime.firecracker]`
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `enabled` | bool | `false` | Register the Firecracker runtime. Must be `true` for Ring to use it. When `true` and `binary_path` can't be resolved at startup, Ring fails fast |
+| `binary_path` | string | `firecracker` (from `$PATH`) | Absolute path to the `firecracker` binary |
+| `kernel_path` | string | `$RING_CONFIG_DIR/firecracker/vmlinux` | Path to the uncompressed kernel image. Firecracker boots a kernel directly — there is no firmware step |
+| `socket_dir` | string | `$RING_CONFIG_DIR/firecracker/sockets` | Where Ring puts per-VM API sockets and per-instance rootfs copies |
+| `boot_args` | string | `console=ttyS0 reboot=k panic=1 pci=off` | Kernel command line passed to every microVM |
+
 ## Examples
 
 ### Minimal single-host (Docker)

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -279,6 +279,8 @@ Both `limits` and `requests` are optional. Within each, `cpu` and `memory` are a
 
 > **Cloud Hypervisor sizing.** When `resources` is not set on a CH deployment, the VM defaults to 1 vCPU and 256 MiB of RAM. Resizing is at-boot only; Ring does not use Cloud Hypervisor's `vm.resize` API to live-resize a running VM, so changing `resources` requires a redeploy.
 
+> **Firecracker sizing.** Reads `limits` (falling back to `requests`): the memory becomes the microVM's RAM and the CPU becomes its vCPU count, **rounded up** to whole vCPUs (Firecracker can't allocate fractional cores) with a floor of 1. When neither is set, a microVM defaults to **1 vCPU and 512 MiB** — enough headroom to boot systemd plus a real service rather than OOMing at boot. Sizing is at-boot only; changing `resources` requires a redeploy.
+
 ### CPU values
 
 - Millicores: `"500m"` (= 0.5 cores), `"1500m"` (= 1.5 cores)

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -32,10 +32,10 @@ fn default_replicas() -> u32 {
 
 fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
     match runtime {
-        "docker" | "podman" | "cloud-hypervisor" => Ok(()),
+        "docker" | "podman" | "cloud-hypervisor" | "firecracker" => Ok(()),
         _ => Err(
             ValidationError::new("deployment.runtime.unsupported").with_message(Cow::Borrowed(
-                "runtime must be one of: docker, podman, cloud-hypervisor",
+                "runtime must be one of: docker, podman, cloud-hypervisor, firecracker",
             )),
         ),
     }

--- a/src/api/action/deployment/get.rs
+++ b/src/api/action/deployment/get.rs
@@ -2,7 +2,7 @@ use axum::extract::State;
 use axum::{Json, extract::Path, response::IntoResponse};
 
 use crate::api::auth::{Auth, require_namespace};
-use crate::api::dto::deployment::DeploymentOutput;
+use crate::api::dto::deployment::{DeploymentInstance, DeploymentOutput};
 use crate::api::server::{Db, RuntimeMap};
 use crate::models::deployments;
 use axum::http::StatusCode;
@@ -22,7 +22,19 @@ pub(crate) async fn get(
             }
             let mut output = DeploymentOutput::from_to_model(deployment.clone());
             if let Some(rt) = runtimes.get(&deployment.runtime) {
-                output.instances = rt.list_instances(deployment.id, "running").await;
+                let ids = rt.list_instances(deployment.id, "running").await;
+                let mut instances = Vec::with_capacity(ids.len());
+                for instance_id in ids {
+                    let address = rt
+                        .instance_address(&instance_id)
+                        .await
+                        .map(|ip| ip.to_string());
+                    instances.push(DeploymentInstance {
+                        id: instance_id,
+                        address,
+                    });
+                }
+                output.instances = instances;
             }
             Json(output).into_response()
         }

--- a/src/api/action/deployment/list.rs
+++ b/src/api/action/deployment/list.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use url::form_urlencoded::parse;
 
 use crate::api::auth::{Auth, filter_by_namespace};
-use crate::api::dto::deployment::DeploymentOutput;
+use crate::api::dto::deployment::{DeploymentInstance, DeploymentOutput};
 use crate::api::server::{Db, RuntimeMap};
 use crate::models::deployments;
 use http::StatusCode;
@@ -133,7 +133,19 @@ pub(crate) async fn list(
         let mut output = DeploymentOutput::from_to_model(deployment);
 
         if let Some(rt) = runtimes.get(&runtime_name) {
-            output.instances = rt.list_instances(id, "running").await;
+            let ids = rt.list_instances(id, "running").await;
+            let mut instances = Vec::with_capacity(ids.len());
+            for instance_id in ids {
+                let address = rt
+                    .instance_address(&instance_id)
+                    .await
+                    .map(|ip| ip.to_string());
+                instances.push(DeploymentInstance {
+                    id: instance_id,
+                    address,
+                });
+            }
+            output.instances = instances;
         }
 
         deployments.push(output);

--- a/src/api/dto/deployment.rs
+++ b/src/api/dto/deployment.rs
@@ -39,7 +39,13 @@ pub(crate) struct DeploymentOutput {
     pub(crate) replicas: u32,
     pub(crate) ports: Vec<DeploymentPort>,
     pub(crate) labels: HashMap<String, String>,
-    pub(crate) instances: Vec<String>,
+    /// Running instances of this deployment. Each carries its id and — when it
+    /// has a reachable network — its routable guest address, so consumers
+    /// (service-discovery providers, proxies) can route to a specific instance.
+    /// Mirrors the Nomad/Consul "service instance = address" model. No display
+    /// name: only Docker has a distinct container name; VM runtimes would just
+    /// echo the id, so a name field would carry no extra information.
+    pub(crate) instances: Vec<DeploymentInstance>,
     pub(crate) environment: HashMap<String, EnvValue>,
     pub(crate) volumes: Vec<DeploymentVolume>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -98,6 +104,16 @@ impl DeploymentOutput {
             network: deployment.network,
         }
     }
+}
+
+/// One running instance of a deployment. `address` is the routable guest IP
+/// (present for VM runtimes and Docker containers that joined a network);
+/// `None` when the instance has no reachable address (e.g. no published ports).
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub(crate) struct DeploymentInstance {
+    pub(crate) id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) address: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -251,9 +251,10 @@ impl Deployment {
         if self.runtime != "docker"
             && self.runtime != "podman"
             && self.runtime != "cloud-hypervisor"
+            && self.runtime != "firecracker"
         {
             return Err(ApplyError::Validation(format!(
-                "Runtime '{}' not supported. Supported runtimes: docker, podman, cloud-hypervisor.",
+                "Runtime '{}' not supported. Supported runtimes: docker, podman, cloud-hypervisor, firecracker.",
                 self.runtime
             )));
         }

--- a/src/commands/deployment/inspect.rs
+++ b/src/commands/deployment/inspect.rs
@@ -110,7 +110,10 @@ pub(crate) async fn execute(
                 println!("INSTANCES");
                 println!("---------");
                 for instance in deployment.instances {
-                    println!("  {}", instance);
+                    match &instance.address {
+                        Some(addr) => println!("  {} ({})", instance.id, addr),
+                        None => println!("  {}", instance.id),
+                    }
                 }
                 println!();
             }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -3,6 +3,7 @@ use crate::cli::style;
 use crate::runtime::cloud_hypervisor::CloudHypervisorLifecycle;
 use crate::runtime::docker;
 use crate::runtime::docker::docker_lifecycle::DockerLifecycle;
+use crate::runtime::firecracker::{FirecrackerLifecycle, FirecrackerRuntimeConfig};
 use crate::runtime::lifecycle_trait::RuntimeLifecycle;
 use clap::ArgMatches;
 use clap::{Arg, ArgAction, Command};
@@ -166,6 +167,33 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
         runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
     } else {
         info!("Cloud Hypervisor runtime disabled in config, skipping");
+    }
+
+    // Firecracker: same opt-in + fail-fast contract. Its binary must resolve
+    // when enabled, else Ring refuses to start.
+    if configuration.server.runtime.firecracker.enabled {
+        let fc_runtime_config =
+            FirecrackerRuntimeConfig::from_user_config(&configuration.server.runtime.firecracker);
+        if !fc_runtime_config.is_available() {
+            error!(
+                "Refusing to start: Firecracker runtime is enabled in config but its binary \
+                 '{}' could not be found",
+                fc_runtime_config.binary_path
+            );
+            std::process::exit(1);
+        }
+        info!(
+            "Firecracker runtime: binary={}, kernel={}, socket_dir={}",
+            fc_runtime_config.binary_path,
+            fc_runtime_config.kernel_path,
+            fc_runtime_config.socket_dir,
+        );
+        runtimes_map.insert(
+            "firecracker".to_string(),
+            Arc::new(FirecrackerLifecycle::new(fc_runtime_config)),
+        );
+    } else {
+        info!("Firecracker runtime disabled in config, skipping");
     }
 
     // Hard floor: no runtime enabled means Ring can't deploy anything — fail

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -49,6 +49,8 @@ pub(crate) struct RuntimesConfig {
     pub(crate) podman: PodmanConfig,
     #[serde(default)]
     pub(crate) cloud_hypervisor: CloudHypervisorConfig,
+    #[serde(default)]
+    pub(crate) firecracker: FirecrackerConfig,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -132,6 +134,27 @@ pub(crate) struct CloudHypervisorConfig {
     /// How many rotated console log backups to keep alongside the live file
     /// (`.console.log.1`, `.console.log.2`, ...). Defaults to 3.
     pub(crate) max_console_log_backups: Option<u32>,
+}
+
+/// User-facing configuration for the Firecracker runtime. Parsed from the
+/// `[server.runtime.firecracker]` section of `config.toml`.
+///
+/// All fields are optional; when unset, `FirecrackerRuntimeConfig::default`
+/// falls back to `$RING_CONFIG_DIR/firecracker/...`.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub(crate) struct FirecrackerConfig {
+    /// Whether to register the Firecracker runtime. Off by default (runtimes
+    /// are opt-in). When `true` and the `firecracker` binary can't be resolved
+    /// at startup, Ring fails fast.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    pub(crate) binary_path: Option<String>,
+    /// Path to the uncompressed kernel image (`vmlinux`). Firecracker boots a
+    /// kernel directly — there is no firmware step like Cloud Hypervisor.
+    pub(crate) kernel_path: Option<String>,
+    pub(crate) socket_dir: Option<String>,
+    /// Kernel command line passed to every microVM.
+    pub(crate) boot_args: Option<String>,
 }
 
 /// User-facing configuration for the embedded web dashboard. Off by default

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod scheduler {
 
 mod runtime {
     pub(crate) mod cloud_hypervisor;
+    pub(crate) mod cloud_init;
     pub(crate) mod docker;
     pub(crate) mod error;
     pub(crate) mod firecracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ mod runtime {
     pub(crate) mod cloud_hypervisor;
     pub(crate) mod docker;
     pub(crate) mod error;
+    pub(crate) mod firecracker;
     pub(crate) mod health_probes;
     pub(crate) mod host_net;
     pub(crate) mod lifecycle_trait;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ mod runtime {
     pub(crate) mod podman;
     pub(crate) mod port_forwarder;
     pub(crate) mod resources;
+    pub(crate) mod tap;
     pub(crate) mod types;
     pub(crate) mod virtiofs;
     pub(crate) mod vsock_client;

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -554,9 +554,9 @@ impl CloudHypervisorLifecycle {
                 RuntimeError::VmStartFailed(format!("Failed to set up virtio-fs: {}", e))
             })?;
 
-        let guest_mounts: Vec<super::cloud_init::GuestMount> = live_mounts
+        let guest_mounts: Vec<crate::runtime::cloud_init::GuestMount> = live_mounts
             .iter()
-            .map(|m| super::cloud_init::GuestMount {
+            .map(|m| crate::runtime::cloud_init::GuestMount {
                 tag: m.tag.clone(),
                 destination: m.destination.clone(),
                 read_only: m.read_only,
@@ -597,12 +597,14 @@ impl CloudHypervisorLifecycle {
         };
         let vsock_socket_path = vsock_cid
             .map(|_| PathBuf::from(&self.config.socket_dir).join(format!("{}.vsock", instance_id)));
-        let guest_net = net_alloc.as_ref().map(|n| super::cloud_init::GuestNet {
-            guest_ip: n.guest_ip.clone(),
-            host_ip: n.host_ip.clone(),
-            prefix_len: n.prefix_len,
-            mac: n.mac.clone(),
-        });
+        let guest_net = net_alloc
+            .as_ref()
+            .map(|n| crate::runtime::cloud_init::GuestNet {
+                guest_ip: n.guest_ip.clone(),
+                host_ip: n.host_ip.clone(),
+                prefix_len: n.prefix_len,
+                mac: n.mac.clone(),
+            });
 
         // Build the disk list. The main rootfs is always there. A cidata ISO
         // is attached whenever there's something for cloud-init to do —
@@ -614,7 +616,7 @@ impl CloudHypervisorLifecycle {
         }];
         if !deployment.environment.is_empty() || !guest_mounts.is_empty() || guest_net.is_some() {
             let socket_dir = PathBuf::from(&self.config.socket_dir);
-            let iso_path = super::cloud_init::build_cidata_iso(
+            let iso_path = crate::runtime::cloud_init::build_cidata_iso(
                 instance_id,
                 deployment,
                 &guest_mounts,

--- a/src/runtime/cloud_hypervisor/mod.rs
+++ b/src/runtime/cloud_hypervisor/mod.rs
@@ -1,9 +1,4 @@
 mod client;
-// NOTE: cloud_init lives here for now because CH is the only VM runtime that
-// uses it. When Firecracker (or any other VM runtime) lands, lift this module
-// to `src/runtime/cloud_init.rs` and adjust the `use` paths — the contents are
-// runtime-agnostic on purpose. See comment at the top of cloud_init.rs.
-mod cloud_init;
 mod console_logs;
 mod lifecycle;
 mod stats;

--- a/src/runtime/cloud_init.rs
+++ b/src/runtime/cloud_init.rs
@@ -1,10 +1,10 @@
 //! cloud-init NoCloud datasource generation for VM runtimes.
 //!
-//! Currently only used by Cloud Hypervisor, but the format (NoCloud) and the
-//! ISO output are standard — Firecracker and any future VM runtime can attach
-//! the same ISO as a second drive. When that day comes, lift this file to
-//! `src/runtime/cloud_init.rs` and update the `use` paths in CH (and the new
-//! runtime). The implementation has zero CH-specific code.
+//! Shared by every KVM-backed runtime (Cloud Hypervisor and Firecracker): the
+//! format (NoCloud) and the ISO output are standard, so each VM runtime attaches
+//! the same `cidata.iso` as an extra drive. The implementation has zero
+//! runtime-specific code — callers pass a `Deployment`, the virtio-fs mounts to
+//! perform in-guest, and an optional static network config.
 //!
 //! Builds a small ISO image (`cidata.iso`) that the guest mounts at boot via
 //! cloud-init's NoCloud datasource. The ISO contains:

--- a/src/runtime/cloud_init.rs
+++ b/src/runtime/cloud_init.rs
@@ -6,8 +6,8 @@
 //! runtime-specific code — callers pass a `Deployment`, the virtio-fs mounts to
 //! perform in-guest, and an optional static network config.
 //!
-//! Builds a small ISO image (`cidata.iso`) that the guest mounts at boot via
-//! cloud-init's NoCloud datasource. The ISO contains:
+//! Builds a small disk image (kept as `cidata.iso` for callers) that the guest
+//! mounts at boot via cloud-init's NoCloud datasource. It contains:
 //!
 //! - `meta-data`  — minimal, just the instance-id (required by the spec)
 //! - `user-data`  — cloud-config YAML that writes `/etc/ring/env` and a
@@ -17,14 +17,14 @@
 //! guest must have cloud-init installed (true for every standard cloud image:
 //! Ubuntu Cloud, Fedora Cloud, Debian Cloud, Cirros, ...).
 //!
-//! The ISO is built with `xorriso` because it's the most universally available
-//! tool that can produce ISO9660 with a custom volume label (NoCloud requires
-//! `CIDATA`). `cloud-localds` from the `cloud-utils` package is the more
-//! ergonomic alternative but is not always installed.
+//! The image is an ext4 filesystem labelled `CIDATA`, built with `mke2fs -d`
+//! (e2fsprogs, userspace — no mount, no root). NoCloud accepts any labelled
+//! filesystem; ext4 is chosen because minimal guest kernels (e.g. the
+//! Firecracker CI vmlinux) ship neither iso9660 nor vfat — only ext4, which is
+//! what the root disk uses — so an ISO/FAT datasource would be unmountable.
 
 use crate::models::deployments::{Deployment, EnvValue};
 use crate::runtime::error::RuntimeError;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
@@ -68,7 +68,7 @@ pub(crate) async fn build_cidata_iso(
             EnvValue::Plain(v) => envs.push((key.clone(), v.clone())),
             EnvValue::SecretRef { .. } => {
                 return Err(RuntimeError::Other(format!(
-                    "unresolved secretRef for '{}' reached the cloud-hypervisor runtime",
+                    "unresolved secretRef for '{}' reached the VM runtime",
                     key
                 )));
             }
@@ -94,52 +94,90 @@ pub(crate) async fn build_cidata_iso(
         .await
         .map_err(RuntimeError::Io)?;
 
-    let iso_path = output_dir.join(format!("{}.cidata.iso", instance_id));
-    if iso_path.exists() {
-        let _ = tokio::fs::remove_file(&iso_path).await;
+    // Build the NoCloud datasource as an ext4 image rather than ISO9660.
+    // NoCloud accepts any labelled filesystem, but minimal guest kernels (e.g.
+    // the Firecracker CI vmlinux) ship neither iso9660 nor vfat — only ext4 (it's
+    // what the root disk uses), so an ISO/FAT cidata fails to mount and the guest
+    // never gets its network config. The file keeps the `.cidata.iso` name for
+    // callers that reference it, but its content is ext4 labelled CIDATA.
+    let img_path = output_dir.join(format!("{}.cidata.iso", instance_id));
+    if img_path.exists() {
+        let _ = tokio::fs::remove_file(&img_path).await;
     }
+    let img_str = img_path
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 cidata path: {:?}", img_path)))?;
 
+    let result = build_ext4_cidata(img_str, &staging).await;
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    result?;
+
+    Ok(img_path)
+}
+
+/// Create an ext4 image labelled `CIDATA` containing the staged user-data and
+/// meta-data, using `mke2fs -d` — no mounting, no root.
+///
+/// ext4 is chosen over ISO9660/vfat because it's the one filesystem every Linux
+/// guest kernel can mount (it's what the root disk uses). Minimal microVM
+/// kernels (e.g. the Firecracker CI vmlinux) frequently ship neither iso9660
+/// nor vfat, leaving the NoCloud datasource unreadable; ext4 always works.
+/// NoCloud locates the datasource by the `CIDATA` label regardless of fs type.
+async fn build_ext4_cidata(img_str: &str, staging: &Path) -> Result<(), RuntimeError> {
     let staging_str = staging
         .to_str()
         .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 staging path: {:?}", staging)))?;
-    let iso_str = iso_path
-        .to_str()
-        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 iso path: {:?}", iso_path)))?;
 
-    // xorriso flags: -as mkisofs gives us the classic mkisofs CLI surface.
-    // -volid CIDATA is mandatory for the NoCloud datasource.
-    let output = Command::new("xorriso")
+    // Ship a pinned mke2fs.conf next to the staging dir. Some hosts carry an
+    // /etc/mke2fs.conf newer than their mke2fs binary, defining ext4 features
+    // (orphan_file, metadata_csum_seed) the binary rejects with a misleading
+    // "Invalid filesystem option set". Pointing MKE2FS_CONFIG at our own file
+    // makes the build reproducible and avoids that mismatch.
+    let conf_path = staging.with_extension("mke2fs.conf");
+    let conf = "[defaults]\n\
+        \tbase_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr\n\
+        \tdefault_mntopts = acl,user_xattr\n\
+        \tblocksize = 1024\n\
+        \tinode_size = 256\n\
+        [fs_types]\n\
+        \text4 = {\n\
+        \t\tfeatures = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize\n\
+        \t}\n";
+    tokio::fs::write(&conf_path, conf)
+        .await
+        .map_err(RuntimeError::Io)?;
+
+    // -d seeds the fs from the staging dir at creation (userspace, no mount).
+    // 1 MiB holds the two small text files comfortably. -L sets the CIDATA label
+    // NoCloud probes for. -F since the target is a regular file, -q for quiet.
+    let mkfs = Command::new("mke2fs")
+        .env("MKE2FS_CONFIG", &conf_path)
         .args([
-            "-as",
-            "mkisofs",
-            "-output",
-            iso_str,
-            "-volid",
+            "-q",
+            "-F",
+            "-t",
+            "ext4",
+            "-L",
             "CIDATA",
-            "-joliet",
-            "-rock",
+            "-d",
             staging_str,
+            img_str,
+            "1M",
         ])
         .output()
         .await
         .map_err(|e| {
-            RuntimeError::Other(format!(
-                "xorriso not available: {} (install xorriso package)",
-                e
-            ))
+            RuntimeError::Other(format!("mke2fs not available: {} (install e2fsprogs)", e))
         })?;
-
-    // The staging dir is no longer needed once the ISO is built.
-    let _ = tokio::fs::remove_dir_all(&staging).await;
-
-    if !output.status.success() {
+    let _ = tokio::fs::remove_file(&conf_path).await;
+    if !mkfs.status.success() {
         return Err(RuntimeError::Other(format!(
-            "xorriso failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            "mke2fs cidata failed: {}",
+            String::from_utf8_lossy(&mkfs.stderr).trim()
         )));
     }
 
-    Ok(iso_path)
+    Ok(())
 }
 
 fn render_meta_data(instance_id: &str) -> String {
@@ -294,12 +332,6 @@ fn base64_encode(input: &str) -> String {
     out
 }
 
-/// Suppress unused-import warning until the loader uses HashMap directly.
-#[allow(dead_code)]
-fn _suppress_unused() {
-    let _ = HashMap::<String, String>::new();
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,14 +431,19 @@ mod tests {
         assert!(md.contains("local-hostname: ch-deadbeef"));
     }
 
-    fn xorriso_or_skip(test: &str) -> bool {
-        if std::process::Command::new("xorriso")
-            .arg("--version")
-            .output()
-            .is_err()
-        {
-            eprintln!("skipping {}: xorriso not installed", test);
-            return true;
+    fn ext4_tools_or_skip(test: &str) -> bool {
+        for tool in ["mke2fs"] {
+            if std::process::Command::new(tool)
+                .arg("--help")
+                .output()
+                .is_err()
+            {
+                eprintln!(
+                    "skipping {}: {} not installed (dosfstools/mtools)",
+                    test, tool
+                );
+                return true;
+            }
         }
         false
     }
@@ -442,7 +479,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_cidata_iso_with_mounts_writes_real_iso() {
-        if xorriso_or_skip("build_cidata_iso_with_mounts_writes_real_iso") {
+        if ext4_tools_or_skip("build_cidata_iso_with_mounts_writes_real_iso") {
             return;
         }
 
@@ -463,18 +500,29 @@ mod tests {
 
         let iso = build_cidata_iso("ch-cidata-test", &dep, &mounts, None, &dir)
             .await
-            .expect("xorriso should produce an ISO");
+            .expect("e2fsprogs should produce a cidata image");
 
         let meta = tokio::fs::metadata(&iso).await.unwrap();
-        assert!(meta.is_file(), "iso should be a file");
-        assert!(meta.len() > 0, "iso should not be empty");
-        // ISO9660 magic "CD001" lives at offset 0x8001 in the volume descriptor.
+        assert!(meta.is_file(), "cidata should be a file");
+        assert!(meta.len() > 0, "cidata should not be empty");
+        // The datasource is an ext4 image (not ISO9660): minimal guest kernels
+        // ship neither iso9660 nor vfat, only ext4. The ext4 superblock starts
+        // at byte 1024; its magic 0xEF53 (little-endian) sits at offset 0x38
+        // within it (file offset 0x438), and the 16-byte volume label
+        // (s_volume_name) at offset 0x78 (file offset 0x478).
         let bytes = tokio::fs::read(&iso).await.unwrap();
-        assert!(bytes.len() > 0x8006);
-        assert_eq!(&bytes[0x8001..0x8006], b"CD001", "missing ISO9660 magic");
-        // The volume label is at offset 0x8028, padded to 32 bytes — we want
-        // CIDATA so cloud-init's NoCloud datasource picks it up.
-        let label = std::str::from_utf8(&bytes[0x8028..0x8028 + 6]).unwrap();
+        assert!(bytes.len() > 0x488, "image too small to hold a superblock");
+        assert_eq!(
+            &bytes[0x438..0x43a],
+            &[0x53, 0xef],
+            "missing ext4 superblock magic"
+        );
+        // The volume label must be CIDATA so cloud-init's NoCloud datasource
+        // picks it up. Trim the NUL padding from the 16-byte field.
+        let label_bytes = &bytes[0x478..0x478 + 16];
+        let label = std::str::from_utf8(label_bytes)
+            .unwrap()
+            .trim_end_matches('\0');
         assert_eq!(label, "CIDATA");
 
         tokio::fs::remove_dir_all(&dir).await.ok();
@@ -482,7 +530,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_cidata_iso_skips_when_nothing_to_emit() {
-        if xorriso_or_skip("build_cidata_iso_skips_when_nothing_to_emit") {
+        if ext4_tools_or_skip("build_cidata_iso_skips_when_nothing_to_emit") {
             return;
         }
         // No env, no mounts: build_cidata_iso still produces an ISO (callers

--- a/src/runtime/firecracker/client.rs
+++ b/src/runtime/firecracker/client.rs
@@ -1,0 +1,220 @@
+//! Client for the Firecracker REST API over a Unix control socket.
+//!
+//! Each microVM is one `firecracker` process with its own API socket
+//! (`<socket_dir>/<instance_id>.sock`). Unlike Cloud Hypervisor's monolithic
+//! `PUT /api/v1/vm.create`, Firecracker is configured by a *sequence* of small
+//! resource PUTs — `/boot-source`, `/drives/<id>`, `/machine-config` — followed
+//! by `PUT /actions {InstanceStart}` to boot. State is read back from `GET /`
+//! (the instance info endpoint).
+//!
+//! This mirrors the manual flow proven by `tests/e2e/firecracker/spike_boot.sh`.
+//! The HTTP transport (hyper + hyperlocal over a `UnixConnector`) is identical
+//! to `cloud_hypervisor::client`; only the endpoints and payload shapes differ.
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::{Method, Request, StatusCode};
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use hyperlocal::{UnixConnector, Uri};
+use serde::{Deserialize, Serialize};
+
+/// Boot source: the uncompressed kernel image plus its command line. Firecracker
+/// boots a kernel directly — there is no firmware step like hypervisor-fw.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct BootSource {
+    pub kernel_image_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boot_args: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initrd_path: Option<String>,
+}
+
+/// One block device. The root device is `/dev/vda`; additional drives attach in
+/// order. `path_on_host` is a raw image on the host filesystem.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct Drive {
+    pub drive_id: String,
+    pub path_on_host: String,
+    pub is_root_device: bool,
+    pub is_read_only: bool,
+}
+
+/// CPU + memory sizing. `smt` (hyper-threading) is left at Firecracker's default.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct MachineConfig {
+    pub vcpu_count: u32,
+    pub mem_size_mib: u32,
+}
+
+/// One TAP-backed network interface. `host_dev_name` is the host tap device;
+/// the guest MAC is set so the guest gets a deterministic address. Reserved for
+/// the networking phase — not sent in the boot-minimal flow.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct NetworkInterface {
+    pub iface_id: String,
+    pub host_dev_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guest_mac: Option<String>,
+}
+
+/// Instance actions. The only one used at boot is `InstanceStart`; graceful
+/// shutdown uses `SendCtrlAltDel` (the guest must run an ACPI handler).
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct Action {
+    pub action_type: String,
+}
+
+/// Subset of `GET /` (instance info). `state` is `Not started`, `Running`, or
+/// `Paused`. Consumed by the state-verification + health phases.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct InstanceInfo {
+    pub state: String,
+    #[serde(default)]
+    #[allow(dead_code)] // Part of the info response; kept for completeness/diagnostics.
+    pub id: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ClientError {
+    Http(String),
+    Api { status: StatusCode, body: String },
+    Json(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Http(e) => write!(f, "HTTP error: {}", e),
+            ClientError::Api { status, body } => write!(f, "API error ({}): {}", status, body),
+            ClientError::Json(e) => write!(f, "JSON error: {}", e),
+        }
+    }
+}
+
+/// Talks to one Firecracker process over its API socket.
+pub(crate) struct FirecrackerClient {
+    socket_path: String,
+}
+
+impl FirecrackerClient {
+    pub fn new(socket_path: &str) -> Self {
+        Self {
+            socket_path: socket_path.to_string(),
+        }
+    }
+
+    async fn request(
+        &self,
+        method: Method,
+        endpoint: &str,
+        body: Option<String>,
+    ) -> Result<String, ClientError> {
+        let uri: hyper::Uri = Uri::new(&self.socket_path, endpoint).into();
+        let connector = UnixConnector;
+        let client: Client<UnixConnector, Full<Bytes>> =
+            Client::builder(TokioExecutor::new()).build(connector);
+
+        let req = match body {
+            Some(b) => Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .body(Full::new(Bytes::from(b)))
+                .map_err(|e| ClientError::Http(e.to_string()))?,
+            None => Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("Accept", "application/json")
+                .body(Full::new(Bytes::new()))
+                .map_err(|e| ClientError::Http(e.to_string()))?,
+        };
+
+        let response = client
+            .request(req)
+            .await
+            .map_err(|e| ClientError::Http(e.to_string()))?;
+
+        let status = response.status();
+        let body_bytes = response
+            .into_body()
+            .collect()
+            .await
+            .map_err(|e| ClientError::Http(e.to_string()))?
+            .to_bytes();
+        let body_str = String::from_utf8_lossy(&body_bytes).to_string();
+
+        if status.is_success() || status == StatusCode::NO_CONTENT {
+            Ok(body_str)
+        } else {
+            Err(ClientError::Api {
+                status,
+                body: body_str,
+            })
+        }
+    }
+
+    /// `PUT /boot-source` — set the kernel and command line.
+    pub async fn put_boot_source(&self, source: &BootSource) -> Result<(), ClientError> {
+        let body = serde_json::to_string(source).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, "/boot-source", Some(body))
+            .await?;
+        Ok(())
+    }
+
+    /// `PUT /drives/<drive_id>` — attach a block device.
+    pub async fn put_drive(&self, drive: &Drive) -> Result<(), ClientError> {
+        let endpoint = format!("/drives/{}", drive.drive_id);
+        let body = serde_json::to_string(drive).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, &endpoint, Some(body)).await?;
+        Ok(())
+    }
+
+    /// `PUT /machine-config` — set vCPU count and memory.
+    pub async fn put_machine_config(&self, config: &MachineConfig) -> Result<(), ClientError> {
+        let body = serde_json::to_string(config).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, "/machine-config", Some(body))
+            .await?;
+        Ok(())
+    }
+
+    /// `PUT /network-interfaces/<id>` — attach a TAP interface. Reserved for the
+    /// networking phase.
+    #[allow(dead_code)]
+    pub async fn put_network_interface(&self, iface: &NetworkInterface) -> Result<(), ClientError> {
+        let endpoint = format!("/network-interfaces/{}", iface.iface_id);
+        let body = serde_json::to_string(iface).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, &endpoint, Some(body)).await?;
+        Ok(())
+    }
+
+    /// `PUT /actions` — issue an instance action (`InstanceStart`, `SendCtrlAltDel`).
+    pub async fn action(&self, action_type: &str) -> Result<(), ClientError> {
+        let action = Action {
+            action_type: action_type.to_string(),
+        };
+        let body = serde_json::to_string(&action).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, "/actions", Some(body)).await?;
+        Ok(())
+    }
+
+    /// Convenience: boot a configured VM.
+    pub async fn start(&self) -> Result<(), ClientError> {
+        self.action("InstanceStart").await
+    }
+
+    /// Convenience: request a graceful guest shutdown via ACPI.
+    pub async fn send_ctrl_alt_del(&self) -> Result<(), ClientError> {
+        self.action("SendCtrlAltDel").await
+    }
+
+    /// `GET /` — read instance info (including `state`). Used by the
+    /// state-verification + health phases.
+    #[allow(dead_code)]
+    pub async fn info(&self) -> Result<InstanceInfo, ClientError> {
+        let body = self.request(Method::GET, "/", None).await?;
+        serde_json::from_str(&body).map_err(|e| ClientError::Json(e.to_string()))
+    }
+}

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -1,0 +1,395 @@
+//! Firecracker microVM runtime — boot-minimal implementation.
+//!
+//! Scope of this first cut: boot `replicas` worker microVMs from a kernel
+//! (config) + a per-deployment rootfs (`deployment.image` on the host), track
+//! them by their API socket, scale up/down, and tear down. No networking, no
+//! volumes, no stats, no health probes yet — those reuse the shared helpers
+//! (`host_net`, `port_forwarder`, `virtiofs`, `vsock_client`) in later phases,
+//! exactly as the Cloud Hypervisor runtime does.
+//!
+//! Mirrors `cloud_hypervisor::lifecycle` structure: a `*RuntimeConfig` with
+//! defaults + `is_available` + `from_user_config`, a lifecycle struct holding
+//! per-instance PIDs, and an instance id of `<deployment_id>-<tiny_id>` whose
+//! presence on disk (its `.sock`) is the source of truth for "is it running".
+
+use crate::config::server::FirecrackerConfig;
+use crate::models::deployments::{Deployment, DeploymentStatus};
+use crate::models::volume::ResolvedMount;
+use crate::runtime::docker::tiny_id;
+use crate::runtime::error::RuntimeError;
+use crate::runtime::firecracker::client::{BootSource, Drive, FirecrackerClient, MachineConfig};
+use crate::runtime::lifecycle_trait::RuntimeLifecycle;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use tracing::{error, info, warn};
+
+/// Resolved Firecracker runtime config (defaults merged with user config).
+#[derive(Debug, Clone)]
+pub(crate) struct FirecrackerRuntimeConfig {
+    /// Path to the `firecracker` binary.
+    pub binary_path: String,
+    /// Path to the uncompressed kernel image (`vmlinux`). Firecracker boots a
+    /// kernel directly; there is no firmware step.
+    pub kernel_path: String,
+    /// Directory for per-VM API sockets and writable rootfs copies.
+    pub socket_dir: String,
+    /// Kernel command line. The default enables the serial console so console
+    /// logs are capturable, and panics reboot rather than hang.
+    pub boot_args: String,
+}
+
+impl Default for FirecrackerRuntimeConfig {
+    fn default() -> Self {
+        let base_dir = crate::config::config::get_config_dir();
+        Self {
+            binary_path: "firecracker".to_string(),
+            kernel_path: format!("{}/firecracker/vmlinux", base_dir),
+            socket_dir: format!("{}/firecracker/sockets", base_dir),
+            boot_args: "console=ttyS0 reboot=k panic=1 pci=off".to_string(),
+        }
+    }
+}
+
+impl FirecrackerRuntimeConfig {
+    /// Whether the `firecracker` binary is resolvable, so the runtime is only
+    /// registered when it can actually run. Mirrors the CH `is_available` gate.
+    pub(crate) fn is_available(&self) -> bool {
+        let binary = &self.binary_path;
+        if binary.contains('/') {
+            return Path::new(binary).exists();
+        }
+        std::env::var_os("PATH")
+            .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(binary).exists()))
+            .unwrap_or(false)
+    }
+
+    /// Merge a user-facing config section with the defaults.
+    pub(crate) fn from_user_config(user: &FirecrackerConfig) -> Self {
+        let defaults = Self::default();
+        Self {
+            binary_path: user.binary_path.clone().unwrap_or(defaults.binary_path),
+            kernel_path: user.kernel_path.clone().unwrap_or(defaults.kernel_path),
+            socket_dir: user.socket_dir.clone().unwrap_or(defaults.socket_dir),
+            boot_args: user.boot_args.clone().unwrap_or(defaults.boot_args),
+        }
+    }
+}
+
+pub struct FirecrackerLifecycle {
+    config: FirecrackerRuntimeConfig,
+    /// PID per instance id, captured at spawn so teardown can kill the right
+    /// process. Absence means the VM is gone (or was never tracked by this
+    /// process — e.g. inherited across a ring-server restart).
+    pids: Mutex<HashMap<String, u32>>,
+}
+
+impl FirecrackerLifecycle {
+    pub fn new(config: FirecrackerRuntimeConfig) -> Self {
+        Self {
+            config,
+            pids: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn socket_path(&self, instance_id: &str) -> String {
+        format!("{}/{}.sock", self.config.socket_dir, instance_id)
+    }
+
+    fn rootfs_path(&self, instance_id: &str) -> String {
+        format!("{}/{}.ext4", self.config.socket_dir, instance_id)
+    }
+
+    /// Boot one worker microVM. Returns the new instance id on success.
+    async fn start_vm(&self, deployment: &Deployment) -> Result<String, RuntimeError> {
+        // Pre-flight: kernel + base rootfs must exist before we spawn anything.
+        if !Path::new(&self.config.kernel_path).exists() {
+            return Err(RuntimeError::VmStartFailed(format!(
+                "kernel image not found at '{}' (set [server.runtime.firecracker] kernel_path)",
+                self.config.kernel_path
+            )));
+        }
+        if !Path::new(&deployment.image).exists() {
+            return Err(RuntimeError::ImageNotFound(format!(
+                "rootfs image '{}' not found on host",
+                deployment.image
+            )));
+        }
+
+        std::fs::create_dir_all(&self.config.socket_dir).map_err(|e| {
+            RuntimeError::VmStartFailed(format!(
+                "could not create socket_dir '{}': {}",
+                self.config.socket_dir, e
+            ))
+        })?;
+
+        let instance_id = format!("{}-{}", deployment.id, tiny_id());
+        let socket_path = self.socket_path(&instance_id);
+        let rootfs_rw = self.rootfs_path(&instance_id);
+
+        // Firecracker mutates the rootfs in place; give each VM a private copy
+        // so replicas and reboots don't share guest state.
+        std::fs::copy(&deployment.image, &rootfs_rw).map_err(|e| {
+            RuntimeError::VmStartFailed(format!(
+                "could not copy rootfs '{}' -> '{}': {}",
+                deployment.image, rootfs_rw, e
+            ))
+        })?;
+
+        // Spawn the firecracker process bound to its API socket.
+        let child = std::process::Command::new(&self.config.binary_path)
+            .arg("--api-sock")
+            .arg(&socket_path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| {
+                RuntimeError::VmStartFailed(format!("could not spawn firecracker: {}", e))
+            })?;
+        let pid = child.id();
+
+        // Wait for the API socket to appear (process creates it on startup).
+        let mut ready = false;
+        for _ in 0..50 {
+            if Path::new(&socket_path).exists() {
+                ready = true;
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        if !ready {
+            let _ = self.kill_pid(pid);
+            let _ = std::fs::remove_file(&rootfs_rw);
+            return Err(RuntimeError::VmStartFailed(
+                "firecracker API socket never appeared".to_string(),
+            ));
+        }
+
+        // Configure + boot via the REST API (the spike's PUT sequence).
+        let client = FirecrackerClient::new(&socket_path);
+        let boot = self
+            .configure_and_boot(&client, &rootfs_rw, deployment)
+            .await;
+        if let Err(e) = boot {
+            let _ = self.kill_pid(pid);
+            let _ = std::fs::remove_file(&socket_path);
+            let _ = std::fs::remove_file(&rootfs_rw);
+            return Err(RuntimeError::VmStartFailed(format!(
+                "configure/boot failed for {}: {}",
+                instance_id, e
+            )));
+        }
+
+        self.pids.lock().unwrap().insert(instance_id.clone(), pid);
+        info!("Firecracker microVM {} booted (pid {})", instance_id, pid);
+        Ok(instance_id)
+    }
+
+    async fn configure_and_boot(
+        &self,
+        client: &FirecrackerClient,
+        rootfs_rw: &str,
+        deployment: &Deployment,
+    ) -> Result<(), String> {
+        client
+            .put_boot_source(&BootSource {
+                kernel_image_path: self.config.kernel_path.clone(),
+                boot_args: Some(self.config.boot_args.clone()),
+                initrd_path: None,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+
+        client
+            .put_drive(&Drive {
+                drive_id: "rootfs".to_string(),
+                path_on_host: rootfs_rw.to_string(),
+                is_root_device: true,
+                is_read_only: false,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let (vcpus, mem_mib) = parse_resources(deployment);
+        client
+            .put_machine_config(&MachineConfig {
+                vcpu_count: vcpus,
+                mem_size_mib: mem_mib,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+
+        client.start().await.map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Tear down one instance: graceful shutdown, kill the process, unlink the
+    /// socket + rootfs copy. Returns true if the instance is gone afterwards.
+    async fn stop_vm(&self, instance_id: &str) -> bool {
+        let socket_path = self.socket_path(instance_id);
+
+        // Best-effort graceful shutdown if the socket is still live.
+        if Path::new(&socket_path).exists() {
+            let client = FirecrackerClient::new(&socket_path);
+            let _ = client.send_ctrl_alt_del().await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+        }
+
+        let pid = self.pids.lock().unwrap().remove(instance_id);
+        if let Some(pid) = pid {
+            let _ = self.kill_pid(pid);
+        }
+        let _ = std::fs::remove_file(&socket_path);
+        let _ = std::fs::remove_file(self.rootfs_path(instance_id));
+        !Path::new(&socket_path).exists()
+    }
+
+    fn kill_pid(&self, pid: u32) -> std::io::Result<()> {
+        // SIGTERM the firecracker process; it exits when the guest is down or
+        // when its VMM thread is signalled.
+        std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .status()
+            .map(|_| ())
+    }
+
+    /// Instance ids currently tracked for a deployment whose socket still
+    /// exists. The socket file is the on-disk source of truth for "running".
+    fn scan_instances(&self, deployment_id: &str) -> Vec<String> {
+        let prefix = format!("{}-", deployment_id);
+        self.pids
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|id| id.starts_with(&prefix))
+            .filter(|id| Path::new(&self.socket_path(id)).exists())
+            .cloned()
+            .collect()
+    }
+
+    async fn handle_worker_deployment(&self, mut deployment: Deployment) -> Deployment {
+        let current = self.scan_instances(&deployment.id);
+        let desired = deployment.replicas as usize;
+
+        if current.len() < desired {
+            for _ in current.len()..desired {
+                match self.start_vm(&deployment).await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!("Firecracker: failed to start instance: {}", e);
+                        deployment.status = DeploymentStatus::CreateContainerError;
+                        break;
+                    }
+                }
+            }
+        } else if current.len() > desired {
+            for instance_id in current.iter().skip(desired) {
+                if !self.stop_vm(instance_id).await {
+                    warn!("Firecracker: failed to stop instance {}", instance_id);
+                }
+            }
+        }
+
+        deployment.instances = self.scan_instances(&deployment.id);
+        if deployment.status != DeploymentStatus::CreateContainerError {
+            deployment.status = DeploymentStatus::Running;
+        }
+        deployment
+    }
+}
+
+/// Parse vCPU count + memory (MiB) from the deployment's resource limits.
+/// Defaults to 1 vCPU / 128 MiB — the same minimal microVM the spike booted.
+fn parse_resources(_deployment: &Deployment) -> (u32, u32) {
+    // TODO(firecracker): wire deployment.resources.limits.{cpu,memory} like CH
+    // does via runtime::resources once the boot path is validated end-to-end.
+    (1, 128)
+}
+
+#[async_trait]
+impl RuntimeLifecycle for FirecrackerLifecycle {
+    async fn apply(
+        &self,
+        mut deployment: Deployment,
+        _resolved_mounts: Vec<ResolvedMount>,
+    ) -> Deployment {
+        if deployment.status == DeploymentStatus::Deleted {
+            for instance_id in self.scan_instances(&deployment.id) {
+                if !self.stop_vm(&instance_id).await {
+                    warn!(
+                        "Firecracker: failed to stop {} during deletion",
+                        instance_id
+                    );
+                }
+            }
+            deployment.instances.clear();
+            return deployment;
+        }
+
+        if deployment.kind == "job" {
+            warn!("Firecracker: kind 'job' not yet supported, treating as worker");
+        }
+        self.handle_worker_deployment(deployment).await
+    }
+
+    async fn list_instances(&self, deployment_id: String, _status: &str) -> Vec<String> {
+        self.scan_instances(&deployment_id)
+    }
+
+    async fn remove_instance(&self, instance_id: String) -> bool {
+        self.stop_vm(&instance_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_uses_config_dir_paths() {
+        let cfg = FirecrackerRuntimeConfig::default();
+        assert_eq!(cfg.binary_path, "firecracker");
+        assert!(cfg.kernel_path.ends_with("/firecracker/vmlinux"));
+        assert!(cfg.socket_dir.ends_with("/firecracker/sockets"));
+        assert!(cfg.boot_args.contains("console=ttyS0"));
+    }
+
+    #[test]
+    fn from_user_config_overrides_only_set_fields() {
+        let user = FirecrackerConfig {
+            enabled: true,
+            binary_path: Some("/opt/fc/firecracker".to_string()),
+            kernel_path: None,
+            socket_dir: Some("/var/run/fc".to_string()),
+            boot_args: None,
+        };
+        let cfg = FirecrackerRuntimeConfig::from_user_config(&user);
+        assert_eq!(cfg.binary_path, "/opt/fc/firecracker");
+        assert_eq!(cfg.socket_dir, "/var/run/fc");
+        // Unset fields fall back to defaults.
+        let defaults = FirecrackerRuntimeConfig::default();
+        assert_eq!(cfg.kernel_path, defaults.kernel_path);
+        assert_eq!(cfg.boot_args, defaults.boot_args);
+    }
+
+    #[test]
+    fn is_available_false_for_missing_absolute_path() {
+        let cfg = FirecrackerRuntimeConfig {
+            binary_path: "/nonexistent/firecracker".to_string(),
+            ..FirecrackerRuntimeConfig::default()
+        };
+        assert!(!cfg.is_available());
+    }
+
+    #[test]
+    fn socket_and_rootfs_paths_are_namespaced_by_instance() {
+        let cfg = FirecrackerRuntimeConfig {
+            socket_dir: "/tmp/fc".to_string(),
+            ..FirecrackerRuntimeConfig::default()
+        };
+        let lc = FirecrackerLifecycle::new(cfg);
+        assert_eq!(lc.socket_path("dep-1-abc"), "/tmp/fc/dep-1-abc.sock");
+        assert_eq!(lc.rootfs_path("dep-1-abc"), "/tmp/fc/dep-1-abc.ext4");
+    }
+}

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -15,13 +15,20 @@
 use crate::config::server::FirecrackerConfig;
 use crate::models::deployments::{Deployment, DeploymentStatus};
 use crate::models::volume::ResolvedMount;
+use crate::runtime::cloud_init::GuestNet;
 use crate::runtime::docker::tiny_id;
 use crate::runtime::error::RuntimeError;
-use crate::runtime::firecracker::client::{BootSource, Drive, FirecrackerClient, MachineConfig};
+use crate::runtime::firecracker::client::{
+    BootSource, Drive, FirecrackerClient, MachineConfig, NetworkInterface,
+};
+use crate::runtime::host_net::InstanceNet;
 use crate::runtime::lifecycle_trait::RuntimeLifecycle;
+use crate::runtime::port_forwarder::{self, PortForwarder};
+use crate::runtime::tap::TapDevice;
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::path::Path;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tracing::{error, info, warn};
 
@@ -83,6 +90,13 @@ pub struct FirecrackerLifecycle {
     /// process. Absence means the VM is gone (or was never tracked by this
     /// process — e.g. inherited across a ring-server restart).
     pids: Mutex<HashMap<String, u32>>,
+    /// Live host tap devices, keyed by instance id. Unlike Cloud Hypervisor,
+    /// Firecracker doesn't create the tap itself — Ring owns its whole
+    /// lifecycle. Dropping the entry deletes the interface from the host.
+    taps: Mutex<HashMap<String, TapDevice>>,
+    /// Live socat port-forwarders, keyed by instance id. Dropping the entry
+    /// kills the socat process.
+    port_forwarders: Mutex<HashMap<String, Vec<PortForwarder>>>,
 }
 
 impl FirecrackerLifecycle {
@@ -90,6 +104,8 @@ impl FirecrackerLifecycle {
         Self {
             config,
             pids: Mutex::new(HashMap::new()),
+            taps: Mutex::new(HashMap::new()),
+            port_forwarders: Mutex::new(HashMap::new()),
         }
     }
 
@@ -159,38 +175,114 @@ impl FirecrackerLifecycle {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         }
         if !ready {
-            let _ = self.kill_pid(pid);
+            self.kill_pid(pid).await;
             let _ = std::fs::remove_file(&rootfs_rw);
             return Err(RuntimeError::VmStartFailed(
                 "firecracker API socket never appeared".to_string(),
             ));
         }
 
-        // Configure + boot via the REST API (the spike's PUT sequence).
+        // If the deployment publishes any port, allocate a deterministic /30
+        // and create the host tap. Unlike Cloud Hypervisor, Firecracker does
+        // not create the tap — Ring creates it here (held in `tap` so an early
+        // return on any later error deletes it via Drop) and hands its name to
+        // Firecracker, while cloud-init configures the matching guest IP.
+        let net_alloc = if deployment.ports.is_empty() {
+            None
+        } else {
+            Some(InstanceNet::for_instance(&instance_id))
+        };
+        let tap = match &net_alloc {
+            Some(n) => match TapDevice::create(&n.tap_name, &n.host_ip, n.prefix_len) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    self.kill_pid(pid).await;
+                    let _ = std::fs::remove_file(&socket_path);
+                    let _ = std::fs::remove_file(&rootfs_rw);
+                    return Err(e);
+                }
+            },
+            None => None,
+        };
+
+        // Configure + boot via the REST API (the spike's PUT sequence, plus a
+        // network interface and a cidata drive when applicable).
         let client = FirecrackerClient::new(&socket_path);
         let boot = self
-            .configure_and_boot(&client, &rootfs_rw, deployment)
+            .configure_and_boot(
+                &client,
+                &instance_id,
+                &rootfs_rw,
+                deployment,
+                net_alloc.as_ref(),
+            )
             .await;
         if let Err(e) = boot {
-            let _ = self.kill_pid(pid);
+            // `tap` drops here, deleting the interface.
+            self.kill_pid(pid).await;
             let _ = std::fs::remove_file(&socket_path);
             let _ = std::fs::remove_file(&rootfs_rw);
+            let _ = std::fs::remove_file(self.cidata_path(&instance_id));
             return Err(RuntimeError::VmStartFailed(format!(
                 "configure/boot failed for {}: {}",
                 instance_id, e
             )));
         }
 
+        // Spawn one socat per declared port now the guest is up. A bind race
+        // (port taken between the pre-check and now) tears the VM down rather
+        // than leaving a black-hole port. `forwarders` is owned locally; its
+        // Drop kills any socat already spawned on early return.
+        if let Some(n) = &net_alloc {
+            let mut forwarders = Vec::with_capacity(deployment.ports.len());
+            for p in &deployment.ports {
+                match port_forwarder::spawn_forwarder(
+                    &n.guest_ip,
+                    p.published,
+                    p.target,
+                    p.host_ip.as_deref(),
+                    p.protocol,
+                )
+                .await
+                {
+                    Ok(fw) => forwarders.push(fw),
+                    Err(e) => {
+                        let _ = client.send_ctrl_alt_del().await;
+                        self.kill_pid(pid).await;
+                        let _ = std::fs::remove_file(&socket_path);
+                        let _ = std::fs::remove_file(&rootfs_rw);
+                        let _ = std::fs::remove_file(self.cidata_path(&instance_id));
+                        return Err(e);
+                    }
+                }
+            }
+            if !forwarders.is_empty() {
+                self.port_forwarders
+                    .lock()
+                    .unwrap()
+                    .insert(instance_id.clone(), forwarders);
+            }
+        }
+
         self.pids.lock().unwrap().insert(instance_id.clone(), pid);
+        if let Some(t) = tap {
+            self.taps.lock().unwrap().insert(instance_id.clone(), t);
+        }
         info!("Firecracker microVM {} booted (pid {})", instance_id, pid);
         Ok(instance_id)
+    }
+
+    fn cidata_path(&self, instance_id: &str) -> String {
+        format!("{}/{}.cidata.iso", self.config.socket_dir, instance_id)
     }
 
     async fn configure_and_boot(
         &self,
         client: &FirecrackerClient,
+        instance_id: &str,
         rootfs_rw: &str,
         deployment: &Deployment,
+        net_alloc: Option<&InstanceNet>,
     ) -> Result<(), String> {
         client
             .put_boot_source(&BootSource {
@@ -211,6 +303,48 @@ impl FirecrackerLifecycle {
             .await
             .map_err(|e| e.to_string())?;
 
+        // A cidata ISO is attached whenever cloud-init has something to do:
+        // env vars or a static network config. Mounts are not wired yet.
+        let guest_net = net_alloc.map(|n| GuestNet {
+            guest_ip: n.guest_ip.clone(),
+            host_ip: n.host_ip.clone(),
+            prefix_len: n.prefix_len,
+            mac: n.mac.clone(),
+        });
+        if !deployment.environment.is_empty() || guest_net.is_some() {
+            let socket_dir = PathBuf::from(&self.config.socket_dir);
+            let iso_path = crate::runtime::cloud_init::build_cidata_iso(
+                instance_id,
+                deployment,
+                &[],
+                guest_net.as_ref(),
+                &socket_dir,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+            client
+                .put_drive(&Drive {
+                    drive_id: "cidata".to_string(),
+                    path_on_host: iso_path.to_string_lossy().to_string(),
+                    is_root_device: false,
+                    is_read_only: true,
+                })
+                .await
+                .map_err(|e| e.to_string())?;
+        }
+
+        // Attach the network interface (the tap already exists on the host).
+        if let Some(n) = net_alloc {
+            client
+                .put_network_interface(&NetworkInterface {
+                    iface_id: "eth0".to_string(),
+                    host_dev_name: n.tap_name.clone(),
+                    guest_mac: Some(n.mac.clone()),
+                })
+                .await
+                .map_err(|e| e.to_string())?;
+        }
+
         let (vcpus, mem_mib) = parse_resources(deployment);
         client
             .put_machine_config(&MachineConfig {
@@ -224,10 +358,14 @@ impl FirecrackerLifecycle {
         Ok(())
     }
 
-    /// Tear down one instance: graceful shutdown, kill the process, unlink the
-    /// socket + rootfs copy. Returns true if the instance is gone afterwards.
+    /// Tear down one instance: kill the socat forwarders, gracefully shut the
+    /// guest, kill the process, delete the host tap, and unlink the socket,
+    /// rootfs copy and cidata ISO. Returns true if the instance is gone after.
     async fn stop_vm(&self, instance_id: &str) -> bool {
         let socket_path = self.socket_path(instance_id);
+
+        // Drop the port-forwarders first so nothing still routes to the guest.
+        self.port_forwarders.lock().unwrap().remove(instance_id);
 
         // Best-effort graceful shutdown if the socket is still live.
         if Path::new(&socket_path).exists() {
@@ -238,20 +376,38 @@ impl FirecrackerLifecycle {
 
         let pid = self.pids.lock().unwrap().remove(instance_id);
         if let Some(pid) = pid {
-            let _ = self.kill_pid(pid);
+            self.kill_pid(pid).await;
         }
+
+        // Delete the host tap. Dropping the entry runs TapDevice::delete, which
+        // clears persistence so the kernel removes the interface. The VM process
+        // is already dead (kill_pid waited), so the tap's backend is free.
+        self.taps.lock().unwrap().remove(instance_id);
+
         let _ = std::fs::remove_file(&socket_path);
         let _ = std::fs::remove_file(self.rootfs_path(instance_id));
+        let _ = std::fs::remove_file(self.cidata_path(instance_id));
         !Path::new(&socket_path).exists()
     }
 
-    fn kill_pid(&self, pid: u32) -> std::io::Result<()> {
-        // SIGTERM the firecracker process; it exits when the guest is down or
-        // when its VMM thread is signalled.
-        std::process::Command::new("kill")
-            .arg(pid.to_string())
-            .status()
-            .map(|_| ())
+    /// SIGTERM the firecracker process, then SIGKILL if it doesn't exit
+    /// promptly, and wait until it's actually gone. Waiting matters for the
+    /// tap: Firecracker holds the tap's backend fd while alive, so the tap
+    /// can only be removed once the process has fully exited.
+    async fn kill_pid(&self, pid: u32) {
+        let pid_i = pid as i32;
+        unsafe { libc::kill(pid_i, libc::SIGTERM) };
+        for i in 0..20 {
+            // kill(pid, 0) returns -1/ESRCH once the process is gone.
+            if unsafe { libc::kill(pid_i, 0) } != 0 {
+                return;
+            }
+            if i == 5 {
+                // Still alive after ~300ms — escalate.
+                unsafe { libc::kill(pid_i, libc::SIGKILL) };
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
     }
 
     /// Instance ids currently tracked for a deployment whose socket still
@@ -339,6 +495,18 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
 
     async fn remove_instance(&self, instance_id: String) -> bool {
         self.stop_vm(&instance_id).await
+    }
+
+    /// The guest IP is a pure function of the instance id (same allocation as
+    /// at boot), so TCP/HTTP health probes can reach the workload without any
+    /// persistent state. Returns `None` for instances without a network (no
+    /// published ports) — there's no reachable address to probe.
+    async fn instance_address(&self, instance_id: &str) -> Option<IpAddr> {
+        // Only instances that allocated a tap have a reachable guest IP.
+        if !self.taps.lock().unwrap().contains_key(instance_id) {
+            return None;
+        }
+        InstanceNet::for_instance(instance_id).guest_ip.parse().ok()
     }
 }
 

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -117,6 +117,13 @@ impl FirecrackerLifecycle {
         format!("{}/{}.ext4", self.config.socket_dir, instance_id)
     }
 
+    /// Per-instance serial console log. Firecracker writes the guest's ttyS0
+    /// (kernel + init + service output) to the process stdout; we persist it so
+    /// boot/runtime issues are diagnosable and log shippers can tail it.
+    fn console_log_path(&self, instance_id: &str) -> String {
+        format!("{}/{}.console.log", self.config.socket_dir, instance_id)
+    }
+
     /// Boot one worker microVM. Returns the new instance id on success.
     async fn start_vm(&self, deployment: &Deployment) -> Result<String, RuntimeError> {
         // Pre-flight: kernel + base rootfs must exist before we spawn anything.
@@ -153,12 +160,29 @@ impl FirecrackerLifecycle {
             ))
         })?;
 
+        // Persist the guest serial console (stdout) to a per-instance file so
+        // boot/runtime issues are diagnosable and log shippers can tail it.
+        // Falls back to null if the file can't be opened — never block boot on
+        // logging. stderr (firecracker's own diagnostics) shares the same file.
+        let console_log = self.console_log_path(&instance_id);
+        let (out, err): (std::process::Stdio, std::process::Stdio) =
+            match std::fs::File::create(&console_log) {
+                Ok(f) => match f.try_clone() {
+                    Ok(f2) => (f.into(), f2.into()),
+                    Err(_) => (f.into(), std::process::Stdio::null()),
+                },
+                Err(e) => {
+                    warn!("could not open console log {}: {}", console_log, e);
+                    (std::process::Stdio::null(), std::process::Stdio::null())
+                }
+            };
+
         // Spawn the firecracker process bound to its API socket.
         let child = std::process::Command::new(&self.config.binary_path)
             .arg("--api-sock")
             .arg(&socket_path)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .stdout(out)
+            .stderr(err)
             .spawn()
             .map_err(|e| {
                 RuntimeError::VmStartFailed(format!("could not spawn firecracker: {}", e))
@@ -374,19 +398,38 @@ impl FirecrackerLifecycle {
             tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         }
 
-        let pid = self.pids.lock().unwrap().remove(instance_id);
+        // Kill the firecracker process. The PID lives in `pids` for instances
+        // this process booted; after a ring-server restart the map is empty, so
+        // fall back to finding the process by its `--api-sock` argument in
+        // /proc. Firecracker has no remote "delete VM" — killing the process is
+        // the only way to stop it — so this fallback is what makes teardown
+        // survive a restart.
+        let pid = self
+            .pids
+            .lock()
+            .unwrap()
+            .remove(instance_id)
+            .or_else(|| find_pid_by_socket(&socket_path));
         if let Some(pid) = pid {
             self.kill_pid(pid).await;
         }
 
-        // Delete the host tap. Dropping the entry runs TapDevice::delete, which
-        // clears persistence so the kernel removes the interface. The VM process
-        // is already dead (kill_pid waited), so the tap's backend is free.
-        self.taps.lock().unwrap().remove(instance_id);
+        // Delete the host tap. For instances we booted it's in `taps` and its
+        // Drop runs TapDevice::delete. After a restart the map is empty, so
+        // re-derive the tap from the instance id (the name is a pure function of
+        // it) and delete it directly — otherwise the interface leaks on the
+        // host. The VM process is already dead (kill_pid waited), so the tap's
+        // backend is free. Harmless if the instance never had a tap: delete just
+        // fails to re-attach and no-ops.
+        if self.taps.lock().unwrap().remove(instance_id).is_none() {
+            let name = InstanceNet::for_instance(instance_id).tap_name;
+            TapDevice::adopt(&name).delete();
+        }
 
         let _ = std::fs::remove_file(&socket_path);
         let _ = std::fs::remove_file(self.rootfs_path(instance_id));
         let _ = std::fs::remove_file(self.cidata_path(instance_id));
+        let _ = std::fs::remove_file(self.console_log_path(instance_id));
         !Path::new(&socket_path).exists()
     }
 
@@ -410,18 +453,27 @@ impl FirecrackerLifecycle {
         }
     }
 
-    /// Instance ids currently tracked for a deployment whose socket still
-    /// exists. The socket file is the on-disk source of truth for "running".
+    /// Instance ids of a deployment whose API socket still exists on disk.
+    /// The `.sock` file is the source of truth for "running", scanned from
+    /// `socket_dir` rather than the in-memory `pids` map — so instances survive
+    /// a `ring-server` restart (after which the maps are empty but the VMs, and
+    /// their sockets, are still there). Mirrors Cloud Hypervisor's disk scan.
     fn scan_instances(&self, deployment_id: &str) -> Vec<String> {
         let prefix = format!("{}-", deployment_id);
-        self.pids
-            .lock()
-            .unwrap()
-            .keys()
-            .filter(|id| id.starts_with(&prefix))
-            .filter(|id| Path::new(&self.socket_path(id)).exists())
-            .cloned()
-            .collect()
+        let mut instances = Vec::new();
+        let entries = match std::fs::read_dir(&self.config.socket_dir) {
+            Ok(e) => e,
+            Err(_) => return instances,
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if let Some(id) = name.strip_suffix(".sock")
+                && id.starts_with(&prefix)
+            {
+                instances.push(id.to_string());
+            }
+        }
+        instances
     }
 
     async fn handle_worker_deployment(&self, mut deployment: Deployment) -> Deployment {
@@ -455,12 +507,74 @@ impl FirecrackerLifecycle {
     }
 }
 
-/// Parse vCPU count + memory (MiB) from the deployment's resource limits.
-/// Defaults to 1 vCPU / 128 MiB — the same minimal microVM the spike booted.
-fn parse_resources(_deployment: &Deployment) -> (u32, u32) {
-    // TODO(firecracker): wire deployment.resources.limits.{cpu,memory} like CH
-    // does via runtime::resources once the boot path is validated end-to-end.
-    (1, 128)
+/// Find the PID of the `firecracker` process bound to `socket_path`, by scanning
+/// `/proc/<pid>/cmdline` for one whose `--api-sock` argument matches. Used as a
+/// teardown fallback after a `ring-server` restart, when the PID is no longer in
+/// the in-memory map but the VM (and its socket) is still alive. Returns `None`
+/// if no live process references that socket (already gone, or never existed).
+fn find_pid_by_socket(socket_path: &str) -> Option<u32> {
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        // Only numeric entries are processes.
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|s| s.parse::<u32>().ok()) else {
+            continue;
+        };
+        let Ok(cmdline) = std::fs::read(format!("/proc/{}/cmdline", pid)) else {
+            continue;
+        };
+        if cmdline_matches_socket(&cmdline, socket_path) {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+/// Does this `/proc/<pid>/cmdline` (NUL-separated argv) belong to a
+/// `firecracker` process bound to `socket_path`? True iff argv[0] ends with
+/// `firecracker` and some later argument equals the socket path exactly — the
+/// exact match stops `/x/a.sock` from matching `/x/a.sock.bak`.
+fn cmdline_matches_socket(cmdline: &[u8], socket_path: &str) -> bool {
+    let mut args = cmdline.split(|&b| b == 0);
+    if args.next().map(|a0| a0.ends_with(b"firecracker")) != Some(true) {
+        return false;
+    }
+    args.any(|arg| arg == socket_path.as_bytes())
+}
+
+/// Parse vCPU count + memory (MiB) from the deployment's resource limits
+/// (falling back to requests). vCPUs round up from a fractional CPU quantity to
+/// at least 1; memory falls back to a sane floor so a microVM has room to run a
+/// real service rather than OOMing at boot.
+fn parse_resources(deployment: &Deployment) -> (u32, u32) {
+    use crate::models::deployments::{parse_cpu_string, parse_memory_string};
+
+    // Minimum that boots systemd + a typical service without OOM. 128 MiB is
+    // enough for the kernel + init but starves php-fpm/most runtimes.
+    const DEFAULT_MEM_MIB: u32 = 512;
+    const DEFAULT_VCPUS: u32 = 1;
+
+    let spec = deployment
+        .resources
+        .as_ref()
+        .and_then(|r| r.limits.as_ref().or(r.requests.as_ref()));
+
+    let mem_mib = spec
+        .and_then(|s| s.memory.as_ref())
+        .and_then(|m| parse_memory_string(m).ok())
+        .map(|bytes| (bytes / (1024 * 1024)).max(1) as u32)
+        .filter(|&m| m >= 64)
+        .unwrap_or(DEFAULT_MEM_MIB);
+
+    // parse_cpu_string returns nano-CPUs (1_000_000_000 = 1 vCPU); round up to
+    // whole vCPUs since Firecracker can't allocate fractional cores.
+    const NANO_PER_VCPU: i64 = 1_000_000_000;
+    let vcpus = spec
+        .and_then(|s| s.cpu.as_ref())
+        .and_then(|c| parse_cpu_string(c).ok())
+        .map(|nanocpu| ((nanocpu + NANO_PER_VCPU - 1) / NANO_PER_VCPU).max(1) as u32)
+        .unwrap_or(DEFAULT_VCPUS);
+
+    (vcpus, mem_mib)
 }
 
 #[async_trait]
@@ -502,17 +616,91 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
     /// persistent state. Returns `None` for instances without a network (no
     /// published ports) — there's no reachable address to probe.
     async fn instance_address(&self, instance_id: &str) -> Option<IpAddr> {
-        // Only instances that allocated a tap have a reachable guest IP.
-        if !self.taps.lock().unwrap().contains_key(instance_id) {
+        // An instance has a reachable IP iff it allocated a tap. That's tracked
+        // in `taps` for instances we booted; after a ring-server restart the map
+        // is empty, so fall back to checking the host for the tap interface
+        // (its name is a pure function of the instance id). Either source means
+        // "has a network" → return the deterministic guest IP.
+        let net = InstanceNet::for_instance(instance_id);
+        let has_tap =
+            self.taps.lock().unwrap().contains_key(instance_id) || TapDevice::exists(&net.tap_name);
+        if !has_tap {
             return None;
         }
-        InstanceNet::for_instance(instance_id).guest_ip.parse().ok()
+        net.guest_ip.parse().ok()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scan_instances_reads_disk_not_memory() {
+        // Post-restart simulation: sockets exist on disk, `pids` is empty.
+        // scan_instances must still find the instances (it scans socket_dir),
+        // otherwise a restarted ring-server would lose track of running VMs.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("ring-fc-scan-{}-{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let cfg = FirecrackerRuntimeConfig {
+            socket_dir: dir.to_string_lossy().to_string(),
+            ..FirecrackerRuntimeConfig::default()
+        };
+        let lc = FirecrackerLifecycle::new(cfg);
+
+        // Two sockets for our deployment, one for another, plus noise.
+        for f in [
+            "dep-1-aaa.sock",
+            "dep-1-bbb.sock",
+            "dep-2-ccc.sock",
+            "dep-1-aaa.ext4", // not a socket
+            "dep-1.txt",
+        ] {
+            std::fs::write(dir.join(f), b"").unwrap();
+        }
+
+        // pids is empty (as after a restart).
+        assert!(lc.pids.lock().unwrap().is_empty());
+
+        let mut found = lc.scan_instances("dep-1");
+        found.sort();
+        assert_eq!(
+            found,
+            vec!["dep-1-aaa".to_string(), "dep-1-bbb".to_string()]
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cmdline_matches_socket_exact_arg() {
+        let sock = "/run/fc/dep-1-aaa.sock";
+        // argv[0]=firecracker, then --api-sock <sock>
+        let cmd = b"/usr/bin/firecracker\0--api-sock\0/run/fc/dep-1-aaa.sock\0";
+        assert!(cmdline_matches_socket(cmd, sock));
+    }
+
+    #[test]
+    fn cmdline_matches_socket_rejects_prefix_collision() {
+        // A different VM whose socket merely starts with ours must not match.
+        let sock = "/run/fc/dep-1-aaa.sock";
+        let cmd = b"/usr/bin/firecracker\0--api-sock\0/run/fc/dep-1-aaa.sock.bak\0";
+        assert!(!cmdline_matches_socket(cmd, sock));
+    }
+
+    #[test]
+    fn cmdline_matches_socket_rejects_non_firecracker() {
+        // Right socket arg, wrong process — must not match.
+        let sock = "/run/fc/dep-1-aaa.sock";
+        let cmd = b"/usr/bin/socat\0--api-sock\0/run/fc/dep-1-aaa.sock\0";
+        assert!(!cmdline_matches_socket(cmd, sock));
+    }
 
     #[test]
     fn default_config_uses_config_dir_paths() {

--- a/src/runtime/firecracker/mod.rs
+++ b/src/runtime/firecracker/mod.rs
@@ -1,0 +1,13 @@
+//! Firecracker microVM runtime.
+//!
+//! Boots each deployment instance as a dedicated Firecracker microVM, driven via
+//! Firecracker's REST API over a per-VM Unix control socket. Structurally a
+//! sibling of `cloud_hypervisor`: same KVM-backed-VM model and the same shared
+//! helpers (`host_net`, `port_forwarder`, `virtiofs`, `vsock_client`), but a
+//! different VMM and a different API shape (a sequence of resource PUTs instead
+//! of CH's monolithic `vm.create`).
+
+mod client;
+mod lifecycle;
+
+pub(crate) use lifecycle::{FirecrackerLifecycle, FirecrackerRuntimeConfig};

--- a/src/runtime/tap.rs
+++ b/src/runtime/tap.rs
@@ -112,6 +112,26 @@ impl TapDevice {
         Ok(dev)
     }
 
+    /// Whether a host interface named `name` currently exists, by checking
+    /// `/sys/class/net/<name>`. Lets a caller deduce "this instance has a
+    /// network" from the host alone, without any in-memory state — needed after
+    /// a `ring-server` restart.
+    pub(crate) fn exists(name: &str) -> bool {
+        std::path::Path::new(&format!("/sys/class/net/{}", name)).exists()
+    }
+
+    /// Build a handle for an *existing* tap, by name, without creating or
+    /// configuring anything. Used to reclaim a tap after a `ring-server` restart
+    /// (when the original [`TapDevice`] was lost with the in-memory map) so it
+    /// can be deleted: `delete` re-attaches by name and clears persistence, and
+    /// is a no-op if the interface is already gone. Never creates an interface.
+    pub(crate) fn adopt(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            live: true,
+        }
+    }
+
     fn configure(&self, host_ip: &str, prefix_len: u8) -> Result<(), RuntimeError> {
         let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
         if sock < 0 {
@@ -163,14 +183,17 @@ impl TapDevice {
         Ok(())
     }
 
-    /// Delete the device from the host. We hold no fd, so reopen `/dev/net/tun`,
-    /// re-attach to the existing tap by name, and clear persistence — once
-    /// persistence is off and this transient fd closes, the kernel removes the
-    /// interface.
+    /// Delete the device from the host via an `RTM_DELLINK` netlink request —
+    /// the same operation as `ip link delete`, done in-process so the server's
+    /// `CAP_NET_ADMIN` stays effective (a forked `ip` would lose it).
     ///
-    /// Re-attach can briefly fail with `EBUSY` if the VM process hasn't fully
-    /// released the tap yet (the caller kills it first, but the fd close is
-    /// asynchronous), so retry a few times before giving up. Idempotent.
+    /// The previous approach — re-attach by name, clear `TUNSETPERSIST`, close
+    /// the fd — does **not** actually remove the interface (verified live: the
+    /// tap survives), so it is not used. `RTM_DELLINK` removes it immediately.
+    ///
+    /// The caller kills the VM first, but the VM's fd close is asynchronous, so
+    /// the link can briefly be `EBUSY`; retry a few times before giving up.
+    /// Idempotent: a missing interface (`ENODEV`) is treated as success.
     pub(crate) fn delete(&mut self) {
         if !self.live {
             return;
@@ -178,32 +201,17 @@ impl TapDevice {
         self.live = false;
 
         for _ in 0..20 {
-            let Ok(tun) = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open("/dev/net/tun")
-            else {
-                return;
-            };
-            let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
-            write_ifname(&mut ifr, &self.name);
-            ifr.ifr_ifru.ifru_flags = IFF_TAP | IFF_NO_PI;
-            // Re-attach to the existing tap, then turn persistence off so the
-            // kernel removes it when this fd closes.
-            if unsafe {
-                ioctl(
-                    tun.as_raw_fd(),
-                    TUNSETIFF,
-                    &mut ifr as *mut _ as *mut libc::c_void,
-                )
+            match rtnl_dellink(&self.name) {
+                // Gone now, or already gone — done either way.
+                Ok(()) => return,
+                Err(e) if e.raw_os_error() == Some(libc::ENODEV) => return,
+                // Still held by the VM (fd not closed yet) — brief spin-wait.
+                Err(e) if e.raw_os_error() == Some(libc::EBUSY) => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                // Any other error (e.g. EPERM): retrying won't help.
+                Err(_) => return,
             }
-            .is_ok()
-            {
-                let _ = unsafe { ioctl_int(tun.as_raw_fd(), TUNSETPERSIST, 0) };
-                return;
-            }
-            // Busy — the previous holder hasn't let go yet. Brief spin-wait.
-            std::thread::sleep(std::time::Duration::from_millis(50));
         }
     }
 
@@ -253,6 +261,80 @@ unsafe fn ioctl_int(fd: libc::c_int, request: libc::c_ulong, arg: libc::c_int) -
         Err(io::Error::last_os_error())
     } else {
         Ok(())
+    }
+}
+
+/// Delete a network interface by name via `RTM_DELLINK` over a `NETLINK_ROUTE`
+/// socket — exactly what `ip link delete <name>` does, but in-process so the
+/// caller's `CAP_NET_ADMIN` applies (a forked `ip` would not inherit it).
+///
+/// Returns `Ok(())` when the kernel acknowledges the deletion, or an `io::Error`
+/// carrying the kernel's errno (e.g. `ENODEV` if already gone, `EBUSY` if a VM
+/// still holds the tap, `EPERM` if the capability is missing).
+fn rtnl_dellink(name: &str) -> io::Result<()> {
+    // Resolve the interface index; 0 means "no such interface".
+    let mut cname = [0i8; libc::IFNAMSIZ];
+    for (i, b) in name.as_bytes().iter().enumerate() {
+        cname[i] = *b as libc::c_char;
+    }
+    let ifindex = unsafe { libc::if_nametoindex(cname.as_ptr()) };
+    if ifindex == 0 {
+        return Err(io::Error::from_raw_os_error(libc::ENODEV));
+    }
+
+    // Open a route netlink socket.
+    let fd = unsafe { libc::socket(libc::AF_NETLINK, libc::SOCK_RAW, libc::NETLINK_ROUTE) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let _guard = FdGuard(fd);
+
+    // Message = nlmsghdr (16 bytes) + ifinfomsg (16 bytes). We hand-pack it:
+    // the kernel only needs ifi_index set to target the link by index.
+    const NLMSG_HDR_LEN: usize = 16;
+    const IFINFO_LEN: usize = 16;
+    const TOTAL: usize = NLMSG_HDR_LEN + IFINFO_LEN;
+    const RTM_DELLINK: u16 = 17;
+    const NLM_F_REQUEST: u16 = 0x01;
+    const NLM_F_ACK: u16 = 0x04;
+
+    let mut buf = [0u8; TOTAL];
+    // nlmsghdr: len(u32), type(u16), flags(u16), seq(u32), pid(u32)
+    buf[0..4].copy_from_slice(&(TOTAL as u32).to_ne_bytes());
+    buf[4..6].copy_from_slice(&RTM_DELLINK.to_ne_bytes());
+    buf[6..8].copy_from_slice(&(NLM_F_REQUEST | NLM_F_ACK).to_ne_bytes());
+    buf[8..12].copy_from_slice(&1u32.to_ne_bytes()); // seq
+    buf[12..16].copy_from_slice(&0u32.to_ne_bytes()); // pid (0 = kernel assigns)
+    // ifinfomsg: family(u8), pad(u8), type(u16), index(i32), flags(u32), change(u32)
+    buf[16] = libc::AF_UNSPEC as u8;
+    buf[20..24].copy_from_slice(&(ifindex as i32).to_ne_bytes());
+
+    let sent = unsafe { libc::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), 0) };
+    if sent < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // Read the ACK. An nlmsgerr payload starts with an i32 error code (0 = ok,
+    // negative errno on failure), right after a 16-byte nlmsghdr.
+    let mut resp = [0u8; 4096];
+    let n = unsafe { libc::recv(fd, resp.as_mut_ptr() as *mut libc::c_void, resp.len(), 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if (n as usize) < NLMSG_HDR_LEN + 4 {
+        // No parsable error body; assume success (kernel sent a bare ACK).
+        return Ok(());
+    }
+    let err = i32::from_ne_bytes([
+        resp[NLMSG_HDR_LEN],
+        resp[NLMSG_HDR_LEN + 1],
+        resp[NLMSG_HDR_LEN + 2],
+        resp[NLMSG_HDR_LEN + 3],
+    ]);
+    if err == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(-err))
     }
 }
 

--- a/src/runtime/tap.rs
+++ b/src/runtime/tap.rs
@@ -1,0 +1,322 @@
+//! Host TAP device management for VM runtimes that don't create their own.
+//!
+//! Cloud Hypervisor creates the tap itself (it holds `CAP_NET_ADMIN` and is
+//! handed a tap *name* to bring up). Firecracker does **not**: it expects the
+//! tap device to already exist on the host and only references it by name. So
+//! for Firecracker, Ring owns the tap's whole lifecycle — create it, give the
+//! host side an IP, bring it up before boot, and delete it on teardown.
+//!
+//! This is done with **direct syscalls** (`ioctl`), not by shelling out to
+//! `ip`. Shelling out is tempting but broken under capabilities: `ring-server`
+//! can hold `CAP_NET_ADMIN`, but a forked `ip` process does **not** inherit it
+//! (the capability is in `ring`'s permitted/effective sets, not the *ambient*
+//! set), so `ip tuntap add` fails with `EPERM`. Doing the ioctls in-process
+//! keeps the capability where it's needed.
+//!
+//! Requires `ring-server` to run with `CAP_NET_ADMIN` (or as root). When the
+//! capability is missing the syscalls return `EPERM`, which we surface as an
+//! actionable [`RuntimeError::NetworkCreationFailed`] telling the operator how
+//! to grant it.
+//!
+//! The parameters (tap name, host IP, prefix) come from
+//! [`crate::runtime::host_net::InstanceNet`], so allocation stays a pure
+//! function of the instance id and two replicas never collide.
+
+use crate::runtime::error::RuntimeError;
+use std::fs::OpenOptions;
+use std::io;
+use std::mem;
+use std::os::fd::AsRawFd;
+
+// Linux ABI constants (stable across kernels). Defined here rather than pulled
+// from libc because not all are exported on every libc version.
+const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
+const TUNSETPERSIST: libc::c_ulong = 0x4004_54cb;
+const IFF_TAP: libc::c_short = 0x0002;
+const IFF_NO_PI: libc::c_short = 0x1000;
+
+const SIOCSIFADDR: libc::c_ulong = 0x8916;
+const SIOCSIFNETMASK: libc::c_ulong = 0x891c;
+const SIOCSIFFLAGS: libc::c_ulong = 0x8914;
+const SIOCGIFFLAGS: libc::c_ulong = 0x8913;
+const IFF_UP: libc::c_short = 0x1;
+const IFF_RUNNING: libc::c_short = 0x40;
+
+/// A live host tap device. Created via [`TapDevice::create`]; deleting it
+/// (via [`TapDevice::delete`] or `Drop`) removes the persistent interface.
+///
+/// Crucially, no `/dev/net/tun` fd is kept open after creation. The device is
+/// made *persistent*, so it survives the creating fd closing — and the fd MUST
+/// be closed, otherwise it stays attached as the tap's backend and Firecracker
+/// gets `EBUSY` ("Resource busy") when it tries to open the same tap. We only
+/// reopen briefly at `delete` time to clear persistence.
+pub(crate) struct TapDevice {
+    name: String,
+    live: bool,
+}
+
+impl TapDevice {
+    /// Create a tap device named `name`, assign `host_ip/prefix_len` to its host
+    /// side, and bring it up. The device is made persistent and our fd is closed
+    /// before returning, so Firecracker can open it as its backend.
+    pub(crate) fn create(name: &str, host_ip: &str, prefix_len: u8) -> Result<Self, RuntimeError> {
+        if name.len() >= libc::IFNAMSIZ {
+            return Err(RuntimeError::NetworkCreationFailed(format!(
+                "tap name '{}' exceeds IFNAMSIZ-1 ({})",
+                name,
+                libc::IFNAMSIZ - 1
+            )));
+        }
+
+        // 1. Open the clone device and create the tap via TUNSETIFF, then mark
+        //    it persistent so it survives the fd closing. The fd is dropped at
+        //    the end of this block — leaving it open would keep the tap's
+        //    backend attached and make Firecracker's open fail with EBUSY.
+        {
+            let tun = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/net/tun")
+                .map_err(|e| Self::map_err(name, "open /dev/net/tun", e))?;
+
+            let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
+            write_ifname(&mut ifr, name);
+            ifr.ifr_ifru.ifru_flags = IFF_TAP | IFF_NO_PI;
+            unsafe {
+                ioctl(
+                    tun.as_raw_fd(),
+                    TUNSETIFF,
+                    &mut ifr as *mut _ as *mut libc::c_void,
+                )
+            }
+            .map_err(|e| Self::map_err(name, "TUNSETIFF (create tap)", e))?;
+
+            unsafe { ioctl_int(tun.as_raw_fd(), TUNSETPERSIST, 1) }
+                .map_err(|e| Self::map_err(name, "TUNSETPERSIST", e))?;
+            // `tun` drops here → fd closed, backend detached, device persists.
+        }
+
+        let dev = Self {
+            name: name.to_string(),
+            live: true,
+        };
+
+        // 2. Configure the host-side IP, netmask, and bring the link up via an
+        //    AF_INET socket. On any failure, roll the device back.
+        if let Err(e) = dev.configure(host_ip, prefix_len) {
+            let mut dev = dev;
+            dev.delete();
+            return Err(e);
+        }
+
+        Ok(dev)
+    }
+
+    fn configure(&self, host_ip: &str, prefix_len: u8) -> Result<(), RuntimeError> {
+        let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+        if sock < 0 {
+            return Err(Self::map_err(
+                &self.name,
+                "socket(AF_INET)",
+                io::Error::last_os_error(),
+            ));
+        }
+        // Ensure the socket fd is closed however we leave this function.
+        let _guard = FdGuard(sock);
+
+        let ip = parse_ipv4(host_ip).ok_or_else(|| {
+            RuntimeError::NetworkCreationFailed(format!("invalid host IP '{}'", host_ip))
+        })?;
+        let mask = prefix_to_mask(prefix_len);
+
+        // SIOCSIFADDR — set the interface address.
+        let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
+        write_ifname(&mut ifr, &self.name);
+        write_sockaddr_in(&mut ifr, ip);
+        unsafe { ioctl(sock, SIOCSIFADDR, &mut ifr as *mut _ as *mut libc::c_void) }
+            .map_err(|e| Self::map_err(&self.name, "SIOCSIFADDR", e))?;
+
+        // SIOCSIFNETMASK — set the netmask.
+        let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
+        write_ifname(&mut ifr, &self.name);
+        write_sockaddr_in(&mut ifr, mask);
+        unsafe {
+            ioctl(
+                sock,
+                SIOCSIFNETMASK,
+                &mut ifr as *mut _ as *mut libc::c_void,
+            )
+        }
+        .map_err(|e| Self::map_err(&self.name, "SIOCSIFNETMASK", e))?;
+
+        // SIOCGIFFLAGS + SIOCSIFFLAGS — bring the link up.
+        let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
+        write_ifname(&mut ifr, &self.name);
+        unsafe { ioctl(sock, SIOCGIFFLAGS, &mut ifr as *mut _ as *mut libc::c_void) }
+            .map_err(|e| Self::map_err(&self.name, "SIOCGIFFLAGS", e))?;
+        unsafe {
+            ifr.ifr_ifru.ifru_flags |= IFF_UP | IFF_RUNNING;
+        }
+        unsafe { ioctl(sock, SIOCSIFFLAGS, &mut ifr as *mut _ as *mut libc::c_void) }
+            .map_err(|e| Self::map_err(&self.name, "SIOCSIFFLAGS (up)", e))?;
+
+        Ok(())
+    }
+
+    /// Delete the device from the host. We hold no fd, so reopen `/dev/net/tun`,
+    /// re-attach to the existing tap by name, and clear persistence — once
+    /// persistence is off and this transient fd closes, the kernel removes the
+    /// interface.
+    ///
+    /// Re-attach can briefly fail with `EBUSY` if the VM process hasn't fully
+    /// released the tap yet (the caller kills it first, but the fd close is
+    /// asynchronous), so retry a few times before giving up. Idempotent.
+    pub(crate) fn delete(&mut self) {
+        if !self.live {
+            return;
+        }
+        self.live = false;
+
+        for _ in 0..20 {
+            let Ok(tun) = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/net/tun")
+            else {
+                return;
+            };
+            let mut ifr: libc::ifreq = unsafe { mem::zeroed() };
+            write_ifname(&mut ifr, &self.name);
+            ifr.ifr_ifru.ifru_flags = IFF_TAP | IFF_NO_PI;
+            // Re-attach to the existing tap, then turn persistence off so the
+            // kernel removes it when this fd closes.
+            if unsafe {
+                ioctl(
+                    tun.as_raw_fd(),
+                    TUNSETIFF,
+                    &mut ifr as *mut _ as *mut libc::c_void,
+                )
+            }
+            .is_ok()
+            {
+                let _ = unsafe { ioctl_int(tun.as_raw_fd(), TUNSETPERSIST, 0) };
+                return;
+            }
+            // Busy — the previous holder hasn't let go yet. Brief spin-wait.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    /// Translate an ioctl/syscall error into an actionable runtime error,
+    /// special-casing `EPERM` (the missing-capability case).
+    fn map_err(name: &str, op: &str, e: io::Error) -> RuntimeError {
+        if e.raw_os_error() == Some(libc::EPERM) {
+            return RuntimeError::NetworkCreationFailed(format!(
+                "could not create tap '{}': operation not permitted ({}). Run ring-server with \
+                 CAP_NET_ADMIN (e.g. `setcap cap_net_admin+ep $(command -v ring)`) or as root",
+                name, op
+            ));
+        }
+        RuntimeError::NetworkCreationFailed(format!("tap '{}' {} failed: {}", name, op, e))
+    }
+}
+
+impl Drop for TapDevice {
+    fn drop(&mut self) {
+        self.delete();
+    }
+}
+
+/// Closes a raw fd on drop.
+struct FdGuard(libc::c_int);
+impl Drop for FdGuard {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}
+
+/// Thin wrapper over `libc::ioctl` (pointer arg) returning `io::Result`.
+unsafe fn ioctl(fd: libc::c_int, request: libc::c_ulong, arg: *mut libc::c_void) -> io::Result<()> {
+    let rc = unsafe { libc::ioctl(fd, request as _, arg) };
+    if rc < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// `libc::ioctl` variant for requests that take an integer by value (e.g.
+/// `TUNSETPERSIST`), rather than a pointer to a struct.
+unsafe fn ioctl_int(fd: libc::c_int, request: libc::c_ulong, arg: libc::c_int) -> io::Result<()> {
+    let rc = unsafe { libc::ioctl(fd, request as _, arg) };
+    if rc < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// Copy an interface name into the `ifr_name` field (NUL-padded).
+fn write_ifname(ifr: &mut libc::ifreq, name: &str) {
+    let bytes = name.as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        ifr.ifr_name[i] = *b as libc::c_char;
+    }
+}
+
+/// Write an IPv4 address into the `ifr_addr` field as a `sockaddr_in`.
+fn write_sockaddr_in(ifr: &mut libc::ifreq, addr_be: u32) {
+    let sin = libc::sockaddr_in {
+        sin_family: libc::AF_INET as libc::sa_family_t,
+        sin_port: 0,
+        sin_addr: libc::in_addr { s_addr: addr_be },
+        sin_zero: [0; 8],
+    };
+    unsafe {
+        let dst = &mut ifr.ifr_ifru.ifru_addr as *mut libc::sockaddr as *mut libc::sockaddr_in;
+        *dst = sin;
+    }
+}
+
+/// Parse a dotted IPv4 into a big-endian (network-order) u32 suitable for
+/// `s_addr`.
+fn parse_ipv4(s: &str) -> Option<u32> {
+    let addr: std::net::Ipv4Addr = s.parse().ok()?;
+    // `s_addr` is in network byte order; Ipv4Addr::octets() is already MSB-first.
+    Some(u32::from_ne_bytes(addr.octets()))
+}
+
+/// Build the network-order netmask u32 for a CIDR prefix length.
+fn prefix_to_mask(prefix_len: u8) -> u32 {
+    let bits: u32 = if prefix_len == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix_len as u32)
+    };
+    // `bits` is host-order MSB-first; convert to network order bytes.
+    u32::from_ne_bytes(bits.to_be_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_30_mask_is_252() {
+        // /30 → 255.255.255.252. Last octet 252 in network order.
+        let mask = prefix_to_mask(30);
+        let octets = mask.to_ne_bytes();
+        assert_eq!(octets, [255, 255, 255, 252]);
+    }
+
+    #[test]
+    fn parse_ipv4_roundtrip() {
+        let be = parse_ipv4("10.42.1.1").unwrap();
+        assert_eq!(be.to_ne_bytes(), [10, 42, 1, 1]);
+    }
+
+    #[test]
+    fn parse_ipv4_rejects_garbage() {
+        assert!(parse_ipv4("not-an-ip").is_none());
+    }
+}

--- a/tests/e2e/firecracker/setup.sh
+++ b/tests/e2e/firecracker/setup.sh
@@ -41,6 +41,12 @@ setup_fc() {
   RING_E2E_FC_SOCKET_DIR="${RING_E2E_FC_SOCKET_DIR:-$(mktemp -d -t ring-e2e-fc-sockets-XXXXXX)}"
   export RING_E2E_FC_KERNEL RING_E2E_FC_ROOTFS RING_E2E_FC_SOCKET_DIR
 
+  # Snapshot pre-existing ring-* taps so cleanup only reaps taps THIS run leaked
+  # (e.g. t4 SIGKILLs ring-server mid-run, leaving a tap with no graceful
+  # teardown) — never orphans from unrelated runs on a shared host.
+  RING_E2E_FC_TAPS_BEFORE=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u)
+  export RING_E2E_FC_TAPS_BEFORE
+
   RING_EXTRA_CONFIG=$(cat <<EOF
 [server.runtime.firecracker]
 enabled = true
@@ -64,5 +70,20 @@ cleanup_fc() {
       pkill -f "$sock" 2>/dev/null || true
     done
     rm -rf "$RING_E2E_FC_SOCKET_DIR"
+  fi
+
+  # Reap any ring-* tap that appeared during this run but wasn't torn down
+  # (e.g. t4 kills ring-server mid-run). Only taps NOT present at setup, so a
+  # shared host's unrelated orphans are left alone. Best-effort: needs
+  # CAP_NET_ADMIN/root; `ip link delete` direct, then `sudo -n` for CI.
+  if [ -n "${RING_E2E_FC_TAPS_BEFORE+x}" ]; then
+    local now leaked
+    now=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u)
+    leaked=$(comm -13 <(printf '%s\n' "$RING_E2E_FC_TAPS_BEFORE") <(printf '%s\n' "$now"))
+    for tap in $leaked; do
+      ip link delete "$tap" 2>/dev/null \
+        || sudo -n ip link delete "$tap" 2>/dev/null \
+        || true
+    done
   fi
 }

--- a/tests/e2e/firecracker/setup.sh
+++ b/tests/e2e/firecracker/setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Firecracker e2e setup: verify the firecracker binary + /dev/kvm are present,
+# download the CI kernel (vmlinux) and Ubuntu rootfs once into a host cache, and
+# inject a [server.runtime.firecracker] block into the config.toml that
+# start_ring generates (lib.sh).
+#
+# Sourced by the t*.sh Firecracker tests. Mirrors cloud-hypervisor/setup.sh.
+
+# Artifacts live outside the repo to avoid bloating it; reused across runs.
+RING_E2E_CACHE_DIR="${RING_E2E_CACHE_DIR:-$HOME/.cache/ring-e2e}/firecracker"
+FC_CI_BASE="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/x86_64"
+RING_E2E_FC_KERNEL="${RING_E2E_FC_KERNEL:-$RING_E2E_CACHE_DIR/vmlinux-6.1.102}"
+RING_E2E_FC_ROOTFS="${RING_E2E_FC_ROOTFS:-$RING_E2E_CACHE_DIR/ubuntu-22.04.ext4}"
+RING_E2E_FC_SOCKET_DIR=""
+
+setup_fc() {
+  command -v firecracker >/dev/null 2>&1 || {
+    echo "[fc-setup] firecracker not in PATH" >&2
+    echo "           install from https://github.com/firecracker-microvm/firecracker/releases" >&2
+    exit 1
+  }
+  [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+    echo "[fc-setup] /dev/kvm not accessible (need the kvm group)" >&2
+    exit 1
+  }
+  for cmd in curl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "[fc-setup] missing: $cmd" >&2; exit 1; }
+  done
+
+  mkdir -p "$RING_E2E_CACHE_DIR"
+  if [ ! -f "$RING_E2E_FC_KERNEL" ]; then
+    echo "[fc-setup] downloading kernel vmlinux-6.1.102 (~25 MB)..."
+    curl -sSL -o "$RING_E2E_FC_KERNEL" "$FC_CI_BASE/vmlinux-6.1.102"
+  fi
+  if [ ! -f "$RING_E2E_FC_ROOTFS" ]; then
+    echo "[fc-setup] downloading rootfs ubuntu-22.04.ext4 (~280 MB)..."
+    curl -sSL -o "$RING_E2E_FC_ROOTFS" "$FC_CI_BASE/ubuntu-22.04.ext4"
+  fi
+
+  RING_E2E_FC_SOCKET_DIR="${RING_E2E_FC_SOCKET_DIR:-$(mktemp -d -t ring-e2e-fc-sockets-XXXXXX)}"
+  export RING_E2E_FC_KERNEL RING_E2E_FC_ROOTFS RING_E2E_FC_SOCKET_DIR
+
+  RING_EXTRA_CONFIG=$(cat <<EOF
+[server.runtime.firecracker]
+enabled = true
+kernel_path = "$RING_E2E_FC_KERNEL"
+socket_dir = "$RING_E2E_FC_SOCKET_DIR"
+EOF
+)
+  export RING_EXTRA_CONFIG
+  # Firecracker-only suite: don't require Docker.
+  export RING_E2E_ENABLE_DOCKER=false
+
+  trap 'cleanup_fc; cleanup_ring' EXIT
+}
+
+cleanup_fc() {
+  # Kill any firecracker processes still bound to this run's sockets, then
+  # remove the socket dir. Best-effort.
+  if [ -n "$RING_E2E_FC_SOCKET_DIR" ] && [ -d "$RING_E2E_FC_SOCKET_DIR" ]; then
+    for sock in "$RING_E2E_FC_SOCKET_DIR"/*.sock; do
+      [ -S "$sock" ] || continue
+      pkill -f "$sock" 2>/dev/null || true
+    done
+    rm -rf "$RING_E2E_FC_SOCKET_DIR"
+  fi
+}

--- a/tests/e2e/firecracker/spike_boot.sh
+++ b/tests/e2e/firecracker/spike_boot.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Firecracker boot spike — NOT a Ring e2e test yet.
+#
+# Proves we can boot a real Firecracker microVM end-to-end before writing any
+# Rust runtime code: downloads the official CI kernel (vmlinux) + Ubuntu rootfs,
+# drives Firecracker's REST API over its Unix control socket, boots the VM,
+# confirms it reaches the Running state, then shuts it down and cleans up.
+#
+# This is the manual reference flow that src/runtime/firecracker/client.rs will
+# later reproduce in Rust. Firecracker's API differs from Cloud Hypervisor's
+# monolithic vm.create: it is a sequence of small PUTs (boot-source, drives,
+# machine-config, actions) against the same socket.
+#
+# Requires: firecracker (in PATH), curl, /dev/kvm. No sudo, no network device
+# setup (this spike boots without a TAP — networking comes in a later phase).
+set -euo pipefail
+
+CACHE_DIR="${RING_E2E_CACHE_DIR:-$HOME/.cache/ring-e2e}/firecracker"
+CI_BASE="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/x86_64"
+KERNEL_URL="$CI_BASE/vmlinux-6.1.102"
+ROOTFS_URL="$CI_BASE/ubuntu-22.04.ext4"
+KERNEL="$CACHE_DIR/vmlinux-6.1.102"
+ROOTFS="$CACHE_DIR/ubuntu-22.04.ext4"
+
+# Per-run scratch: a private control socket + a writable copy of the rootfs so
+# repeated runs don't accumulate guest mutations in the cached image.
+RUN_DIR="$(mktemp -d /tmp/fc-spike.XXXXXX)"
+SOCKET="$RUN_DIR/firecracker.sock"
+ROOTFS_RW="$RUN_DIR/rootfs.ext4"
+FC_PID=""
+
+log()  { echo "[fc-spike] $*"; }
+fail() { echo "[fc-spike] FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  if [ -n "$FC_PID" ] && kill -0 "$FC_PID" 2>/dev/null; then
+    kill "$FC_PID" 2>/dev/null || true
+    wait "$FC_PID" 2>/dev/null || true
+  fi
+  rm -rf "$RUN_DIR"
+}
+trap cleanup EXIT
+
+# PUT helper against the Firecracker control socket.
+fc_put() {
+  local path="$1" body="$2"
+  curl -s -f --unix-socket "$SOCKET" \
+    -X PUT "http://localhost/${path#/}" \
+    -H 'Content-Type: application/json' -H 'Accept: application/json' \
+    -d "$body" \
+    || fail "PUT /$path rejected (body: $body)"
+}
+
+fc_get() {
+  curl -s -f --unix-socket "$SOCKET" "http://localhost/${1#/}"
+}
+
+# --- 0. Prereqs ---------------------------------------------------------------
+command -v firecracker >/dev/null || fail "firecracker not in PATH"
+command -v curl >/dev/null        || fail "curl not in PATH"
+[ -r /dev/kvm ] && [ -w /dev/kvm ] || fail "/dev/kvm not accessible (need kvm group)"
+log "firecracker: $(firecracker --version | head -1)"
+
+# --- 1. Fetch assets (cached) -------------------------------------------------
+mkdir -p "$CACHE_DIR"
+if [ ! -f "$KERNEL" ]; then
+  log "downloading kernel vmlinux-6.1.102 (~25 MB)..."
+  curl -sSL -o "$KERNEL" "$KERNEL_URL" || fail "kernel download failed"
+fi
+if [ ! -f "$ROOTFS" ]; then
+  log "downloading rootfs ubuntu-22.04.ext4 (~280 MB)..."
+  curl -sSL -o "$ROOTFS" "$ROOTFS_URL" || fail "rootfs download failed"
+fi
+log "kernel: $KERNEL ($(du -h "$KERNEL" | cut -f1))"
+log "rootfs: $ROOTFS ($(du -h "$ROOTFS" | cut -f1))"
+
+# Writable per-run copy of the rootfs.
+cp --reflink=auto "$ROOTFS" "$ROOTFS_RW"
+
+# --- 2. Launch the Firecracker process ---------------------------------------
+log "starting firecracker (socket: $SOCKET)"
+firecracker --api-sock "$SOCKET" >"$RUN_DIR/fc.log" 2>&1 &
+FC_PID=$!
+
+# Wait for the API socket to appear (Firecracker creates it on startup).
+for _ in $(seq 1 50); do
+  [ -S "$SOCKET" ] && break
+  kill -0 "$FC_PID" 2>/dev/null || fail "firecracker exited early: $(cat "$RUN_DIR/fc.log")"
+  sleep 0.1
+done
+[ -S "$SOCKET" ] || fail "API socket never appeared"
+
+# --- 3. Configure the microVM via the REST API --------------------------------
+# Boot source: uncompressed kernel + serial console on ttyS0 so we see boot logs.
+log "PUT /boot-source"
+fc_put "boot-source" "$(printf '{"kernel_image_path":"%s","boot_args":"console=ttyS0 reboot=k panic=1 pci=off"}' "$KERNEL")"
+
+# Root drive: the writable rootfs as /dev/vda.
+log "PUT /drives/rootfs"
+fc_put "drives/rootfs" "$(printf '{"drive_id":"rootfs","path_on_host":"%s","is_root_device":true,"is_read_only":false}' "$ROOTFS_RW")"
+
+# Machine config: 1 vCPU, 128 MiB — minimal microVM.
+log "PUT /machine-config"
+fc_put "machine-config" '{"vcpu_count":1,"mem_size_mib":128}'
+
+# --- 4. Boot -----------------------------------------------------------------
+log "PUT /actions InstanceStart"
+fc_put "actions" '{"action_type":"InstanceStart"}'
+
+# --- 5. Verify Running --------------------------------------------------------
+sleep 1
+STATE="$(fc_get "" | grep -oE '"state":"[A-Za-z]+"' | head -1)"
+log "instance info: $STATE"
+echo "$STATE" | grep -q '"state":"Running"' || fail "VM not Running (got: $STATE)"
+log "boot log tail:"
+tail -5 "$RUN_DIR/fc.log" | sed 's/^/    /' || true
+
+# --- 6. Shut down -------------------------------------------------------------
+log "PUT /actions SendCtrlAltDel (graceful shutdown)"
+fc_put "actions" '{"action_type":"SendCtrlAltDel"}' || true
+sleep 1
+
+log "PASS — Firecracker microVM booted to Running and shut down cleanly."

--- a/tests/e2e/firecracker/t1_boot_delete.sh
+++ b/tests/e2e/firecracker/t1_boot_delete.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# T1-FC: apply a firecracker deployment, wait for the microVM to be reported
+# running by Ring, assert that a Firecracker API socket exists on disk, then
+# delete the deployment and assert the socket + per-instance rootfs are cleaned
+# up.
+#
+# Requires: firecracker binary, /dev/kvm, and the CI kernel + rootfs downloaded
+# by setup.sh. The deployment `image` is the host path to the rootfs (Firecracker
+# boots a host rootfs file directly — there is no image pull).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T1-FC: boot / delete =="
+
+setup_fc
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-vm:
+    name: fc-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# Booting a real microVM takes longer than a container, but Firecracker is fast.
+wait_deployment_status "ring-e2e" "fc-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-vm")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# A Firecracker API socket must exist for the running instance.
+socket_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+[ "$socket_count" -ge 1 ] || {
+  ls -la "$RING_E2E_FC_SOCKET_DIR" >&2 || true
+  fail "expected at least 1 Firecracker socket in $RING_E2E_FC_SOCKET_DIR, got $socket_count"
+}
+log "found $socket_count firecracker socket(s)"
+
+# Delete the deployment and assert the socket + rootfs copy are reaped.
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-vm >/dev/null 2>&1 || true
+
+# Give the runtime a moment to tear down the VM and unlink artifacts.
+for _ in $(seq 1 20); do
+  remaining=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$remaining" -eq 0 ] && break
+  sleep 0.5
+done
+[ "$remaining" -eq 0 ] || fail "sockets not cleaned up after delete (got $remaining)"
+
+rootfs_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$rootfs_count" -eq 0 ] || fail "rootfs copies not cleaned up after delete (got $rootfs_count)"
+
+log "PASS — T1-FC: microVM booted, socket present, cleaned up on delete."

--- a/tests/e2e/firecracker/t2_ports.sh
+++ b/tests/e2e/firecracker/t2_ports.sh
@@ -65,6 +65,12 @@ deployments:
       - { published: $PORT_B, target: 8080 }
 EOF
 
+# Record any pre-existing ring-* taps (orphans from earlier runs on a shared
+# host) so we can attribute the NEW tap to this deployment rather than picking
+# an unrelated one with `head -1`.
+taps_now() { ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u; }
+TAPS_BEFORE=$(taps_now)
+
 "$RING_BIN" apply --file "$FIXTURE"
 wait_deployment_status "ring-e2e" "ports-vm" "running" 60
 
@@ -73,15 +79,16 @@ DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "ports-vm")
 log "deployment id: $DEPLOYMENT_ID"
 
 # === tap interface created by Ring ===
-# The tap name is `ring-<hex>`, derived from the instance id. Assert at least
-# one ring-* tap exists and carries a 10.42.x.y/30 host IP.
+# The tap name is `ring-<hex>`, derived from the instance id. Take the tap that
+# APPEARED since the apply (set difference), so a pre-existing orphan can't be
+# mistaken for ours.
 TAP=""
 for _ in $(seq 1 20); do
-  TAP=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | head -1 || true)
+  TAP=$(comm -13 <(printf '%s\n' "$TAPS_BEFORE") <(taps_now) | head -1 || true)
   [ -n "$TAP" ] && break
   sleep 0.5
 done
-[ -n "$TAP" ] || { ip -o link show | grep ring- >&2 || true; fail "no ring-* tap interface created"; }
+[ -n "$TAP" ] || { ip -o link show | grep ring- >&2 || true; fail "no new ring-* tap interface created"; }
 log "tap interface: $TAP"
 
 have_ip=false
@@ -110,7 +117,7 @@ log "$SOCAT_COUNT socat forwarders alive"
   "$RING_BIN" delete --namespace ring-e2e ports-vm >/dev/null 2>&1 || true
 
 for _ in $(seq 1 20); do
-  still_tap=$(ip -o link show 2>/dev/null | grep -c "$TAP" || true)
+  still_tap=$(taps_now | grep -cxF "$TAP" || true)
   still_socat=$( (pgrep -f "socat.*TCP4-LISTEN:($PORT_A|$PORT_B)" || true) | wc -l | tr -d ' ')
   [ "$still_tap" -eq 0 ] && [ "$still_socat" -eq 0 ] && break
   sleep 0.5

--- a/tests/e2e/firecracker/t2_ports.sh
+++ b/tests/e2e/firecracker/t2_ports.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# T2-FC: a firecracker deployment with `ports` must:
+#   1. boot with a host tap interface created by Ring (Firecracker, unlike
+#      Cloud Hypervisor, does not create the tap itself — Ring does),
+#   2. spawn one socat forwarder per port mapping (host-side observable),
+#   3. on delete, release the host ports, kill the socats, and remove the tap.
+#
+# Like the Cloud Hypervisor port test, we do NOT validate end-to-end TCP into
+# a service inside the guest: the Firecracker CI rootfs has no reliable
+# cloud-init, so the guest may not bring eth0 up. We assert the host-side
+# plumbing Ring is responsible for. End-to-end traffic belongs to a manual
+# check with a cloud-init-capable image.
+#
+# Requires: firecracker, /dev/kvm, socat, and CAP_NET_ADMIN for ring-server
+# (tap creation). Run with a binary that has the capability, e.g.:
+#   sudo setcap cap_net_admin+ep target/debug/ring
+# The test SKIPs (exit 0) if tap creation is not permitted, so it never fails
+# spuriously on an unprivileged CI runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T2-FC: port mapping (tap + socat) =="
+
+command -v socat >/dev/null 2>&1 || { echo "[e2e] SKIP: socat not installed" >&2; exit 0; }
+
+# ring-server is what creates the tap, so it (not this shell) needs
+# CAP_NET_ADMIN. SKIP rather than fail when neither the ring binary carries
+# the capability nor we're running as root.
+ring_can_net=false
+if getcap "$RING_BIN" 2>/dev/null | grep -q 'cap_net_admin'; then
+  ring_can_net=true
+elif [ "$(id -u)" -eq 0 ]; then
+  ring_can_net=true
+fi
+if [ "$ring_can_net" != true ]; then
+  echo "[e2e] SKIP: ring binary lacks CAP_NET_ADMIN (tap creation). " \
+       "Grant it with: sudo setcap cap_net_admin+ep $RING_BIN" >&2
+  exit 0
+fi
+
+PORT_A=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+PORT_B=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+
+setup_fc
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/ports-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  ports-vm:
+    name: ports-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    ports:
+      - { published: $PORT_A, target: 80 }
+      - { published: $PORT_B, target: 8080 }
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "ports-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "ports-vm")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === tap interface created by Ring ===
+# The tap name is `ring-<hex>`, derived from the instance id. Assert at least
+# one ring-* tap exists and carries a 10.42.x.y/30 host IP.
+TAP=""
+for _ in $(seq 1 20); do
+  TAP=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | head -1 || true)
+  [ -n "$TAP" ] && break
+  sleep 0.5
+done
+[ -n "$TAP" ] || { ip -o link show | grep ring- >&2 || true; fail "no ring-* tap interface created"; }
+log "tap interface: $TAP"
+
+have_ip=false
+for _ in $(seq 1 20); do
+  if ip -o addr show dev "$TAP" 2>/dev/null | grep -qE '10\.42\.[0-9]+\.[0-9]+/30'; then
+    have_ip=true
+    break
+  fi
+  sleep 0.5
+done
+[ "$have_ip" = true ] || { ip addr show dev "$TAP" >&2; fail "tap $TAP has no 10.42.x.y/30 host IP"; }
+log "tap $TAP has a /30 host IP"
+
+# === socat forwarders ===
+SOCAT_COUNT=0
+for _ in $(seq 1 30); do
+  SOCAT_COUNT=$( (pgrep -f "socat.*TCP4-LISTEN:($PORT_A|$PORT_B)" || true) | wc -l | tr -d ' ')
+  [ "$SOCAT_COUNT" -ge 2 ] && break
+  sleep 1
+done
+[ "$SOCAT_COUNT" -ge 2 ] || { pgrep -af socat >&2 || true; fail "expected 2 socat forwarders, found $SOCAT_COUNT"; }
+log "$SOCAT_COUNT socat forwarders alive"
+
+# === delete cleans up tap + socat ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e ports-vm >/dev/null 2>&1 || true
+
+for _ in $(seq 1 20); do
+  still_tap=$(ip -o link show 2>/dev/null | grep -c "$TAP" || true)
+  still_socat=$( (pgrep -f "socat.*TCP4-LISTEN:($PORT_A|$PORT_B)" || true) | wc -l | tr -d ' ')
+  [ "$still_tap" -eq 0 ] && [ "$still_socat" -eq 0 ] && break
+  sleep 0.5
+done
+[ "${still_tap:-1}" -eq 0 ] || fail "tap $TAP not removed after delete"
+[ "${still_socat:-1}" -eq 0 ] || fail "socat forwarders not killed after delete"
+
+log "PASS — T2-FC: tap + socat created on boot, cleaned up on delete."

--- a/tests/e2e/firecracker/t3_api_instances.sh
+++ b/tests/e2e/firecracker/t3_api_instances.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# T3-FC: the API must report each running instance as a structured object
+# ({ id, address }), not a bare id string. This guards the DeploymentOutput
+# DTO change where `instances: Vec<String>` became `Vec<DeploymentInstance>`:
+#
+#   1. a deployment WITH ports → each instance carries its id AND a routable
+#      guest address (the 10.42.x.y/30 allocated for its tap),
+#   2. a deployment WITHOUT ports → each instance carries its id but NO address
+#      (no network was allocated, so there is nothing to route to).
+#
+# We assert against `deployment list --output json`, which serializes the same
+# DTO the REST API returns — so this covers get.rs/list.rs + the dto shape.
+#
+# Requires: firecracker, /dev/kvm, jq, and CAP_NET_ADMIN for ring-server (tap
+# creation, needed by the with-ports case). SKIPs (exit 0) when the ring binary
+# can't create taps, so it never fails spuriously on an unprivileged runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T3-FC: API instance shape ({ id, address }) =="
+
+command -v jq >/dev/null 2>&1 || { echo "[e2e] SKIP: jq not installed" >&2; exit 0; }
+
+# The with-ports case needs ring-server to create a tap, which requires
+# CAP_NET_ADMIN. SKIP rather than fail when the binary lacks it.
+ring_can_net=false
+if getcap "$RING_BIN" 2>/dev/null | grep -q 'cap_net_admin'; then
+  ring_can_net=true
+elif [ "$(id -u)" -eq 0 ]; then
+  ring_can_net=true
+fi
+if [ "$ring_can_net" != true ]; then
+  echo "[e2e] SKIP: ring binary lacks CAP_NET_ADMIN (tap creation). " \
+       "Grant it with: sudo setcap cap_net_admin+ep $RING_BIN" >&2
+  exit 0
+fi
+
+PORT_A=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+
+setup_fc
+start_ring
+ring_login
+
+# Returns the JSON `.instances` array for a deployment, by namespace/name.
+instances_json() {
+  local namespace="$1" name="$2"
+  "$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -c --arg ns "$namespace" --arg n "$name" \
+        '.[] | select(.namespace==$ns and .name==$n) | .instances' \
+    | head -n1
+}
+
+# === Case 1: deployment WITH ports → instances carry id + address ===
+FIXTURE_PORTS="$RING_TEST_DIR/api-ports-vm.yaml"
+cat > "$FIXTURE_PORTS" <<EOF
+deployments:
+  api-ports-vm:
+    name: api-ports-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    ports:
+      - { published: $PORT_A, target: 80 }
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE_PORTS"
+wait_deployment_status "ring-e2e" "api-ports-vm" "running" 60
+
+# The instance address is populated from the tap allocation, which can lag a
+# beat behind the "running" status; poll until it appears.
+INSTANCES=""
+ADDR=""
+for _ in $(seq 1 20); do
+  INSTANCES=$(instances_json "ring-e2e" "api-ports-vm")
+  ADDR=$(printf '%s' "$INSTANCES" | jq -r '.[0].address // empty' 2>/dev/null || true)
+  [ -n "$ADDR" ] && break
+  sleep 0.5
+done
+
+# Each entry must be an OBJECT with a non-empty `id` (not a bare string).
+ID=$(printf '%s' "$INSTANCES" | jq -r '.[0].id // empty' 2>/dev/null || true)
+[ -n "$ID" ] || { printf '%s\n' "$INSTANCES" >&2; fail "instance has no .id (DTO not { id, address }?)"; }
+log "with-ports instance id: $ID"
+
+# ... and a routable guest address in the 10.42.x.y range.
+[ -n "$ADDR" ] || { printf '%s\n' "$INSTANCES" >&2; fail "instance with ports has no .address"; }
+printf '%s' "$ADDR" | grep -qE '^10\.42\.[0-9]+\.[0-9]+$' \
+  || fail "instance address '$ADDR' is not a 10.42.x.y guest IP"
+log "with-ports instance address: $ADDR"
+
+# === Case 2: deployment WITHOUT ports → instances carry id but NO address ===
+FIXTURE_NOPORTS="$RING_TEST_DIR/api-noports-vm.yaml"
+cat > "$FIXTURE_NOPORTS" <<EOF
+deployments:
+  api-noports-vm:
+    name: api-noports-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE_NOPORTS"
+wait_deployment_status "ring-e2e" "api-noports-vm" "running" 60
+
+INSTANCES_NP=$(instances_json "ring-e2e" "api-noports-vm")
+ID_NP=$(printf '%s' "$INSTANCES_NP" | jq -r '.[0].id // empty' 2>/dev/null || true)
+[ -n "$ID_NP" ] || { printf '%s\n' "$INSTANCES_NP" >&2; fail "no-ports instance has no .id"; }
+log "no-ports instance id: $ID_NP"
+
+# `address` must be absent/null — no network was allocated, so there is no
+# reachable endpoint. `#[serde(skip_serializing_if = "Option::is_none")]` means
+# the field should not even be present; `// empty` collapses both null + absent.
+ADDR_NP=$(printf '%s' "$INSTANCES_NP" | jq -r '.[0].address // empty' 2>/dev/null || true)
+[ -z "$ADDR_NP" ] \
+  || { printf '%s\n' "$INSTANCES_NP" >&2; fail "no-ports instance unexpectedly has address '$ADDR_NP'"; }
+log "no-ports instance has no address (as expected)"
+
+# === Cleanup ===
+for name in api-ports-vm api-noports-vm; do
+  id=$(get_deployment_id "ring-e2e" "$name")
+  [ -n "$id" ] && { "$RING_BIN" deployment delete "$id" >/dev/null 2>&1 || true; }
+done
+
+log "PASS — T3-FC: API reports instances as { id, address }; address present with ports, absent without."

--- a/tests/e2e/firecracker/t4_restart.sh
+++ b/tests/e2e/firecracker/t4_restart.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# T4-FC: a microVM must survive a ring-server restart.
+#
+# Firecracker tracks its instances by PID + tap in memory (it has no remote
+# "delete VM" — it must kill(pid) — and Ring owns the tap). If those maps were
+# the source of truth, a restarted ring-server would lose every running VM:
+# scan_instances would return nothing, the scheduler would boot duplicates over
+# the live VMs, and the originals would become un-killable orphans (PID lost)
+# with leaked taps.
+#
+# The fix makes the on-disk `.sock` the source of truth: scan_instances reads
+# socket_dir, teardown re-finds the PID via /proc (--api-sock arg) and the tap
+# via its deterministic name. This test proves it end to end:
+#   1. apply a deployment with ports, record its instance id + tap,
+#   2. SIGKILL ring-server (leaving the VM + socket + tap alive),
+#   3. restart ring-server with the SAME config/db/socket_dir,
+#   4. assert it re-adopts the SAME instance (no duplicate, replicas still 1),
+#   5. delete and assert the VM process, socket, rootfs and tap are all reaped.
+#
+# Requires: firecracker, /dev/kvm, jq, and CAP_NET_ADMIN for ring-server (tap).
+# SKIPs (exit 0) when the ring binary can't create taps.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T4-FC: reconciliation across ring-server restart =="
+
+command -v jq >/dev/null 2>&1 || { echo "[e2e] SKIP: jq not installed" >&2; exit 0; }
+
+ring_can_net=false
+if getcap "$RING_BIN" 2>/dev/null | grep -q 'cap_net_admin'; then
+  ring_can_net=true
+elif [ "$(id -u)" -eq 0 ]; then
+  ring_can_net=true
+fi
+if [ "$ring_can_net" != true ]; then
+  echo "[e2e] SKIP: ring binary lacks CAP_NET_ADMIN (tap creation). " \
+       "Grant it with: sudo setcap cap_net_admin+ep $RING_BIN" >&2
+  exit 0
+fi
+
+PORT_A=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+
+setup_fc
+start_ring
+ring_login
+
+instance_ids() {
+  "$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r '.[] | select(.namespace=="ring-e2e" and .name=="restart-vm") | .instances[].id'
+}
+
+FIXTURE="$RING_TEST_DIR/restart-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  restart-vm:
+    name: restart-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    ports:
+      - { published: $PORT_A, target: 80 }
+EOF
+
+# Record pre-existing ring-* taps so we attribute the NEW one to this VM, not an
+# orphan left by an earlier run on a shared host.
+taps_now() { ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u; }
+TAPS_BEFORE=$(taps_now)
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "restart-vm" "running" 60
+
+# Record the instance id and the firecracker PID + tap that back it.
+INSTANCE_ID=""
+for _ in $(seq 1 20); do
+  INSTANCE_ID=$(instance_ids | head -n1)
+  [ -n "$INSTANCE_ID" ] && break
+  sleep 0.5
+done
+[ -n "$INSTANCE_ID" ] || fail "no instance id after apply"
+log "instance before restart: $INSTANCE_ID"
+
+SOCK="$RING_E2E_FC_SOCKET_DIR/$INSTANCE_ID.sock"
+[ -S "$SOCK" ] || fail "expected socket $SOCK"
+FC_PID=$(pgrep -f "firecracker.*--api-sock $SOCK" | head -n1 || true)
+[ -n "$FC_PID" ] || fail "could not find firecracker pid for $SOCK"
+# The tap that appeared since the apply belongs to this VM.
+TAP=""
+for _ in $(seq 1 20); do
+  TAP=$(comm -13 <(printf '%s\n' "$TAPS_BEFORE") <(taps_now) | head -1 || true)
+  [ -n "$TAP" ] && break
+  sleep 0.5
+done
+[ -n "$TAP" ] || fail "no new ring-* tap before restart"
+log "firecracker pid=$FC_PID, tap=$TAP"
+
+# === 2. SIGKILL ring-server, leaving the VM alive ===
+log "killing ring-server (pid=$RING_PID), VM should keep running"
+kill -9 "$RING_PID" 2>/dev/null || true
+for _ in $(seq 1 20); do kill -0 "$RING_PID" 2>/dev/null || break; sleep 0.2; done
+kill -0 "$RING_PID" 2>/dev/null && fail "ring-server did not die"
+
+# The VM must still be alive and its socket present.
+kill -0 "$FC_PID" 2>/dev/null || fail "VM died when ring-server was killed (should outlive it)"
+[ -S "$SOCK" ] || fail "socket vanished after ring-server kill"
+log "VM still alive (pid=$FC_PID) after ring-server died"
+
+# === 3. Restart ring-server with the SAME config/db/socket_dir ===
+# Reuse the env start_ring exported (RING_CONFIG_DIR, RING_DATABASE_PATH, etc.)
+# so it reads the same state — but spawn it directly, since start_ring would
+# mint a fresh temp dir + db.
+log "restarting ring-server on the same config dir"
+"$RING_BIN" server start > "$RING_TEST_DIR/ring-restart.log" 2>&1 &
+RING_PID=$!
+for _ in $(seq 1 60); do
+  curl -sf "${RING_URL}/healthz" >/dev/null 2>&1 && break
+  kill -0 "$RING_PID" 2>/dev/null || { cat "$RING_TEST_DIR/ring-restart.log" >&2; fail "restarted ring died"; }
+  sleep 0.5
+done
+curl -sf "${RING_URL}/healthz" >/dev/null 2>&1 || { cat "$RING_TEST_DIR/ring-restart.log" >&2; fail "restarted ring never healthy"; }
+ring_login
+log "ring-server back up (pid=$RING_PID)"
+
+# === 4. It must re-adopt the SAME instance — no duplicate ===
+# Give the scheduler a couple of ticks; assert the id set is exactly {original}.
+ADOPTED=""
+for _ in $(seq 1 30); do
+  mapfile -t ids < <(instance_ids)
+  if [ "${#ids[@]}" -eq 1 ] && [ "${ids[0]}" = "$INSTANCE_ID" ]; then
+    ADOPTED=true; break
+  fi
+  sleep 1
+done
+if [ "$ADOPTED" != true ]; then
+  echo "instances after restart: $(instance_ids | tr '\n' ' ')" >&2
+  fail "expected the single original instance $INSTANCE_ID to be re-adopted (no duplicate)"
+fi
+# And it must be the same firecracker process (proves no reboot-over).
+kill -0 "$FC_PID" 2>/dev/null || fail "original VM pid $FC_PID gone — a duplicate was booted over it"
+log "re-adopted same instance $INSTANCE_ID (pid $FC_PID still the one running)"
+
+# === 5. Delete reaps the VM, socket, rootfs and tap — via the disk fallbacks ===
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "restart-vm")
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e restart-vm >/dev/null 2>&1 || true
+
+for _ in $(seq 1 30); do
+  gone_pid=true; kill -0 "$FC_PID" 2>/dev/null && gone_pid=false
+  gone_sock=true; [ -S "$SOCK" ] && gone_sock=false
+  gone_tap=true; taps_now | grep -qxF "$TAP" && gone_tap=false
+  [ "$gone_pid" = true ] && [ "$gone_sock" = true ] && [ "$gone_tap" = true ] && break
+  sleep 0.5
+done
+[ "$gone_pid" = true ]  || fail "VM pid $FC_PID not killed on delete (PID-via-/proc fallback failed)"
+[ "$gone_sock" = true ] || fail "socket $SOCK not removed on delete"
+[ "$gone_tap" = true ]  || fail "tap $TAP not removed on delete (tap-adopt fallback failed)"
+
+log "PASS — T4-FC: VM survived restart, was re-adopted (no duplicate), cleaned up via disk fallbacks."


### PR DESCRIPTION
## Summary

Adds **Firecracker** as a fourth runtime, alongside Docker, Podman, and Cloud Hypervisor. Each deployment instance boots as a dedicated KVM-backed microVM, driven over Firecracker's REST API on a per-VM control socket.

Structurally a sibling of the Cloud Hypervisor runtime: same KVM-VM model and the same shared helpers (`cloud_init`, `host_net`, `port_forwarder`), but a different VMM and API shape (a sequence of resource PUTs instead of CH's monolithic `vm.create`).

## What's included

- **Boot lifecycle** — one `firecracker` process per VM, configured via `boot-source` / `drives` / `machine-config` / `actions`, with a per-instance rootfs copy and serial console log. Scale up/down and teardown.
- **Networking** — per-VM `/30` subnet, guest IP via cloud-init, host-port forwarding via `socat`. Firecracker does not create its own TAP, so Ring owns the whole TAP lifecycle via **direct ioctls** (keeps `CAP_NET_ADMIN` in-process; a forked `ip` would lose it).
- **Shared cloud-init** — hoisted out of `cloud_hypervisor` into a shared runtime module. The NoCloud datasource is an **ext4** image labelled `CIDATA` (minimal guest kernels mount neither iso9660 nor vfat).
- **Resource sizing** — reads `limits`/`requests`, rounds vCPUs up, defaults to 1 vCPU / 512 MiB.
- **Structured instances API** — `instances` is now `[{ id, address }]` (routable guest IP, omitted when there's no network), mirroring the Nomad/Consul model. Dashboard + CLI updated.
- **Restart reconciliation** — instance state is derived from the on-disk `.sock` (not in-memory maps), so a `ring-server` restart re-adopts running VMs instead of booting duplicates over them. Teardown re-finds the PID via `/proc` and the TAP by its deterministic name.
- **Reliable TAP teardown** — host TAP deletion uses `RTM_DELLINK` netlink (the persist-clear approach did not actually remove the interface).

## Testing

- Unit tests for config, resource parsing, disk scan, `/proc` matching, cidata ext4, and tap math.
- E2E suite (`tests/e2e/firecracker/`): `t1` boot/delete, `t2` ports (tap + socat lifecycle), `t3` API instance shape, `t4` restart reconciliation. All four pass against a real Firecracker + KVM host.

## Notes

- Firecracker is **opt-in** like every runtime (`[server.runtime.firecracker] enabled = true`), registered only when the binary is resolvable.
- Documented in `concepts/runtimes.md`, `reference/config-toml.md`, `reference/manifest.md`, `reference/api.md`.
- Known gaps (tracked): volumes, `command` health checks, metrics, and `kind: job` are not yet wired.