### PR TITLE
feat: containerd runtime over native gRPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
       - uses: oven-sh/setup-bun@v2
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: rustup component add clippy
@@ -64,6 +66,8 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
       - uses: oven-sh/setup-bun@v2
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: docker pull nginx:alpine

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ jobs:
           bun install --frozen-lockfile
           bun run build
 
+      # The containerd runtime's gRPC bindings are generated at build time by
+      # containerd-client's build script, which needs protoc.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Build release binary
         run: cargo build --release --bin ring
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "containerd-client"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814eedf2860b6df6e8002f917a0fbabf53bace3d3d9d2c2022661ae55a6ab6e4"
+dependencies = [
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tower",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +891,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
@@ -1296,6 +1318,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1785,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -2015,6 +2065,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2219,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2356,6 +2488,7 @@ dependencies = [
  "chrono",
  "clap",
  "cli-table",
+ "containerd-client",
  "futures",
  "hex",
  "hmac",
@@ -2371,6 +2504,8 @@ dependencies = [
  "nix",
  "once_cell",
  "owo-colors",
+ "prost",
+ "prost-types",
  "rand 0.9.4",
  "regex",
  "reqwest",
@@ -2385,8 +2520,10 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-vsock",
  "toml",
+ "tonic",
  "tower",
  "tower-http",
  "tracing",
@@ -3350,6 +3487,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,9 +3562,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3821,7 +4029,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,22 @@ mime_guess = "2"
 anyhow = "1"
 caps = "0.5.6"
 nix = { version = "0.31.3", features = ["signal"] }
+# containerd runtime: native gRPC over containerd's Unix socket. We drive the
+# raw containerd API (images, content, snapshots, containers, tasks) rather
+# than going through Docker — there is no daemon in between. `containerd-client`
+# carries the official prost/tonic bindings for that API generated from
+# containerd's own .proto, and its `connect` helper dials the Unix socket.
+# tonic/prost/prost-types are pinned to the same versions it uses so the
+# generated types and our hand-written code agree on one set of crates.
+containerd-client = "0.9"
+# Kept on the same tonic/prost majors that containerd-client 0.9 uses, so the
+# generated containerd types and our hand-written gRPC code share one copy of
+# each crate (a second copy would stop the Request/message types unifying and
+# every round-trip would fail to typecheck).
+tonic = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+tokio-stream = "0.1"
 
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -1,6 +1,6 @@
 # Runtimes
 
-Ring is a state engine; the runtime is the thing that actually starts your workload. Four implementations sit behind the same trait: **Docker** (production-ready), **Podman** (Docker-compatible, rootless-friendly), **Cloud Hypervisor** (alpha), and **Firecracker** (experimental). A deployment picks one with `runtime: docker`, `runtime: podman`, `runtime: cloud-hypervisor`, or `runtime: firecracker`.
+Ring is a state engine; the runtime is the thing that actually starts your workload. Five implementations sit behind the same trait: **Docker** (production-ready), **Podman** (Docker-compatible, rootless-friendly), **containerd** (the OCI runtime under Docker/Kubernetes, driven directly over gRPC), **Cloud Hypervisor** (alpha), and **Firecracker** (experimental). A deployment picks one with `runtime: docker`, `runtime: podman`, `runtime: containerd`, `runtime: cloud-hypervisor`, or `runtime: firecracker`.
 
 This page covers the trade-offs and the mental model for each. For step-by-step setup, see the how-to guides; for exact manifest semantics, see the [manifest reference](/documentation/reference/manifest).
 
@@ -13,24 +13,24 @@ Runtimes are **opt-in**: none is enabled by default. You turn one on in `config.
 enabled = true
 ```
 
-Enable just the runtimes a host actually runs — Docker-only, Podman-only, Cloud-Hypervisor-only, or any mix. Ring registers exactly those, and refuses to start if none is enabled or if an enabled runtime is unreachable (an explicit-but-broken runtime is a configuration error, surfaced at startup rather than as a failed deployment later). See the [config.toml reference](/documentation/reference/config-toml#runtimes-are-opt-in) for the full rules.
+Enable just the runtimes a host actually runs — Docker-only, Podman-only, containerd-only, Cloud-Hypervisor-only, or any mix. Ring registers exactly those, and refuses to start if none is enabled or if an enabled runtime is unreachable (an explicit-but-broken runtime is a configuration error, surfaced at startup rather than as a failed deployment later). See the [config.toml reference](/documentation/reference/config-toml#runtimes-are-opt-in) for the full rules.
 
 ## Quick comparison
 
-| Aspect | Docker | Podman | Cloud Hypervisor | Firecracker |
-|---|---|---|---|---|
-| Status | Production | Beta | Alpha | Experimental |
-| Isolation | Linux namespaces + cgroups | Linux namespaces + cgroups (rootless by default) | Full kernel, KVM-backed VM | Full kernel, KVM-backed microVM |
-| Boot time | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) | ~1 s (minimal microVM) |
-| Memory overhead per workload | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) | ~5–50 MB (minimal device model) |
-| Image format | Docker image (`nginx:1.25`) | Docker/OCI image | Raw disk image on the host filesystem | Kernel (`vmlinux`) + ext4 rootfs on the host filesystem |
-| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | Per-VM /30 subnet, host-port forwarding via `socat` | Per-VM /30 subnet, host-port forwarding via `socat` (Ring-owned host TAP) |
-| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) | No (tick-bound) |
-| `command` health checks | `docker exec` | `podman exec` (same API) | In-guest `ring-agent` over AF_VSOCK | Not yet |
-| `kind: job` | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) | Not yet (runs as worker) |
-| Labels (`labels:`) | Forwarded to container | Forwarded to container | Silently ignored | Silently ignored |
-| Host networking | Supported | Not supported by Ring yet | N/A | N/A |
-| Private registry creds | Supported | Supported | N/A (no image pull) | N/A (no image pull) |
+| Aspect | Docker | Podman | containerd | Cloud Hypervisor | Firecracker |
+|---|---|---|---|---|---|
+| Status | Production | Beta | Beta | Alpha | Experimental |
+| Isolation | Linux namespaces + cgroups | Linux namespaces + cgroups (rootless by default) | Linux namespaces + cgroups | Full kernel, KVM-backed VM | Full kernel, KVM-backed microVM |
+| Boot time | ~1 s | ~1 s | ~1 s | ~3–5 s (cloud-init, kernel boot) | ~1 s (minimal microVM) |
+| Memory overhead per workload | ~10 MB | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) | ~5–50 MB (minimal device model) |
+| Image format | Docker image (`nginx:1.25`) | Docker/OCI image | OCI image (`nginx:1.25`) | Raw disk image on the host filesystem | Kernel (`vmlinux`) + ext4 rootfs on the host filesystem |
+| Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | CNI (bridge + host-local IPAM) | Per-VM /30 subnet, host-port forwarding via `socat` | Per-VM /30 subnet, host-port forwarding via `socat` (Ring-owned host TAP) |
+| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) | No (tick-bound) | No (tick-bound) |
+| `command` health checks | `docker exec` | `podman exec` (same API) | `Tasks.Exec` (gRPC) | In-guest `ring-agent` over AF_VSOCK | Not yet |
+| `kind: job` | Exit code visible | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) | Not yet (runs as worker) |
+| Labels (`labels:`) | Forwarded to container | Forwarded to container | Forwarded to container | Silently ignored | Silently ignored |
+| Host networking | Supported | Not supported by Ring yet | Not supported by Ring yet | N/A | N/A |
+| Private registry creds | Supported | Supported | Supported (basic auth) | N/A (no image pull) | N/A (no image pull) |
 
 ## Docker runtime
 
@@ -69,6 +69,34 @@ The socket must be running — start it once with `systemctl --user start podman
 - **Event stream**: Podman only emits events while `podman system service` is up. Ring does not yet consume Podman events (the orphan-volume reaper stays Docker-only), so crash detection is tick-bound for now.
 - **Host networking** (`network.mode: host`) is not yet allowed on Podman — Docker only.
 - Rootless remaps UID/GID; bind-mount and named-volume ownership behave differently than Docker-root — mind file permissions on mounts.
+
+## containerd runtime (beta)
+
+containerd is the OCI runtime that sits *underneath* Docker and Kubernetes. Where Podman is reached through a Docker-compatible API, containerd speaks its own native **gRPC** protocol on `/run/containerd/containerd.sock` — so Ring drives it directly, with no Docker daemon in the picture. This is the right choice on hosts that already run containerd for Kubernetes (k3s, RKE2, stock `containerd`) and don't want a second container engine.
+
+Enable it and (optionally) point Ring at a non-default socket or namespace:
+
+```toml
+[server.runtime.containerd]
+enabled = true
+# socket = "/run/containerd/containerd.sock"
+# namespace = "ring"
+```
+
+Ring keeps all the objects it creates under its own containerd **namespace** (`ring` by default) so they don't collide with `k8s.io`, `moby` or `default`. This is containerd's metadata-partition concept and is unrelated to a Ring deployment namespace — deployments are still scoped the usual way, via the `ring_deployment` label.
+
+Because containerd is lower-level than Docker, Ring assembles by hand what bollard would otherwise hide: images are pulled through the **transfer** service (resolve → fetch layers → unpack), the rootfs is a writable **snapshot** prepared from the image's layer chain, the container runs as a **task** under the `runc` shim, and networking is wired with **CNI** (a `bridge` + `host-local` IPAM chain, auto-written to `/etc/cni/net.d` if absent) so every container gets a routable IP — the same model Kubernetes and `nerdctl` use.
+
+**Good fit when:**
+- The host already runs containerd (Kubernetes nodes, k3s/RKE2) and you don't want Docker too
+- You want the standard OCI/CNI stack without a higher-level daemon
+- You need exec-based health checks, labels and registry auth (all supported, like Docker)
+
+**Caveats:**
+- **CNI plugins must be installed** (`/opt/cni/bin`: `bridge`, `host-local`, `loopback`). They ship with most Kubernetes distros; on a bare host install the `containernetworking-plugins` package. Ring writes a default conflist but cannot supply the plugin binaries — without them a container boots with no CNI address.
+- **Stats**: memory and pids come from cgroup v2; CPU% and per-interface network/disk I/O aren't derivable from a single cgroup sample, so they read as zero.
+- **Event stream**: containerd has one, but Ring does not consume it yet — crash detection is tick-bound, like Cloud Hypervisor.
+- **Host networking** (`network.mode: host`) is not yet allowed on containerd — Docker only.
 
 ## Cloud Hypervisor runtime (alpha)
 

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -91,6 +91,16 @@ Podman speaks the Docker-compatible API (`podman system service`), so Ring drive
 | `enabled` | bool | no | `false` | Register the Podman runtime. Must be `true` for Ring to use Podman. When `true` and the socket is unreachable at startup, Ring fails fast |
 | `host` | string | no | rootless-first resolution | Podman API socket. Default resolution: `RING_PODMAN_HOST` → `DOCKER_HOST` → `unix:///run/user/$UID/podman/podman.sock` → `unix:///run/podman/podman.sock`. Start it with `systemctl --user start podman.socket` (rootless) |
 
+### `[server.runtime.containerd]`
+
+containerd speaks its own native gRPC API on a Unix socket — no Docker daemon in between. CNI plugins (`/opt/cni/bin`) must be present for container networking.
+
+| Field | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Register the containerd runtime. Must be `true` for Ring to use containerd. When `true` and the socket doesn't answer a `Version` round-trip at startup, Ring fails fast |
+| `socket` | string | no | `/run/containerd/containerd.sock` | Path to the containerd gRPC Unix socket (the stock location used by `containerd`, k3s and RKE2) |
+| `namespace` | string | no | `ring` | containerd metadata namespace Ring creates its images, snapshots, containers and tasks under. Keeps Ring's objects from colliding with `k8s.io`, `moby` or `default` on a shared host. This is containerd's own partition concept, unrelated to a Ring deployment namespace |
+
 ### `[server.runtime.cloud_hypervisor]`
 
 | Field | Type | Default | Purpose |

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -32,10 +32,10 @@ fn default_replicas() -> u32 {
 
 fn validate_runtime(runtime: &str) -> Result<(), ValidationError> {
     match runtime {
-        "docker" | "podman" | "cloud-hypervisor" | "firecracker" => Ok(()),
+        "docker" | "podman" | "containerd" | "cloud-hypervisor" | "firecracker" => Ok(()),
         _ => Err(
             ValidationError::new("deployment.runtime.unsupported").with_message(Cow::Borrowed(
-                "runtime must be one of: docker, podman, cloud-hypervisor, firecracker",
+                "runtime must be one of: docker, podman, containerd, cloud-hypervisor, firecracker",
             )),
         ),
     }

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -249,11 +249,12 @@ impl Deployment {
 
         if self.runtime != "docker"
             && self.runtime != "podman"
+            && self.runtime != "containerd"
             && self.runtime != "cloud-hypervisor"
             && self.runtime != "firecracker"
         {
             return Err(ApplyError::Validation(format!(
-                "Runtime '{}' not supported. Supported runtimes: docker, podman, cloud-hypervisor, firecracker.",
+                "Runtime '{}' not supported. Supported runtimes: docker, podman, containerd, cloud-hypervisor, firecracker.",
                 self.runtime
             )));
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -36,7 +36,7 @@ pub(crate) fn command_config() -> Command {
                 .long("runtime")
                 .value_name("RUNTIME")
                 .help(
-                    "Runtime to configure, skipping the prompt: docker, podman, cloud-hypervisor, firecracker, or both",
+                    "Runtime to configure, skipping the prompt: docker, podman, containerd, cloud-hypervisor, firecracker, or both",
                 )
                 .value_parser(clap::value_parser!(RuntimeChoice)),
         )
@@ -63,6 +63,7 @@ pub(crate) struct InitSettings {
 pub(crate) enum RuntimeChoice {
     Docker,
     Podman,
+    Containerd,
     CloudHypervisor,
     Firecracker,
     Both,
@@ -73,6 +74,7 @@ impl RuntimeChoice {
         match self {
             RuntimeChoice::Docker => "Docker",
             RuntimeChoice::Podman => "Podman",
+            RuntimeChoice::Containerd => "containerd",
             RuntimeChoice::CloudHypervisor => "Cloud Hypervisor",
             RuntimeChoice::Firecracker => "Firecracker (experimental)",
             RuntimeChoice::Both => "Both",
@@ -221,6 +223,7 @@ fn collect_settings(args: &ArgMatches) -> InitSettings {
             vec![
                 RuntimeChoice::Docker,
                 RuntimeChoice::Podman,
+                RuntimeChoice::Containerd,
                 RuntimeChoice::CloudHypervisor,
                 RuntimeChoice::Firecracker,
                 RuntimeChoice::Both,
@@ -284,6 +287,7 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         RuntimeChoice::Docker | RuntimeChoice::Both
     );
     let podman = matches!(settings.runtime, RuntimeChoice::Podman);
+    let containerd = matches!(settings.runtime, RuntimeChoice::Containerd);
     let cloud_hypervisor = matches!(
         settings.runtime,
         RuntimeChoice::CloudHypervisor | RuntimeChoice::Both
@@ -305,6 +309,14 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         out.push_str("enabled = true\n");
         // Default is rootless-first; uncomment to pin a specific socket.
         out.push_str("# host = \"unix:///run/user/1000/podman/podman.sock\"  # rootless\n");
+    }
+
+    if containerd {
+        out.push('\n');
+        out.push_str("[server.runtime.containerd]\n");
+        out.push_str("enabled = true\n");
+        out.push_str("# socket = \"/run/containerd/containerd.sock\"\n");
+        out.push_str("# namespace = \"ring\"\n");
     }
 
     if cloud_hypervisor {
@@ -483,6 +495,20 @@ mod tests {
         assert!(out.contains("[server.runtime.podman]"));
         assert!(out.contains("enabled = true"));
         // Podman is exclusive — no Docker or CH block.
+        assert!(!out.contains("[server.runtime.docker]"));
+        assert!(!out.contains("runtime.cloud_hypervisor"));
+    }
+
+    #[test]
+    fn build_config_containerd_only_emits_containerd_section() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Containerd,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("[server.runtime.containerd]"));
+        assert!(out.contains("enabled = true"));
+        // containerd is exclusive — no Docker or CH block.
         assert!(!out.contains("[server.runtime.docker]"));
         assert!(!out.contains("runtime.cloud_hypervisor"));
     }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -2,6 +2,7 @@ use crate::api::server as ApiServer;
 use crate::cli::style;
 use crate::hypervisor::lifecycle_trait::RuntimeLifecycle;
 use crate::runtime::cloud_hypervisor::CloudHypervisorLifecycle;
+use crate::runtime::containerd::{ContainerdLifecycle, ContainerdRuntimeConfig};
 use crate::runtime::docker;
 use crate::runtime::docker::docker_lifecycle::DockerLifecycle;
 use crate::runtime::firecracker::{FirecrackerLifecycle, FirecrackerRuntimeConfig};
@@ -137,6 +138,29 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
         }
     } else {
         info!("Podman runtime disabled in config, skipping");
+    }
+
+    // containerd: enabled in config → verify the gRPC socket answers a Version
+    // round-trip, else fail fast. Unlike Podman, containerd speaks its own native
+    // API (no Docker daemon in between), so it has its own ContainerdLifecycle
+    // registered under the "containerd" key.
+    if configuration.server.runtime.containerd.enabled {
+        let containerd_config =
+            ContainerdRuntimeConfig::from_user_config(&configuration.server.runtime.containerd);
+        match ContainerdLifecycle::connect_and_verify(containerd_config).await {
+            Ok(containerd) => {
+                runtimes_map.insert("containerd".to_string(), Arc::new(containerd));
+            }
+            Err(e) => {
+                error!(
+                    "Refusing to start: containerd runtime is enabled in config but unreachable: {}",
+                    e
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        info!("containerd runtime disabled in config, skipping");
     }
 
     // Cloud Hypervisor: enabled in config → its binary must resolve, else fail

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -48,6 +48,8 @@ pub(crate) struct RuntimesConfig {
     #[serde(default)]
     pub(crate) podman: PodmanConfig,
     #[serde(default)]
+    pub(crate) containerd: ContainerdConfig,
+    #[serde(default)]
     pub(crate) cloud_hypervisor: CloudHypervisorConfig,
     #[serde(default)]
     pub(crate) firecracker: FirecrackerConfig,
@@ -105,6 +107,45 @@ impl Default for PodmanConfig {
         PodmanConfig {
             enabled: false,
             host: default_podman_host(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct ContainerdConfig {
+    /// Whether to register the containerd runtime. Off by default (runtimes
+    /// are opt-in). Unlike Podman, containerd speaks its own native gRPC API,
+    /// so Ring drives it directly with no Docker daemon in between. When `true`
+    /// and the socket doesn't answer at startup, Ring fails fast.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    /// Path to the containerd gRPC Unix socket. Defaults to the stock location
+    /// used by `containerd`, k3s and RKE2.
+    #[serde(default = "default_containerd_socket")]
+    pub(crate) socket: String,
+    /// containerd metadata namespace under which Ring creates its images,
+    /// snapshots, containers and tasks. This is containerd's own partition
+    /// concept (akin to `k8s.io`, `moby`, `default`) and is unrelated to a Ring
+    /// deployment namespace — keeping Ring's objects under their own namespace
+    /// avoids colliding with Kubernetes or Docker on a shared host.
+    #[serde(default = "default_containerd_namespace")]
+    pub(crate) namespace: String,
+}
+
+fn default_containerd_socket() -> String {
+    "/run/containerd/containerd.sock".to_string()
+}
+
+fn default_containerd_namespace() -> String {
+    "ring".to_string()
+}
+
+impl Default for ContainerdConfig {
+    fn default() -> Self {
+        ContainerdConfig {
+            enabled: false,
+            socket: default_containerd_socket(),
+            namespace: default_containerd_namespace(),
         }
     }
 }

--- a/src/runtime/containerd/client.rs
+++ b/src/runtime/containerd/client.rs
@@ -1,0 +1,93 @@
+//! Connection management for the containerd runtime.
+//!
+//! [`ContainerdRuntimeConfig`] is the resolved, daemon-side configuration (which
+//! socket, which containerd namespace). [`ContainerdLifecycle`] holds it and a
+//! lazily-created gRPC [`Client`]; the trait impl lives in
+//! [`super::lifecycle`].
+
+use crate::config::server::ContainerdConfig;
+use crate::hypervisor::error::RuntimeError;
+use containerd_client::Client;
+use containerd_client::services::v1::version_client::VersionClient;
+
+/// Default snapshotter. `overlayfs` is the stock default on virtually every
+/// containerd install (Docker, k3s, RKE2 all use it). Pinning it here keeps the
+/// rootfs path consistent with what the image was unpacked into during pull.
+pub(crate) const DEFAULT_SNAPSHOTTER: &str = "overlayfs";
+
+/// containerd's built-in runtime shim name (runc v2). This is the `runtime.name`
+/// field on the container object — not a binary path.
+pub(crate) const DEFAULT_RUNTIME: &str = "io.containerd.runc.v2";
+
+/// Resolved configuration for the containerd runtime.
+#[derive(Clone, Debug)]
+pub(crate) struct ContainerdRuntimeConfig {
+    /// Path to the containerd gRPC Unix socket.
+    pub(crate) socket: String,
+    /// containerd metadata namespace Ring operates under.
+    pub(crate) namespace: String,
+}
+
+impl ContainerdRuntimeConfig {
+    /// Build the runtime config from the user-facing `[server.runtime.containerd]`
+    /// section. Both fields already carry sensible defaults from the config
+    /// layer, so this is a straight copy.
+    pub(crate) fn from_user_config(cfg: &ContainerdConfig) -> Self {
+        Self {
+            socket: cfg.socket.clone(),
+            namespace: cfg.namespace.clone(),
+        }
+    }
+}
+
+/// The containerd runtime handle. Cloning is cheap: it only carries the resolved
+/// config; each gRPC call opens its own multiplexed stream over a fresh client
+/// built from the socket (containerd's gRPC channel is connection-pooled by
+/// tonic under the hood).
+#[derive(Clone)]
+pub(crate) struct ContainerdLifecycle {
+    pub(crate) config: ContainerdRuntimeConfig,
+}
+
+impl ContainerdLifecycle {
+    pub(crate) fn new(config: ContainerdRuntimeConfig) -> Self {
+        Self { config }
+    }
+
+    /// Open a gRPC client to the configured socket.
+    ///
+    /// `Client::from_path` actually dials the Unix socket, so unlike Docker's
+    /// lazy `connect`, a failure here already means containerd is unreachable.
+    pub(crate) async fn connect(&self) -> Result<Client, RuntimeError> {
+        Client::from_path(&self.config.socket).await.map_err(|e| {
+            RuntimeError::Other(format!(
+                "failed to connect to containerd socket {}: {}",
+                self.config.socket, e
+            ))
+        })
+    }
+
+    /// Fail-fast availability probe used at daemon startup, mirroring the Docker
+    /// runtime's `connect_and_verify`. A successful `Version` round-trip proves
+    /// the socket is up *and* speaking the containerd API, so it gates whether
+    /// the runtime is registered at all.
+    pub(crate) async fn connect_and_verify(
+        config: ContainerdRuntimeConfig,
+    ) -> Result<Self, RuntimeError> {
+        let lifecycle = Self::new(config);
+        let client = lifecycle.connect().await?;
+        let mut version = VersionClient::new(client.channel());
+        let resp = version.version(()).await.map_err(|e| {
+            RuntimeError::Other(format!(
+                "containerd at {} did not answer Version: {}",
+                lifecycle.config.socket, e
+            ))
+        })?;
+        let v = resp.into_inner();
+        info!(
+            "containerd runtime ready (version {} / {}, namespace '{}')",
+            v.version, v.revision, lifecycle.config.namespace
+        );
+        Ok(lifecycle)
+    }
+}

--- a/src/runtime/containerd/cni.rs
+++ b/src/runtime/containerd/cni.rs
@@ -1,0 +1,238 @@
+//! CNI networking for containerd tasks.
+//!
+//! containerd has no networking of its own — that is by design, it leaves the
+//! network namespace to a [CNI] plugin chain. We drive the standard CNI plugins
+//! ourselves over the documented CNI execution protocol: a JSON network config
+//! on stdin, the operation in `CNI_COMMAND`, and the container/netns identifiers
+//! in environment variables. This is the same protocol Kubernetes and `nerdctl`
+//! use; it is *not* an application shell-out (we invoke the plugin binaries the
+//! CNI spec defines, with the spec's wire format).
+//!
+//! On `ADD` we capture the assigned IP so [`super::health_check`] can resolve a
+//! reachable address; on `DEL` we tear the interface down.
+//!
+//! [CNI]: https://github.com/containernetworking/cni
+
+use serde::Deserialize;
+use std::io::Write;
+use std::net::IpAddr;
+use std::path::Path;
+use std::process::Stdio;
+
+/// Where Ring writes its default CNI network configuration.
+const CNI_CONF_DIR: &str = "/etc/cni/net.d";
+const CNI_CONF_FILE: &str = "/etc/cni/net.d/10-ring.conflist";
+/// Standard search path for CNI plugin binaries.
+const CNI_BIN_DIR: &str = "/opt/cni/bin";
+/// Network name + bridge used by Ring's default conflist.
+const CNI_NETWORK_NAME: &str = "ring";
+const CNI_BRIDGE: &str = "ring-cni0";
+/// IPAM subnet for Ring containers. /16 gives ample address space and avoids the
+/// common 10.42/10.88 ranges k3s and nerdctl default to.
+const CNI_SUBNET: &str = "10.43.0.0/16";
+/// Interface name inside the container.
+const CNI_IFNAME: &str = "eth0";
+
+/// Subset of a CNI ADD result we parse: the IPs assigned to the interface.
+#[derive(Deserialize)]
+struct CniResult {
+    #[serde(default)]
+    ips: Vec<CniIp>,
+}
+
+#[derive(Deserialize)]
+struct CniIp {
+    /// `address` is CIDR form, e.g. `10.43.0.5/16`.
+    address: String,
+}
+
+/// Ensure Ring's default CNI conflist exists. Idempotent: written only when
+/// absent so an operator can drop in their own config to override it.
+pub(crate) fn ensure_default_config() {
+    if Path::new(CNI_CONF_FILE).exists() {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(CNI_CONF_DIR) {
+        warn!("could not create CNI config dir {}: {}", CNI_CONF_DIR, e);
+        return;
+    }
+    let conflist = default_conflist();
+    match std::fs::write(CNI_CONF_FILE, conflist) {
+        Ok(_) => info!("wrote default CNI conflist to {}", CNI_CONF_FILE),
+        Err(e) => warn!("could not write CNI conflist {}: {}", CNI_CONF_FILE, e),
+    }
+}
+
+fn default_conflist() -> String {
+    serde_json::json!({
+        "cniVersion": "1.0.0",
+        "name": CNI_NETWORK_NAME,
+        "plugins": [
+            {
+                "type": "bridge",
+                "bridge": CNI_BRIDGE,
+                "isGateway": true,
+                "ipMasq": true,
+                "hairpinMode": true,
+                "ipam": {
+                    "type": "host-local",
+                    "ranges": [[{ "subnet": CNI_SUBNET }]],
+                    "routes": [{ "dst": "0.0.0.0/0" }]
+                }
+            },
+            { "type": "loopback" }
+        ]
+    })
+    .to_string()
+}
+
+/// Whether the CNI plugin binaries are present. When missing we skip networking
+/// with a clear warning rather than failing the whole deployment — the workload
+/// still boots, just without a CNI address (health checks that need an IP will
+/// report the missing address).
+pub(crate) fn plugins_available() -> bool {
+    Path::new(CNI_BIN_DIR).join("bridge").exists()
+}
+
+/// Run `CNI ADD` for a container's network namespace and return the assigned IP.
+///
+/// `netns_path` is the path to the network namespace (e.g.
+/// `/proc/<pid>/ns/net`); `container_id` is the CNI container id (we use the
+/// task/instance id).
+pub(crate) async fn add(container_id: &str, netns_path: &str) -> Option<IpAddr> {
+    if !plugins_available() {
+        warn!(
+            "CNI plugins not found under {} — instance {} will have no CNI network",
+            CNI_BIN_DIR, container_id
+        );
+        return None;
+    }
+    // The plugin invocation (fork-exec + host-local IPAM filesystem I/O) blocks,
+    // so run it off the async runtime's worker threads.
+    let (cid, ns) = (container_id.to_string(), netns_path.to_string());
+    let stdout = match tokio::task::spawn_blocking(move || exec_plugin("ADD", &cid, &ns))
+        .await
+        .ok()
+        .flatten()
+    {
+        Some(out) => out,
+        None => return None,
+    };
+    let result: CniResult = match serde_json::from_slice(&stdout) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("could not parse CNI ADD result for {}: {}", container_id, e);
+            return None;
+        }
+    };
+    for ip in result.ips {
+        if let Some((addr, _)) = ip.address.split_once('/')
+            && let Ok(parsed) = addr.parse::<IpAddr>()
+        {
+            return Some(parsed);
+        }
+    }
+    None
+}
+
+/// Run `CNI DEL` to tear down a container's network. Best-effort and idempotent
+/// (the CNI spec requires DEL to succeed even if ADD never ran, so calling it
+/// during cleanup of a half-created instance is safe).
+pub(crate) async fn del(container_id: &str, netns_path: &str) {
+    if !plugins_available() {
+        return;
+    }
+    let (cid, ns) = (container_id.to_string(), netns_path.to_string());
+    let _ = tokio::task::spawn_blocking(move || exec_plugin("DEL", &cid, &ns)).await;
+}
+
+/// Execute the chained CNI plugins for the conflist. We invoke the first plugin
+/// (`bridge`) directly with the conflist's plugin config — for Ring's simple two
+/// plugin chain this is sufficient; a full chained runtime would feed each
+/// plugin's output as `prevResult` to the next, which is unnecessary for a
+/// bridge+loopback chain where only the bridge allocates an IP.
+fn exec_plugin(command: &str, container_id: &str, netns_path: &str) -> Option<Vec<u8>> {
+    // Extract the bridge plugin config from the conflist and add the required
+    // top-level fields each plugin invocation expects (`cniVersion`, `name`).
+    let net_config = serde_json::json!({
+        "cniVersion": "1.0.0",
+        "name": CNI_NETWORK_NAME,
+        "type": "bridge",
+        "bridge": CNI_BRIDGE,
+        "isGateway": true,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+            "type": "host-local",
+            "ranges": [[{ "subnet": CNI_SUBNET }]],
+            "routes": [{ "dst": "0.0.0.0/0" }]
+        }
+    })
+    .to_string();
+
+    let plugin = Path::new(CNI_BIN_DIR).join("bridge");
+    let mut child = match std::process::Command::new(&plugin)
+        .env("CNI_COMMAND", command)
+        .env("CNI_CONTAINERID", container_id)
+        .env("CNI_NETNS", netns_path)
+        .env("CNI_IFNAME", CNI_IFNAME)
+        .env("CNI_PATH", CNI_BIN_DIR)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("failed to spawn CNI bridge plugin: {}", e);
+            return None;
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take()
+        && let Err(e) = stdin.write_all(net_config.as_bytes())
+    {
+        warn!("failed to write CNI config to plugin stdin: {}", e);
+        return None;
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            warn!("CNI bridge plugin {} did not complete: {}", command, e);
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        warn!(
+            "CNI {} failed for {}: {}",
+            command,
+            container_id,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    Some(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_conflist_is_valid_json_with_bridge() {
+        let conf: serde_json::Value = serde_json::from_str(&default_conflist()).unwrap();
+        assert_eq!(conf["name"], CNI_NETWORK_NAME);
+        let plugins = conf["plugins"].as_array().unwrap();
+        assert_eq!(plugins[0]["type"], "bridge");
+        assert_eq!(plugins[0]["bridge"], CNI_BRIDGE);
+    }
+
+    #[test]
+    fn cni_result_parses_ip() {
+        let raw = r#"{"ips":[{"address":"10.43.0.5/16"}]}"#;
+        let result: CniResult = serde_json::from_slice(raw.as_bytes()).unwrap();
+        assert_eq!(result.ips[0].address, "10.43.0.5/16");
+    }
+}

--- a/src/runtime/containerd/health_check.rs
+++ b/src/runtime/containerd/health_check.rs
@@ -1,0 +1,222 @@
+//! Health-check primitives for the containerd runtime.
+//!
+//! - [`instance_address`] resolves the CNI-assigned IP so the trait-default
+//!   `execute_health_check` can run TCP/HTTP probes.
+//! - [`execute_command_check`] runs a `command` probe inside the task via
+//!   `Tasks.Exec`, equivalent to `docker exec`.
+//!
+//! `instance_address` reads the IP that `host-local` IPAM recorded for the
+//! container at CNI ADD time. host-local writes one file per allocated address
+//! under its data dir, named by the IP and containing the container id, so we
+//! reverse-map the container id to its IP there. This avoids having to keep the
+//! CNI ADD result in memory across the daemon's lifetime.
+
+use crate::models::health_check::HealthCheckStatus;
+use containerd_client::services::v1::tasks_client::TasksClient;
+use containerd_client::services::v1::{
+    DeleteProcessRequest, ExecProcessRequest, GetRequest, WaitRequest,
+};
+use containerd_client::types::v1::Status as TaskStatus;
+use containerd_client::with_namespace;
+use std::net::IpAddr;
+use std::path::Path;
+use tonic::Request;
+
+/// host-local IPAM data directory for Ring's CNI network. The plugin stores one
+/// file per allocated IP here (named by the address); each file's contents are
+/// the owning container id.
+const HOST_LOCAL_DIR: &str = "/var/lib/cni/networks/ring";
+
+/// Resolve the container's CNI IP by scanning the host-local IPAM store for the
+/// file whose contents reference this container id.
+pub(crate) async fn instance_address(
+    _client: &containerd_client::Client,
+    _namespace: &str,
+    instance_id: &str,
+) -> Option<IpAddr> {
+    let dir = Path::new(HOST_LOCAL_DIR);
+    let mut entries = tokio::fs::read_dir(dir).await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Only consider files that parse as an IP address.
+        let Ok(ip) = name.parse::<IpAddr>() else {
+            continue;
+        };
+        if let Ok(contents) = tokio::fs::read_to_string(entry.path()).await {
+            // host-local writes the container id (sometimes followed by the
+            // interface name on a second line) into the file.
+            if contents.lines().any(|l| l.trim() == instance_id) {
+                return Some(ip);
+            }
+        }
+    }
+    None
+}
+
+/// Run a `command` probe inside the task via `Tasks.Exec`, reporting `Success`
+/// on exit code 0 and `Failed` otherwise. The exec process gets a unique id; we
+/// `Wait` on it for the exit status, then `DeleteProcess` to reap it.
+pub(crate) async fn execute_command_check(
+    client: &containerd_client::Client,
+    namespace: &str,
+    instance_id: &str,
+    command: &str,
+) -> (HealthCheckStatus, Option<String>) {
+    let args = match shell_words::split(command) {
+        Ok(a) if a.is_empty() => {
+            return (HealthCheckStatus::Failed, Some("Empty command".to_string()));
+        }
+        Ok(a) => a,
+        Err(e) => {
+            return (
+                HealthCheckStatus::Failed,
+                Some(format!("Invalid command syntax: {}", e)),
+            );
+        }
+    };
+
+    // Refuse to exec into a task that is not running — Exec would error opaquely.
+    if !task_running(client, namespace, instance_id).await {
+        return (
+            HealthCheckStatus::Failed,
+            Some("task is not running".to_string()),
+        );
+    }
+
+    let exec_id = format!("ring-hc-{}", super::tiny_id());
+    let spec = super::oci::build_exec_process_spec(args);
+
+    let mut tasks = TasksClient::new(client.channel());
+    let exec_req = with_namespace!(
+        ExecProcessRequest {
+            container_id: instance_id.to_string(),
+            stdin: String::new(),
+            stdout: String::new(),
+            stderr: String::new(),
+            terminal: false,
+            spec: Some(spec),
+            exec_id: exec_id.clone(),
+        },
+        namespace
+    );
+    if let Err(e) = tasks.exec(exec_req).await {
+        return (
+            HealthCheckStatus::Failed,
+            Some(format!("Failed to create exec: {}", e)),
+        );
+    }
+
+    // Start the exec process.
+    let start_req = with_namespace!(
+        containerd_client::services::v1::StartRequest {
+            container_id: instance_id.to_string(),
+            exec_id: exec_id.clone(),
+        },
+        namespace
+    );
+    if let Err(e) = tasks.start(start_req).await {
+        cleanup_exec(&mut tasks, namespace, instance_id, &exec_id).await;
+        return (
+            HealthCheckStatus::Failed,
+            Some(format!("Failed to start exec: {}", e)),
+        );
+    }
+
+    // Wait for completion and read the exit status. Bound the wait: a probe
+    // command that hangs (e.g. `sleep 9999`) would otherwise block this call
+    // forever, since Task.Wait has no built-in deadline. The trait dispatch
+    // doesn't thread the per-probe timeout down here, so we apply a defensive
+    // upper bound — a hung probe must fail, not wedge the health loop.
+    let wait_req = with_namespace!(
+        WaitRequest {
+            container_id: instance_id.to_string(),
+            exec_id: exec_id.clone(),
+        },
+        namespace
+    );
+    let outcome = match tokio::time::timeout(EXEC_WAIT_TIMEOUT, tasks.wait(wait_req)).await {
+        Ok(Ok(resp)) => match resp.into_inner().exit_status {
+            0 => (
+                HealthCheckStatus::Success,
+                Some("Command exited 0".to_string()),
+            ),
+            code => (
+                HealthCheckStatus::Failed,
+                Some(format!("Command exited {}", code)),
+            ),
+        },
+        Ok(Err(e)) => (
+            HealthCheckStatus::Failed,
+            Some(format!("Failed to wait for exec: {}", e)),
+        ),
+        Err(_) => {
+            // Timed out: SIGKILL the hung exec process so it doesn't linger.
+            let _ = tasks
+                .kill(with_namespace!(
+                    containerd_client::services::v1::KillRequest {
+                        container_id: instance_id.to_string(),
+                        exec_id: exec_id.clone(),
+                        signal: 9,
+                        all: false,
+                    },
+                    namespace
+                ))
+                .await;
+            (
+                HealthCheckStatus::Failed,
+                Some(format!(
+                    "Command probe timed out after {}s",
+                    EXEC_WAIT_TIMEOUT.as_secs()
+                )),
+            )
+        }
+    };
+
+    cleanup_exec(&mut tasks, namespace, instance_id, &exec_id).await;
+    outcome
+}
+
+/// Defensive upper bound for a `command` probe's exec. The configured per-probe
+/// timeout isn't threaded into the trait's `execute_command_probe`, so this
+/// guards against a probe that never returns.
+const EXEC_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+async fn cleanup_exec(
+    tasks: &mut TasksClient<tonic::transport::Channel>,
+    namespace: &str,
+    instance_id: &str,
+    exec_id: &str,
+) {
+    let req = with_namespace!(
+        DeleteProcessRequest {
+            container_id: instance_id.to_string(),
+            exec_id: exec_id.to_string(),
+        },
+        namespace
+    );
+    let _ = tasks.delete_process(req).await;
+}
+
+async fn task_running(
+    client: &containerd_client::Client,
+    namespace: &str,
+    instance_id: &str,
+) -> bool {
+    let mut tasks = TasksClient::new(client.channel());
+    let req = with_namespace!(
+        GetRequest {
+            container_id: instance_id.to_string(),
+            exec_id: String::new(),
+        },
+        namespace
+    );
+    match tasks.get(req).await {
+        Ok(resp) => resp
+            .into_inner()
+            .process
+            .map(|p| matches!(TaskStatus::try_from(p.status), Ok(TaskStatus::Running)))
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}

--- a/src/runtime/containerd/image.rs
+++ b/src/runtime/containerd/image.rs
@@ -1,0 +1,389 @@
+//! Image acquisition and rootfs resolution.
+//!
+//! Containerd has no single "pull and unpack" verb. We use the **Transfer**
+//! service to move an image from a registry (`OciRegistry` source) into the
+//! local image store and unpack it into the configured snapshotter
+//! (`ImageStore` destination with an `UnpackConfiguration`). Then, to give each
+//! task a writable rootfs, we need the *chain ID* of the image's read-only
+//! layers — the parent for `Snapshots.Prepare`. Containerd computes and labels
+//! that on the image during unpack, so we read it back from the image labels
+//! (falling back to recomputing it from the image config's `rootfs.diff_ids`).
+
+use super::client::DEFAULT_SNAPSHOTTER;
+use crate::hypervisor::error::RuntimeError;
+use crate::runtime::docker::{ImagePullPolicy, ImageReference, parse_image_reference};
+use containerd_client::services::v1::GetImageRequest;
+use containerd_client::services::v1::ReadContentRequest;
+use containerd_client::services::v1::TransferRequest;
+use containerd_client::services::v1::content_client::ContentClient;
+use containerd_client::services::v1::images_client::ImagesClient;
+use containerd_client::services::v1::transfer_client::TransferClient;
+use containerd_client::types::Platform;
+use containerd_client::types::transfer::{
+    ImageStore, OciRegistry, RegistryResolver, UnpackConfiguration,
+};
+use containerd_client::{to_any, with_namespace};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+/// Everything the runtime needs to address one image: the canonical reference
+/// (what containerd stores it under) and optional registry credentials.
+pub(crate) struct ContainerdImage {
+    pub(crate) reference: String,
+    pub(crate) repo: String,
+    pub(crate) parsed_ref: ImageReference,
+    /// `(server, username, password)` registry credentials, when configured.
+    pub(crate) auth: Option<(String, String, String)>,
+}
+
+impl ContainerdImage {
+    /// Build from the deployment's image string and optional config auth.
+    pub(crate) fn from_deployment(image: &str, auth: Option<(String, String, String)>) -> Self {
+        let (repo, parsed_ref) = parse_image_reference(image);
+        // The reference containerd stores the image under is the canonical
+        // `name:tag` / `name@digest` — same string the user wrote, normalized.
+        let reference = match &parsed_ref {
+            ImageReference::Tag(t) => format!("{}:{}", repo, t),
+            ImageReference::Digest(d) => format!("{}@{}", repo, d),
+        };
+        Self {
+            reference,
+            repo,
+            parsed_ref,
+            auth,
+        }
+    }
+}
+
+/// Subset of an OCI image manifest we need: the `config` descriptor pointer.
+#[derive(Deserialize)]
+struct OciManifest {
+    config: OciDescriptor,
+}
+
+#[derive(Deserialize)]
+struct OciDescriptor {
+    digest: String,
+}
+
+/// Subset of an OCI image config we need: the rootfs diff ids.
+#[derive(Deserialize)]
+struct OciImageConfig {
+    rootfs: OciRootfs,
+}
+
+#[derive(Deserialize)]
+struct OciRootfs {
+    diff_ids: Vec<String>,
+}
+
+/// Result of resolving an image to a runnable rootfs parent.
+pub(crate) struct ResolvedImage {
+    /// Manifest digest of the image (what we record as `image_digest`).
+    pub(crate) digest: Option<String>,
+    /// Snapshot chain id that serves as the read-only parent of each
+    /// per-instance writable snapshot.
+    pub(crate) chain_id: String,
+}
+
+/// Ensure the image is present (and unpacked) honouring `policy`, then resolve
+/// its rootfs chain id.
+pub(crate) async fn ensure_image(
+    client: &containerd_client::Client,
+    namespace: &str,
+    image: &ContainerdImage,
+    policy: ImagePullPolicy,
+) -> Result<ResolvedImage, RuntimeError> {
+    let present = image_present(client, namespace, &image.reference).await;
+
+    let must_pull = match policy {
+        ImagePullPolicy::Never => {
+            if !present {
+                return Err(RuntimeError::ImageNotFound(format!(
+                    "image '{}' not in containerd image store and image_pull_policy=Never forbids pulling",
+                    image.reference
+                )));
+            }
+            false
+        }
+        ImagePullPolicy::IfNotPresent => !present,
+        // A digest reference is immutable; re-pulling buys nothing.
+        ImagePullPolicy::Always => {
+            !matches!(image.parsed_ref, ImageReference::Digest(_)) || !present
+        }
+    };
+
+    if must_pull {
+        pull_image(client, namespace, image).await?;
+    } else {
+        debug!(
+            "containerd image {} served from local store (policy {:?})",
+            image.reference, policy
+        );
+    }
+
+    let descriptor = get_image_target(client, namespace, &image.reference).await?;
+    let chain_id = resolve_chain_id(client, namespace, &descriptor.digest).await?;
+
+    Ok(ResolvedImage {
+        digest: Some(descriptor.digest),
+        chain_id,
+    })
+}
+
+/// Whether an image with this reference exists in the image store.
+async fn image_present(
+    client: &containerd_client::Client,
+    namespace: &str,
+    reference: &str,
+) -> bool {
+    let mut images = ImagesClient::new(client.channel());
+    let req = with_namespace!(
+        GetImageRequest {
+            name: reference.to_string(),
+        },
+        namespace
+    );
+    match images.get(req).await {
+        Ok(resp) => resp.into_inner().image.is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Pull + unpack an image via the Transfer service. The source is an OCI
+/// registry; the destination is the image store with an unpack into the default
+/// snapshotter so the rootfs layers are materialized for `Snapshots.Prepare`.
+async fn pull_image(
+    client: &containerd_client::Client,
+    namespace: &str,
+    image: &ContainerdImage,
+) -> Result<(), RuntimeError> {
+    info!("containerd pulling image {}", image.reference);
+
+    // Registry credentials are passed as a static `Authorization: Basic <...>`
+    // header on the resolver. The Transfer service also supports an interactive
+    // `auth_stream` callback, but a direct Basic header is sufficient for the
+    // username/password Ring receives and avoids running a streaming auth
+    // handler. Token-auth registries (Docker Hub, GHCR) accept Basic creds on
+    // the token endpoint, so this covers the common private-registry case.
+    let mut headers = HashMap::new();
+    if let Some((_, username, password)) = &image.auth {
+        use base64::Engine as _;
+        let raw = format!("{}:{}", username, password);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
+        headers.insert("Authorization".to_string(), format!("Basic {}", encoded));
+    }
+
+    let resolver = RegistryResolver {
+        headers,
+        ..Default::default()
+    };
+    let source = OciRegistry {
+        reference: image.reference.clone(),
+        resolver: Some(resolver),
+    };
+
+    let platform = Platform {
+        os: "linux".to_string(),
+        architecture: std::env::consts::ARCH.to_string(),
+        ..Default::default()
+    };
+    let dest = ImageStore {
+        name: image.reference.clone(),
+        platforms: vec![platform.clone()],
+        unpacks: vec![UnpackConfiguration {
+            platform: Some(platform),
+            snapshotter: DEFAULT_SNAPSHOTTER.to_string(),
+        }],
+        ..Default::default()
+    };
+
+    let request = TransferRequest {
+        source: Some(to_any(&source)),
+        destination: Some(to_any(&dest)),
+        options: None,
+    };
+
+    let mut transfer = TransferClient::new(client.channel());
+    transfer
+        .transfer(with_namespace!(request, namespace))
+        .await
+        .map_err(|e| classify_pull_error(&e.message().to_string(), &image.reference))?;
+
+    info!("containerd successfully pulled image {}", image.reference);
+    Ok(())
+}
+
+/// Map a Transfer error string into a typed `RuntimeError`, mirroring the Docker
+/// runtime's `classify_pull_error` so deployments land in the right status.
+fn classify_pull_error(msg: &str, image: &str) -> RuntimeError {
+    let lower = msg.to_lowercase();
+    if lower.contains("not found") || lower.contains("manifest unknown") || lower.contains("404") {
+        return RuntimeError::ImageNotFound(format!("image '{}' not found: {}", image, msg));
+    }
+    if lower.contains("unauthorized")
+        || lower.contains("authentication")
+        || lower.contains("denied")
+        || lower.contains("forbidden")
+    {
+        return RuntimeError::ImagePullFailed(format!(
+            "registry authentication failed for '{}' — check config.server, config.username and \
+             config.password (original error: {})",
+            image, msg
+        ));
+    }
+    if lower.contains("connection refused")
+        || lower.contains("no such host")
+        || lower.contains("timeout")
+        || lower.contains("dial")
+    {
+        return RuntimeError::ImagePullFailed(format!(
+            "cannot reach the registry for '{}' (original error: {})",
+            image, msg
+        ));
+    }
+    RuntimeError::ImagePullFailed(msg.to_string())
+}
+
+/// Fetch the image's target (manifest) descriptor from the image store.
+async fn get_image_target(
+    client: &containerd_client::Client,
+    namespace: &str,
+    reference: &str,
+) -> Result<containerd_client::types::Descriptor, RuntimeError> {
+    let mut images = ImagesClient::new(client.channel());
+    let req = with_namespace!(
+        GetImageRequest {
+            name: reference.to_string(),
+        },
+        namespace
+    );
+    let resp = images
+        .get(req)
+        .await
+        .map_err(|e| RuntimeError::Other(format!("GetImage failed for {}: {}", reference, e)))?;
+    resp.into_inner()
+        .image
+        .and_then(|img| img.target)
+        .ok_or_else(|| {
+            RuntimeError::ImageNotFound(format!("image '{}' has no target descriptor", reference))
+        })
+}
+
+/// Compute the rootfs chain id of an image from its manifest + config.
+///
+/// containerd stores the image config (with `rootfs.diff_ids`) in the content
+/// store, keyed by the manifest's `config.digest`. The chain id is the iterated
+/// SHA-256 of the diff ids — the same value the snapshotter keys unpacked layers
+/// under, so it is the correct parent for a writable snapshot.
+async fn resolve_chain_id(
+    client: &containerd_client::Client,
+    namespace: &str,
+    manifest_digest: &str,
+) -> Result<String, RuntimeError> {
+    let manifest_bytes = read_content(client, namespace, manifest_digest).await?;
+    let manifest: OciManifest = serde_json::from_slice(&manifest_bytes).map_err(|e| {
+        RuntimeError::Other(format!(
+            "failed to parse image manifest {}: {}",
+            manifest_digest, e
+        ))
+    })?;
+
+    let config_bytes = read_content(client, namespace, &manifest.config.digest).await?;
+    let config: OciImageConfig = serde_json::from_slice(&config_bytes).map_err(|e| {
+        RuntimeError::Other(format!(
+            "failed to parse image config {}: {}",
+            manifest.config.digest, e
+        ))
+    })?;
+
+    if config.rootfs.diff_ids.is_empty() {
+        return Err(RuntimeError::Other(
+            "image config has no rootfs diff_ids".to_string(),
+        ));
+    }
+
+    Ok(compute_chain_id(&config.rootfs.diff_ids))
+}
+
+/// Iterated chain id over an ordered list of layer diff ids, per the OCI image
+/// spec: `chainID(L0) = L0`, `chainID(Ln) = sha256(chainID(Ln-1) + " " + Ln)`.
+pub(crate) fn compute_chain_id(diff_ids: &[String]) -> String {
+    let mut chain = diff_ids[0].clone();
+    for diff in &diff_ids[1..] {
+        let mut hasher = Sha256::new();
+        hasher.update(format!("{} {}", chain, diff).as_bytes());
+        chain = format!("sha256:{}", hex::encode(hasher.finalize()));
+    }
+    chain
+}
+
+/// Read a full blob from the content store by digest.
+async fn read_content(
+    client: &containerd_client::Client,
+    namespace: &str,
+    digest: &str,
+) -> Result<Vec<u8>, RuntimeError> {
+    let mut content = ContentClient::new(client.channel());
+    let req = with_namespace!(
+        ReadContentRequest {
+            digest: digest.to_string(),
+            offset: 0,
+            size: 0,
+        },
+        namespace
+    );
+    let resp = content
+        .read(req)
+        .await
+        .map_err(|e| RuntimeError::Other(format!("ReadContent failed for {}: {}", digest, e)))?;
+
+    let mut stream = resp.into_inner();
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|e| RuntimeError::Other(format!("ReadContent stream error: {}", e)))?;
+        buf.extend_from_slice(&chunk.data);
+    }
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_id_single_layer_is_diff_id() {
+        let ids = vec!["sha256:aaaa".to_string()];
+        assert_eq!(compute_chain_id(&ids), "sha256:aaaa");
+    }
+
+    #[test]
+    fn chain_id_multi_layer_iterates() {
+        // Known reference vector: chainID of two layers is
+        // sha256("<L0> <L1>"). We only assert determinism + the prefix here
+        // since the literal hash is verified against containerd at e2e time.
+        let ids = vec!["sha256:aaaa".to_string(), "sha256:bbbb".to_string()];
+        let chain = compute_chain_id(&ids);
+        assert!(chain.starts_with("sha256:"));
+        assert_ne!(chain, "sha256:aaaa");
+        // Stable across calls.
+        assert_eq!(chain, compute_chain_id(&ids));
+    }
+
+    #[test]
+    fn image_reference_tag_canonicalized() {
+        let img = ContainerdImage::from_deployment("nginx", None);
+        assert_eq!(img.reference, "nginx:latest");
+        assert_eq!(img.repo, "nginx");
+    }
+
+    #[test]
+    fn image_reference_digest_canonicalized() {
+        let img = ContainerdImage::from_deployment("nginx@sha256:abc", None);
+        assert_eq!(img.reference, "nginx@sha256:abc");
+    }
+}

--- a/src/runtime/containerd/image.rs
+++ b/src/runtime/containerd/image.rs
@@ -33,7 +33,6 @@ use tonic::Request;
 /// (what containerd stores it under) and optional registry credentials.
 pub(crate) struct ContainerdImage {
     pub(crate) reference: String,
-    pub(crate) repo: String,
     pub(crate) parsed_ref: ImageReference,
     /// `(server, username, password)` registry credentials, when configured.
     pub(crate) auth: Option<(String, String, String)>,
@@ -51,7 +50,6 @@ impl ContainerdImage {
         };
         Self {
             reference,
-            repo,
             parsed_ref,
             auth,
         }
@@ -211,7 +209,7 @@ async fn pull_image(
     transfer
         .transfer(with_namespace!(request, namespace))
         .await
-        .map_err(|e| classify_pull_error(&e.message().to_string(), &image.reference))?;
+        .map_err(|e| classify_pull_error(e.message(), &image.reference))?;
 
     info!("containerd successfully pulled image {}", image.reference);
     Ok(())
@@ -378,7 +376,6 @@ mod tests {
     fn image_reference_tag_canonicalized() {
         let img = ContainerdImage::from_deployment("nginx", None);
         assert_eq!(img.reference, "nginx:latest");
-        assert_eq!(img.repo, "nginx");
     }
 
     #[test]

--- a/src/runtime/containerd/instances.rs
+++ b/src/runtime/containerd/instances.rs
@@ -1,0 +1,124 @@
+//! Listing Ring-managed containerd instances.
+//!
+//! Containers are tagged with the [`RING_DEPLOYMENT_LABEL`] at create time, so
+//! we list by containerd's label filter and cross-check the task status. The
+//! "active" vs "all" semantics mirror the Docker runtime: an "active" instance
+//! is one whose task is actually `Running`, so a container whose task never
+//! started (or already exited) is not counted toward the replica target and the
+//! scheduler retries.
+
+use super::RING_DEPLOYMENT_LABEL;
+use crate::hypervisor::error::RuntimeError;
+use containerd_client::services::v1::ListContainersRequest;
+use containerd_client::services::v1::ListTasksRequest;
+use containerd_client::services::v1::containers_client::ContainersClient;
+use containerd_client::services::v1::tasks_client::TasksClient;
+use containerd_client::types::v1::Status as TaskStatus;
+use containerd_client::with_namespace;
+use std::collections::HashMap;
+use tonic::Request;
+
+/// Map a containerd task `Status` to whether the instance counts as "active".
+fn is_active(status: i32) -> bool {
+    matches!(
+        TaskStatus::try_from(status),
+        Ok(TaskStatus::Running) | Ok(TaskStatus::Paused) | Ok(TaskStatus::Pausing)
+    )
+}
+
+/// List container ids for a deployment, filtered by `status` ("all" or
+/// "active"). Returns the containerd container ids (which are also the Ring
+/// instance ids).
+pub(crate) async fn list_instances(
+    client: &containerd_client::Client,
+    namespace: &str,
+    deployment_id: &str,
+    status: &str,
+) -> Vec<String> {
+    match list_instances_inner(client, namespace, deployment_id, status).await {
+        Ok(ids) => ids.into_iter().map(|(id, _)| id).collect(),
+        Err(e) => {
+            debug!("containerd list instances error: {}", e);
+            Vec::new()
+        }
+    }
+}
+
+/// Like [`list_instances`] but returns `(id, name)` pairs. The container id is
+/// already the human-readable `<namespace>_<name>_<suffix>` we set at creation,
+/// so name == id here.
+pub(crate) async fn list_instances_with_names(
+    client: &containerd_client::Client,
+    namespace: &str,
+    deployment_id: &str,
+    status: &str,
+) -> Vec<(String, String)> {
+    match list_instances_inner(client, namespace, deployment_id, status).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            debug!("containerd list instances error: {}", e);
+            Vec::new()
+        }
+    }
+}
+
+async fn list_instances_inner(
+    client: &containerd_client::Client,
+    namespace: &str,
+    deployment_id: &str,
+    status: &str,
+) -> Result<Vec<(String, String)>, RuntimeError> {
+    let mut containers = ContainersClient::new(client.channel());
+    // containerd filter syntax: match the ring_deployment label exactly.
+    let filter = format!("labels.\"{}\"=={}", RING_DEPLOYMENT_LABEL, deployment_id);
+    let req = with_namespace!(
+        ListContainersRequest {
+            filters: vec![filter],
+        },
+        namespace
+    );
+    let resp = containers
+        .list(req)
+        .await
+        .map_err(|e| RuntimeError::Other(format!("ListContainers failed: {}", e)))?;
+    let container_ids: Vec<String> = resp
+        .into_inner()
+        .containers
+        .into_iter()
+        .map(|c| c.id)
+        .collect();
+
+    if status == "all" {
+        return Ok(container_ids
+            .into_iter()
+            .map(|id| (id.clone(), id))
+            .collect());
+    }
+
+    // "active": cross-check against running tasks.
+    let mut tasks = TasksClient::new(client.channel());
+    let task_req = with_namespace!(
+        ListTasksRequest {
+            filter: String::new(),
+        },
+        namespace
+    );
+    let task_status: HashMap<String, i32> = match tasks.list(task_req).await {
+        Ok(resp) => resp
+            .into_inner()
+            .tasks
+            .into_iter()
+            .map(|t| (t.container_id, t.status))
+            .collect(),
+        Err(e) => {
+            debug!("containerd ListTasks failed: {}", e);
+            HashMap::new()
+        }
+    };
+
+    Ok(container_ids
+        .into_iter()
+        .filter(|id| task_status.get(id).copied().is_some_and(is_active))
+        .map(|id| (id.clone(), id))
+        .collect())
+}

--- a/src/runtime/containerd/lifecycle.rs
+++ b/src/runtime/containerd/lifecycle.rs
@@ -1,0 +1,857 @@
+//! The `RuntimeLifecycle` implementation for containerd.
+//!
+//! `apply` reproduces the Docker runtime's reconciliation loop (job vs worker,
+//! scale up/down one instance per tick, terminal states) on top of containerd's
+//! lower-level primitives. Creating one instance is a five-step dance:
+//!
+//! 1. **image** — ensure the image is pulled + unpacked, resolve its rootfs
+//!    chain id ([`super::image`]).
+//! 2. **snapshot** — `Prepare` a writable rootfs snapshot from that chain id and
+//!    capture the mounts.
+//! 3. **container** — register the container object with the OCI spec
+//!    ([`super::oci`]) and the snapshot key.
+//! 4. **task** — `Create` the task with the snapshot mounts and log files, wire
+//!    up CNI on its netns ([`super::cni`]), then `Start` it.
+//! 5. **track** — record the instance id on the deployment.
+//!
+//! Teardown reverses it: kill + delete task, delete container, remove snapshot,
+//! CNI `DEL`.
+
+use super::client::{DEFAULT_RUNTIME, DEFAULT_SNAPSHOTTER};
+use super::image::{ContainerdImage, ensure_image};
+use super::{ContainerdLifecycle, RING_DEPLOYMENT_LABEL, cni, instances, oci, tiny_id};
+use crate::api::dto::stats::InstanceStatsOutput;
+use crate::hypervisor::error::RuntimeError;
+use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, extract_date};
+use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
+use crate::models::health_check::HealthCheckStatus;
+use crate::models::volume::ResolvedMount;
+use crate::runtime::docker::ImagePullPolicy;
+use async_trait::async_trait;
+use axum::response::sse::Event;
+use containerd_client::services::v1::container::Runtime;
+use containerd_client::services::v1::containers_client::ContainersClient;
+use containerd_client::services::v1::snapshots::snapshots_client::SnapshotsClient;
+use containerd_client::services::v1::snapshots::{PrepareSnapshotRequest, RemoveSnapshotRequest};
+use containerd_client::services::v1::tasks_client::TasksClient;
+use containerd_client::services::v1::{
+    Container, CreateContainerRequest, CreateTaskRequest, DeleteContainerRequest,
+    DeleteTaskRequest, GetRequest, KillRequest, StartRequest, WaitRequest,
+};
+use containerd_client::types::Mount;
+use containerd_client::types::v1::Status as TaskStatus;
+use containerd_client::with_namespace;
+use futures::stream::{self, Stream};
+use std::cmp::Ordering;
+use std::convert::Infallible;
+use std::pin::Pin;
+use tonic::Request;
+
+/// SIGTERM / SIGKILL signal numbers (Linux). Used for graceful then forced kill.
+const SIGTERM: u32 = 15;
+const SIGKILL: u32 = 9;
+
+/// How long an instance gets to exit after SIGTERM before we SIGKILL it. Matches
+/// Docker's default 10s stop grace period.
+const STOP_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Host directory where Ring keeps per-instance log files written by the task's
+/// stdio. Mirrors how the shim's fifo/file stdio is consumed.
+fn log_path(instance_id: &str) -> String {
+    format!("/var/log/ring/containerd/{}.log", instance_id)
+}
+
+/// Host directory for content/config/secret mount temp files.
+fn config_dir(deployment_id: &str) -> String {
+    format!("/var/lib/ring/configs/{}", deployment_id)
+}
+
+#[async_trait]
+impl RuntimeLifecycle for ContainerdLifecycle {
+    async fn apply(
+        &self,
+        mut deployment: Deployment,
+        resolved_mounts: Vec<ResolvedMount>,
+    ) -> Deployment {
+        let client = match self.connect().await {
+            Ok(c) => c,
+            Err(e) => {
+                error!("[{}] containerd connect failed: {}", deployment.id, e);
+                deployment.status = DeploymentStatus::Error;
+                deployment.emit_event(
+                    "error",
+                    format!("containerd unreachable: {}", e),
+                    "containerd",
+                    Some("runtime_error"),
+                );
+                return deployment;
+            }
+        };
+
+        let status_filter = if deployment.status == DeploymentStatus::Deleted {
+            "all"
+        } else {
+            "active"
+        };
+        deployment.instances = instances::list_instances(
+            &client,
+            &self.config.namespace,
+            &deployment.id,
+            status_filter,
+        )
+        .await;
+
+        if deployment.kind == "job" {
+            self.handle_job(deployment, &client, &resolved_mounts).await
+        } else {
+            self.handle_worker(deployment, &client, &resolved_mounts)
+                .await
+        }
+    }
+
+    async fn list_instances(&self, deployment_id: String, status: &str) -> Vec<String> {
+        let Ok(client) = self.connect().await else {
+            return Vec::new();
+        };
+        instances::list_instances(&client, &self.config.namespace, &deployment_id, status).await
+    }
+
+    async fn list_instances_with_names(
+        &self,
+        deployment_id: String,
+        status: &str,
+    ) -> Vec<(String, String)> {
+        let Ok(client) = self.connect().await else {
+            return Vec::new();
+        };
+        instances::list_instances_with_names(
+            &client,
+            &self.config.namespace,
+            &deployment_id,
+            status,
+        )
+        .await
+    }
+
+    async fn remove_instance(&self, instance_id: String) -> bool {
+        let Ok(client) = self.connect().await else {
+            return false;
+        };
+        self.teardown_instance(&client, &instance_id).await
+    }
+
+    async fn get_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> Vec<Log> {
+        let instances = self
+            .list_instances_with_names(deployment_id.to_string(), "all")
+            .await;
+        let mut logs = Vec::new();
+        for (instance_id, instance_name) in instances {
+            if let Some(f) = instance_filter
+                && !instance_id.contains(f)
+                && !instance_name.contains(f)
+            {
+                continue;
+            }
+            for message in super::logs::read_logs(&instance_id, tail, since).await {
+                logs.push(Log {
+                    instance: instance_name.clone(),
+                    level: classify_log(&message),
+                    timestamp: extract_date(&message),
+                    message,
+                });
+            }
+        }
+        logs
+    }
+
+    async fn stream_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> {
+        let instances = self
+            .list_instances_with_names(deployment_id.to_string(), "all")
+            .await;
+        let mut streams: Vec<Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>>> =
+            Vec::new();
+        for (instance_id, instance_name) in instances {
+            if let Some(f) = instance_filter
+                && !instance_id.contains(f)
+                && !instance_name.contains(f)
+            {
+                continue;
+            }
+            let raw = super::logs::stream_logs(instance_id, tail, since).await;
+            let mapped = futures::StreamExt::map(raw, move |line| {
+                let log = Log {
+                    instance: instance_name.clone(),
+                    level: classify_log(&line),
+                    timestamp: extract_date(&line),
+                    message: line,
+                };
+                let json = serde_json::to_string(&log).unwrap_or_default();
+                Ok(Event::default().data(json))
+            });
+            streams.push(Box::pin(mapped));
+        }
+        if streams.is_empty() {
+            return Box::pin(stream::empty());
+        }
+        Box::pin(stream::select_all(streams))
+    }
+
+    async fn instance_address(&self, instance_id: &str) -> Option<std::net::IpAddr> {
+        let client = self.connect().await.ok()?;
+        super::health_check::instance_address(&client, &self.config.namespace, instance_id).await
+    }
+
+    async fn execute_command_probe(
+        &self,
+        instance_id: &str,
+        command: &str,
+    ) -> (HealthCheckStatus, Option<String>) {
+        let client = match self.connect().await {
+            Ok(c) => c,
+            Err(e) => return (HealthCheckStatus::Failed, Some(e.to_string())),
+        };
+        super::health_check::execute_command_check(
+            &client,
+            &self.config.namespace,
+            instance_id,
+            command,
+        )
+        .await
+    }
+
+    async fn get_instance_stats(&self, deployment_id: &str) -> Vec<InstanceStatsOutput> {
+        let Ok(client) = self.connect().await else {
+            return Vec::new();
+        };
+        let instances = self
+            .list_instances_with_names(deployment_id.to_string(), "all")
+            .await;
+        let mut results = Vec::new();
+        for (id, name) in instances {
+            if let Some(stats) =
+                super::stats::fetch_instance_stats(&client, &self.config.namespace, &id, &name)
+                    .await
+            {
+                results.push(stats);
+            }
+        }
+        results
+    }
+}
+
+impl ContainerdLifecycle {
+    async fn handle_job(
+        &self,
+        mut deployment: Deployment,
+        client: &containerd_client::Client,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Deployment {
+        if deployment.status == DeploymentStatus::Deleted {
+            self.remove_all(&mut deployment, client, "job").await;
+            return deployment;
+        }
+        if matches!(
+            deployment.status,
+            DeploymentStatus::Completed | DeploymentStatus::Failed
+        ) {
+            return deployment;
+        }
+        if deployment.restart_count >= MAX_RESTART_COUNT {
+            deployment.status = DeploymentStatus::Failed;
+            return deployment;
+        }
+
+        let all =
+            instances::list_instances(client, &self.config.namespace, &deployment.id, "all").await;
+        if let Some(instance_id) = all.first() {
+            match self.task_status(client, instance_id).await {
+                Some(TaskStatus::Running) | Some(TaskStatus::Paused) => {
+                    deployment.status = DeploymentStatus::Running;
+                }
+                Some(TaskStatus::Stopped) => {
+                    // A stopped task: inspect exit code to tell completed vs
+                    // failed. The Get response carries exit_status.
+                    deployment.status = match self.task_exit_status(client, instance_id).await {
+                        Some(0) => DeploymentStatus::Completed,
+                        _ => DeploymentStatus::Failed,
+                    };
+                }
+                _ => {
+                    deployment.status = DeploymentStatus::Failed;
+                }
+            }
+        } else {
+            match self
+                .create_instance(&mut deployment, client, resolved_mounts)
+                .await
+            {
+                Ok(_) => deployment.status = DeploymentStatus::Running,
+                Err(err) => handle_create_error(&mut deployment, err, true),
+            }
+        }
+        deployment
+    }
+
+    async fn handle_worker(
+        &self,
+        mut deployment: Deployment,
+        client: &containerd_client::Client,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Deployment {
+        if deployment.status == DeploymentStatus::Deleted {
+            self.remove_all(&mut deployment, client, "worker").await;
+            return deployment;
+        }
+        if deployment.restart_count >= MAX_RESTART_COUNT {
+            deployment.status = DeploymentStatus::CrashLoopBackOff;
+            return deployment;
+        }
+        if deployment.status == DeploymentStatus::CrashLoopBackOff {
+            return deployment;
+        }
+
+        let current = deployment.instances.len();
+        let target = match usize::try_from(deployment.replicas) {
+            Ok(t) => t,
+            Err(_) => {
+                deployment.status = DeploymentStatus::Failed;
+                return deployment;
+            }
+        };
+
+        match current.cmp(&target) {
+            Ordering::Less => {
+                match self
+                    .create_instance(&mut deployment, client, resolved_mounts)
+                    .await
+                {
+                    Ok(_) => {
+                        deployment.emit_event(
+                            "info",
+                            format!("Scaled up from {} to {} replicas", current, current + 1),
+                            "containerd",
+                            Some("scale_up"),
+                        );
+                        if matches!(
+                            deployment.status,
+                            DeploymentStatus::Pending | DeploymentStatus::Creating
+                        ) {
+                            deployment.status = DeploymentStatus::Running;
+                        }
+                    }
+                    Err(err) => handle_create_error(&mut deployment, err, true),
+                }
+            }
+            Ordering::Greater => {
+                if let Some(instance_id) = deployment.instances.first().cloned() {
+                    self.teardown_instance(client, &instance_id).await;
+                    deployment.instances.remove(0);
+                    deployment.emit_event(
+                        "info",
+                        format!(
+                            "Scaled down from {} to {} replicas (removed {})",
+                            current,
+                            current - 1,
+                            instance_id
+                        ),
+                        "containerd",
+                        Some("scale_down"),
+                    );
+                }
+            }
+            Ordering::Equal => {
+                debug!("containerd replicas match target: {}", current);
+            }
+        }
+        deployment
+    }
+
+    async fn remove_all(
+        &self,
+        deployment: &mut Deployment,
+        client: &containerd_client::Client,
+        kind: &str,
+    ) {
+        let count = deployment.instances.len();
+        for instance in deployment.instances.clone() {
+            self.teardown_instance(client, &instance).await;
+            info!("containerd instance {} deleted", instance);
+        }
+        if count > 0 {
+            deployment.emit_event(
+                "info",
+                format!(
+                    "Deleted {} instance(s) for {} marked as deleted",
+                    count, kind
+                ),
+                "containerd",
+                Some("container_deletion"),
+            );
+        }
+        // Clean up config temp files.
+        let dir = config_dir(&deployment.id);
+        if std::path::Path::new(&dir).exists()
+            && let Err(e) = std::fs::remove_dir_all(&dir)
+        {
+            warn!("failed to clean config temp files at {}: {}", dir, e);
+        }
+    }
+
+    /// Create + start a single instance. On any failure mid-flight, the partial
+    /// objects (snapshot, container) are cleaned up so the next reconcile tick
+    /// starts clean and `restart_count` drives convergence to a terminal state.
+    async fn create_instance(
+        &self,
+        deployment: &mut Deployment,
+        client: &containerd_client::Client,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Result<(), RuntimeError> {
+        crate::hypervisor::resources::check_host_memory(deployment)?;
+
+        let ns = &self.config.namespace;
+
+        // 1. Image + rootfs chain id.
+        let auth =
+            deployment
+                .config
+                .as_ref()
+                .and_then(|c| match (&c.server, &c.username, &c.password) {
+                    (Some(s), Some(u), Some(p)) => Some((s.clone(), u.clone(), p.clone())),
+                    _ => None,
+                });
+        let image = ContainerdImage::from_deployment(&deployment.image, auth);
+        let policy = deployment
+            .config
+            .as_ref()
+            .map(|c| ImagePullPolicy::parse(&c.image_pull_policy))
+            .unwrap_or(ImagePullPolicy::Always);
+        let resolved = ensure_image(client, ns, &image, policy).await?;
+        deployment.image_digest = resolved.digest;
+
+        // Instance id: human-readable, unique, also the container + snapshot key.
+        let instance_id = format!("{}_{}_{}", deployment.namespace, deployment.name, tiny_id());
+
+        // 2. Writable snapshot from the chain id.
+        let mounts = self
+            .prepare_snapshot(client, &instance_id, &resolved.chain_id)
+            .await?;
+
+        // 3. Materialize content mounts to disk, then build the OCI spec.
+        let config_files = match write_config_files(deployment, resolved_mounts).await {
+            Ok(f) => f,
+            Err(e) => {
+                self.remove_snapshot(client, &instance_id).await;
+                return Err(e);
+            }
+        };
+        let spec = oci::build_spec(deployment, resolved_mounts, &config_files);
+
+        // 4. Register the container object, tagged with the owning deployment.
+        if let Err(e) = self
+            .create_container_object(
+                client,
+                &instance_id,
+                &deployment.id,
+                &deployment.labels,
+                &image.reference,
+                spec,
+            )
+            .await
+        {
+            self.remove_snapshot(client, &instance_id).await;
+            return Err(e);
+        }
+
+        // 5. Create + start the task, wiring CNI in between.
+        if let Err(e) = self
+            .create_and_start_task(client, &instance_id, mounts)
+            .await
+        {
+            self.delete_container_object(client, &instance_id).await;
+            self.remove_snapshot(client, &instance_id).await;
+            return Err(e);
+        }
+
+        deployment.instances.push(instance_id.clone());
+        info!("containerd instance {} created and started", instance_id);
+        Ok(())
+    }
+
+    async fn prepare_snapshot(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+        chain_id: &str,
+    ) -> Result<Vec<Mount>, RuntimeError> {
+        let mut snapshots = SnapshotsClient::new(client.channel());
+        let req = with_namespace!(
+            PrepareSnapshotRequest {
+                snapshotter: DEFAULT_SNAPSHOTTER.to_string(),
+                key: instance_id.to_string(),
+                parent: chain_id.to_string(),
+                labels: Default::default(),
+            },
+            self.config.namespace
+        );
+        let resp = snapshots.prepare(req).await.map_err(|e| {
+            RuntimeError::InstanceCreationFailed(format!(
+                "PrepareSnapshot failed for {}: {}",
+                instance_id, e
+            ))
+        })?;
+        Ok(resp.into_inner().mounts)
+    }
+
+    async fn remove_snapshot(&self, client: &containerd_client::Client, instance_id: &str) {
+        let mut snapshots = SnapshotsClient::new(client.channel());
+        let req = with_namespace!(
+            RemoveSnapshotRequest {
+                snapshotter: DEFAULT_SNAPSHOTTER.to_string(),
+                key: instance_id.to_string(),
+            },
+            self.config.namespace
+        );
+        if let Err(e) = snapshots.remove(req).await {
+            debug!("RemoveSnapshot failed for {}: {}", instance_id, e);
+        }
+    }
+
+    async fn create_container_object(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+        deployment_id: &str,
+        user_labels: &std::collections::HashMap<String, String>,
+        image_ref: &str,
+        spec: prost_types::Any,
+    ) -> Result<(), RuntimeError> {
+        // Carry the owning deployment id (for list/remove filtering) plus any
+        // user-supplied labels, matching the Docker runtime's label set.
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(RING_DEPLOYMENT_LABEL.to_string(), deployment_id.to_string());
+        for (k, v) in user_labels {
+            labels.insert(k.clone(), v.clone());
+        }
+
+        let container = Container {
+            id: instance_id.to_string(),
+            labels,
+            image: image_ref.to_string(),
+            runtime: Some(Runtime {
+                name: DEFAULT_RUNTIME.to_string(),
+                options: None,
+            }),
+            spec: Some(spec),
+            snapshotter: DEFAULT_SNAPSHOTTER.to_string(),
+            snapshot_key: instance_id.to_string(),
+            ..Default::default()
+        };
+        let mut containers = ContainersClient::new(client.channel());
+        let req = with_namespace!(
+            CreateContainerRequest {
+                container: Some(container),
+            },
+            self.config.namespace
+        );
+        containers.create(req).await.map_err(|e| {
+            RuntimeError::InstanceCreationFailed(format!(
+                "CreateContainer failed for {}: {}",
+                instance_id, e
+            ))
+        })?;
+        Ok(())
+    }
+
+    async fn delete_container_object(&self, client: &containerd_client::Client, instance_id: &str) {
+        let mut containers = ContainersClient::new(client.channel());
+        let req = with_namespace!(
+            DeleteContainerRequest {
+                id: instance_id.to_string(),
+            },
+            self.config.namespace
+        );
+        if let Err(e) = containers.delete(req).await {
+            debug!("DeleteContainer failed for {}: {}", instance_id, e);
+        }
+    }
+
+    async fn create_and_start_task(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+        mounts: Vec<Mount>,
+    ) -> Result<(), RuntimeError> {
+        // Ensure the log file's parent dir exists so the shim can write stdio.
+        let log_file = log_path(instance_id);
+        if let Some(parent) = std::path::Path::new(&log_file).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let mut tasks = TasksClient::new(client.channel());
+        let create = CreateTaskRequest {
+            container_id: instance_id.to_string(),
+            rootfs: mounts,
+            // Direct the shim's stdout/stderr to a host file. containerd accepts
+            // a `file://` or `binary://` URI here; a plain path is treated as a
+            // fifo/file the shim opens for writing.
+            stdout: format!("file://{}", log_file),
+            stderr: format!("file://{}", log_file),
+            ..Default::default()
+        };
+        let create_resp = tasks
+            .create(with_namespace!(create, self.config.namespace))
+            .await
+            .map_err(|e| {
+                RuntimeError::InstanceCreationFailed(format!(
+                    "CreateTask failed for {}: {}",
+                    instance_id, e
+                ))
+            })?;
+        let pid = create_resp.into_inner().pid;
+
+        // Wire up CNI on the task's netns *before* starting, while the process
+        // is created-but-not-running. The runc shim sets up the netns at create
+        // time, exposed at /proc/<pid>/ns/net.
+        cni::ensure_default_config();
+        let netns = format!("/proc/{}/ns/net", pid);
+        if cni::add(instance_id, &netns).await.is_none() {
+            debug!("no CNI address assigned for {}", instance_id);
+        }
+
+        let start = StartRequest {
+            container_id: instance_id.to_string(),
+            exec_id: String::new(),
+        };
+        if let Err(e) = tasks
+            .start(with_namespace!(start, self.config.namespace))
+            .await
+        {
+            // The task was created (a shim + netns exist) and CNI may have
+            // reserved an IP. Unwind both before surfacing the error, otherwise
+            // we leak a created-but-stopped task and a permanent IPAM lease.
+            cni::del(instance_id, &netns).await;
+            let _ = tasks
+                .delete(with_namespace!(
+                    DeleteTaskRequest {
+                        container_id: instance_id.to_string(),
+                    },
+                    self.config.namespace
+                ))
+                .await;
+            return Err(RuntimeError::InstanceCreationFailed(format!(
+                "StartTask failed for {}: {}",
+                instance_id, e
+            )));
+        }
+        Ok(())
+    }
+
+    /// Full teardown of one instance: kill (TERM then KILL), delete task, CNI
+    /// DEL, delete container, remove snapshot. Best-effort throughout.
+    async fn teardown_instance(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+    ) -> bool {
+        let mut tasks = TasksClient::new(client.channel());
+
+        // Capture the pid for CNI teardown before we kill the task.
+        let netns = self
+            .task_pid(client, instance_id)
+            .await
+            .map(|pid| format!("/proc/{}/ns/net", pid));
+
+        // Graceful then forced: send SIGTERM, give the workload a grace period to
+        // exit on its own (interrupted early if it does), then SIGKILL whatever
+        // is left. Sending both signals back-to-back would make graceful
+        // shutdown impossible — the process never sees SIGTERM before SIGKILL.
+        let _ = tasks
+            .kill(with_namespace!(
+                KillRequest {
+                    container_id: instance_id.to_string(),
+                    exec_id: String::new(),
+                    signal: SIGTERM,
+                    all: true,
+                },
+                self.config.namespace
+            ))
+            .await;
+
+        // Wait up to the grace period for the task to exit; Task.Wait returns as
+        // soon as it does, so a clean shutdown isn't penalised the full delay.
+        let wait = tasks.wait(with_namespace!(
+            WaitRequest {
+                container_id: instance_id.to_string(),
+                exec_id: String::new(),
+            },
+            self.config.namespace
+        ));
+        let _ = tokio::time::timeout(STOP_GRACE_PERIOD, wait).await;
+
+        let _ = tasks
+            .kill(with_namespace!(
+                KillRequest {
+                    container_id: instance_id.to_string(),
+                    exec_id: String::new(),
+                    signal: SIGKILL,
+                    all: true,
+                },
+                self.config.namespace
+            ))
+            .await;
+
+        // Tear down CNI. When the task was already stopped we have no live pid
+        // (so no /proc/<pid>/ns/net), but host-local IPAM keys its lease off the
+        // container id alone, so DEL with an empty netns still frees the address.
+        match &netns {
+            Some(netns) => cni::del(instance_id, netns).await,
+            None => cni::del(instance_id, "").await,
+        }
+
+        let _ = tasks
+            .delete(with_namespace!(
+                DeleteTaskRequest {
+                    container_id: instance_id.to_string(),
+                },
+                self.config.namespace
+            ))
+            .await;
+
+        self.delete_container_object(client, instance_id).await;
+        self.remove_snapshot(client, instance_id).await;
+
+        // Clean up the instance log file.
+        let _ = std::fs::remove_file(log_path(instance_id));
+        true
+    }
+
+    async fn task_status(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+    ) -> Option<TaskStatus> {
+        let mut tasks = TasksClient::new(client.channel());
+        let req = with_namespace!(
+            GetRequest {
+                container_id: instance_id.to_string(),
+                exec_id: String::new(),
+            },
+            self.config.namespace
+        );
+        let resp = tasks.get(req).await.ok()?;
+        let process = resp.into_inner().process?;
+        TaskStatus::try_from(process.status).ok()
+    }
+
+    async fn task_exit_status(
+        &self,
+        client: &containerd_client::Client,
+        instance_id: &str,
+    ) -> Option<u32> {
+        let mut tasks = TasksClient::new(client.channel());
+        let req = with_namespace!(
+            GetRequest {
+                container_id: instance_id.to_string(),
+                exec_id: String::new(),
+            },
+            self.config.namespace
+        );
+        let resp = tasks.get(req).await.ok()?;
+        resp.into_inner().process.map(|p| p.exit_status)
+    }
+
+    async fn task_pid(&self, client: &containerd_client::Client, instance_id: &str) -> Option<u32> {
+        let mut tasks = TasksClient::new(client.channel());
+        let req = with_namespace!(
+            GetRequest {
+                container_id: instance_id.to_string(),
+                exec_id: String::new(),
+            },
+            self.config.namespace
+        );
+        let resp = tasks.get(req).await.ok()?;
+        resp.into_inner().process.map(|p| p.pid)
+    }
+}
+
+/// Materialize `Content` mounts (config/secret) to host files and return
+/// `(host_path, destination)` pairs for the OCI spec.
+async fn write_config_files(
+    deployment: &Deployment,
+    resolved_mounts: &[ResolvedMount],
+) -> Result<Vec<(String, String)>, RuntimeError> {
+    use sha2::{Digest, Sha256};
+    let mut out = Vec::new();
+    let dir = config_dir(&deployment.id);
+    for m in resolved_mounts {
+        if let ResolvedMount::Content {
+            content,
+            destination,
+        } = m
+        {
+            tokio::fs::create_dir_all(&dir).await?;
+            // Derive the filename from a *stable* content hash. DefaultHasher is
+            // seeded randomly per process, so it would produce a new filename on
+            // every daemon restart — the try_exists guard would never hit and
+            // stale files would accumulate. Sha256 keys the same content to the
+            // same file across restarts.
+            let digest = Sha256::digest(content.as_bytes());
+            let file = format!("{}/{:x}", dir, digest);
+            if !tokio::fs::try_exists(&file).await.unwrap_or(false) {
+                tokio::fs::write(&file, content).await?;
+            }
+            out.push((file, destination.clone()));
+        }
+    }
+    Ok(out)
+}
+
+/// Translate a runtime error into the deployment's status + event, mirroring the
+/// Docker runtime's `handle_create_error`.
+fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment_restart: bool) {
+    if increment_restart {
+        deployment.restart_count += 1;
+    }
+    let (status, reason, message) = match &err {
+        RuntimeError::ImageNotFound(detail) => (
+            DeploymentStatus::ImagePullBackOff,
+            "image_pull_back_off",
+            format!("Image '{}' not found: {}", deployment.image, detail),
+        ),
+        RuntimeError::ImagePullFailed(detail) => (
+            DeploymentStatus::ImagePullBackOff,
+            "image_pull_back_off",
+            format!("Failed to pull image '{}': {}", deployment.image, detail),
+        ),
+        RuntimeError::InstanceCreationFailed(msg) => (
+            DeploymentStatus::CreateContainerError,
+            "instance_creation_failed",
+            format!("Instance creation failed: {}", msg),
+        ),
+        RuntimeError::InsufficientResources(detail) => (
+            DeploymentStatus::InsufficientResources,
+            "insufficient_resources",
+            detail.clone(),
+        ),
+        other => (
+            DeploymentStatus::Error,
+            "runtime_error",
+            format!("containerd error: {}", other),
+        ),
+    };
+    error!("[{}] {}: {}", deployment.id, reason, err);
+    deployment.status = status;
+    deployment.emit_event("error", message, "containerd", Some(reason));
+}

--- a/src/runtime/containerd/logs.rs
+++ b/src/runtime/containerd/logs.rs
@@ -1,0 +1,91 @@
+//! Reading task logs.
+//!
+//! Unlike Docker, containerd does not buffer container logs behind an API call —
+//! the task's stdio is whatever sink we configured at `CreateTask` time. The
+//! lifecycle points stdout/stderr at a per-instance host file
+//! (`/var/log/ring/containerd/<id>.log`); here we read and tail that file.
+
+use futures::stream::{self, Stream};
+use std::pin::Pin;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+fn log_file(instance_id: &str) -> String {
+    format!("/var/log/ring/containerd/{}.log", instance_id)
+}
+
+/// Read the instance log file into lines, honouring an optional `tail` count.
+/// `since` is accepted for trait parity but not applied — the file lines carry
+/// no reliable timestamp containerd guarantees, so time-based filtering is left
+/// to the log content's own timestamps (see `extract_date`).
+pub(crate) async fn read_logs(
+    instance_id: &str,
+    tail: Option<&str>,
+    _since: Option<i32>,
+) -> Vec<String> {
+    let path = log_file(instance_id);
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("could not read log file {}: {}", path, e);
+            return Vec::new();
+        }
+    };
+    let mut lines: Vec<String> = content
+        .lines()
+        .map(|l| l.trim_end().to_string())
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    if let Some(tail) = tail
+        && let Ok(n) = tail.parse::<usize>()
+        && lines.len() > n
+    {
+        lines = lines.split_off(lines.len() - n);
+    }
+    lines
+}
+
+/// Stream the instance log file, following appends. Emits the existing content
+/// (subject to `tail`) then polls for new lines.
+pub(crate) async fn stream_logs(
+    instance_id: String,
+    tail: Option<&str>,
+    since: Option<i32>,
+) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+    let path = log_file(&instance_id);
+    // Seed with the current tail.
+    let initial = read_logs(&instance_id, tail, since).await;
+
+    let file = match tokio::fs::File::open(&path).await {
+        Ok(f) => f,
+        Err(_) => return Box::pin(stream::iter(initial)),
+    };
+
+    // Resume following at EOF so we only emit new appends after the initial
+    // snapshot. `unfold` drives the reader without pulling in an extra
+    // async-stream dependency.
+    use tokio::io::AsyncSeekExt;
+    let mut reader = BufReader::new(file);
+    let _ = reader.seek(std::io::SeekFrom::End(0)).await;
+
+    let follow = stream::unfold(reader, |mut reader| async move {
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line).await {
+                Ok(0) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                Ok(_) => {
+                    let trimmed = line.trim_end().to_string();
+                    if !trimmed.trim().is_empty() {
+                        return Some((trimmed, reader));
+                    }
+                }
+                Err(_) => return None,
+            }
+        }
+    });
+
+    use futures::StreamExt;
+    Box::pin(stream::iter(initial).chain(follow))
+}

--- a/src/runtime/containerd/mod.rs
+++ b/src/runtime/containerd/mod.rs
@@ -1,0 +1,57 @@
+//! Containerd runtime: drive deployment instances on a host's `containerd`
+//! daemon **through its native gRPC API**, with no `ctr`/`nerdctl` shell-out and
+//! no Docker daemon in between.
+//!
+//! # Why native gRPC
+//!
+//! Ring already drives Docker (and Docker-compatible Podman) over the Docker
+//! HTTP API via `bollard`. Containerd sits one layer below that: it is the
+//! container supervisor Docker itself delegates to. Talking to it directly buys
+//! us a smaller trusted surface (no `dockerd`), the same daemon Kubernetes
+//! (k3s/RKE2) already runs, and an API that is stable and versioned. The cost is
+//! that containerd is *low level* — it has no opinion about pull policy,
+//! networking, or a "run this image" convenience verb. Each of those is a
+//! distinct gRPC service we orchestrate by hand:
+//!
+//! - **Transfer** — pull an image from a registry into the content store and
+//!   unpack it into a snapshot (`transfer.rs`/`image.rs`).
+//! - **Images / Content** — resolve the pulled image's config to compute the
+//!   rootfs *chain ID*, which is the parent for a writable snapshot.
+//! - **Snapshots** — `Prepare` a per-instance writable rootfs from that chain
+//!   ID and return the mounts the task needs.
+//! - **Containers** — register the container metadata object, carrying the OCI
+//!   runtime spec (`oci.rs`) as a protobuf `Any`.
+//! - **Tasks** — create + start the actual process from the container, kill and
+//!   delete it on teardown, exec health probes, and read cgroup metrics.
+//! - **CNI** — containerd does *not* do networking; we drive the standard CNI
+//!   plugins ourselves (`cni.rs`).
+//!
+//! The shape of a deployment (N replicas, env, command, labels, registry auth,
+//! pull policy) is identical to the Docker runtime — this module reproduces that
+//! semantics on top of the lower-level primitives.
+
+pub(crate) mod client;
+pub(crate) mod cni;
+pub(crate) mod health_check;
+pub(crate) mod image;
+pub(crate) mod instances;
+pub(crate) mod lifecycle;
+pub(crate) mod logs;
+pub(crate) mod oci;
+pub(crate) mod stats;
+
+pub(crate) use client::{ContainerdLifecycle, ContainerdRuntimeConfig};
+
+/// Label key under which every Ring-managed container records its owning
+/// deployment id. Mirrors the Docker runtime's `ring_deployment` label so
+/// `list_instances`/`remove_instance` can filter by deployment without keeping
+/// external state. Containerd's filter syntax matches on `labels."<key>"`.
+pub(crate) const RING_DEPLOYMENT_LABEL: &str = "ring_deployment";
+
+/// Generate a short random suffix for instance ids, matching the Docker
+/// runtime's `tiny_id` so container names read the same across runtimes.
+pub(crate) fn tiny_id() -> String {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    format!("{:08x}", rng.random::<u32>())
+}

--- a/src/runtime/containerd/oci.rs
+++ b/src/runtime/containerd/oci.rs
@@ -1,0 +1,358 @@
+//! OCI runtime spec generation.
+//!
+//! containerd's runc shim consumes a standard [OCI runtime spec] (the same
+//! `config.json` runc reads) carried as the container's `spec` field. There is
+//! no convenience builder in the gRPC API: we construct the spec ourselves and
+//! wrap the JSON in a protobuf [`Any`] with the runtime-spec type url that the
+//! shim recognises.
+//!
+//! This is a deliberately minimal-but-correct spec modeled on runc's default
+//! (`runc spec`): a Linux process with the standard namespaces, the canonical
+//! pseudo-filesystem mounts, and the deployment's process args / env / cwd.
+//!
+//! [OCI runtime spec]: https://github.com/opencontainers/runtime-spec
+
+use crate::models::deployments::{Deployment, EnvValue};
+use crate::models::volume::ResolvedMount;
+use prost_types::Any;
+use serde_json::{Value, json};
+
+/// The type url the runc shim matches to decode the container spec. This is the
+/// fixed identifier containerd registers for the OCI runtime spec; it is not a
+/// generated prost type, so we set it on a raw `Any` by hand.
+const RUNTIME_SPEC_TYPE_URL: &str = "types.containerd.io/opencontainers/runtime-spec/1/Spec";
+
+/// Build the OCI runtime spec for a deployment instance and pack it as an `Any`.
+///
+/// `rootfs_path` is the absolute host path the snapshot mounts resolve to — but
+/// when the rootfs is delivered as task mounts (the snapshot path), the runc
+/// shim mounts them onto `root.path` itself, so we keep the conventional
+/// relative `rootfs` here and let the task `rootfs` mounts populate it.
+pub(crate) fn build_spec(
+    deployment: &Deployment,
+    resolved_mounts: &[ResolvedMount],
+    config_files: &[(String, String)],
+) -> Any {
+    let spec = build_spec_value(deployment, resolved_mounts, config_files);
+    // `spec` is an in-memory serde_json::Value built from owned data, so
+    // serialisation cannot fail in practice; expect() over unwrap_or_default()
+    // so a truly impossible failure surfaces loudly instead of silently
+    // shipping an empty spec that the shim would reject with an opaque error.
+    let bytes = serde_json::to_vec(&spec).expect("OCI spec Value must serialize");
+    Any {
+        type_url: RUNTIME_SPEC_TYPE_URL.to_string(),
+        value: bytes,
+    }
+}
+
+/// Pure spec construction, split out so it can be unit-tested without gRPC.
+pub(crate) fn build_spec_value(
+    deployment: &Deployment,
+    resolved_mounts: &[ResolvedMount],
+    config_files: &[(String, String)],
+) -> Value {
+    let args = deployment.command.clone();
+
+    let mut env: Vec<String> =
+        vec!["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()];
+    for (key, value) in deployment.environment.iter() {
+        if let EnvValue::Plain(v) = value {
+            env.push(format!("{}={}", key, v));
+        }
+    }
+
+    let (uid, gid) = deployment
+        .config
+        .as_ref()
+        .and_then(|c| c.user.as_ref())
+        .map(|u| (u.id.unwrap_or(0), u.group.unwrap_or(0)))
+        .unwrap_or((0, 0));
+
+    let mut mounts = default_mounts();
+    mounts.extend(spec_mounts_from_resolved(resolved_mounts, config_files));
+
+    // `args` may legitimately be empty (use the image entrypoint). The OCI spec
+    // requires `process.args` to be non-empty, but the runc shim merges the
+    // image config's entrypoint/cmd when the container is created from an image,
+    // so omitting `args` entirely lets the image defaults apply. We only set
+    // `args` when the deployment overrides the command.
+    let mut process = json!({
+        "terminal": false,
+        "user": { "uid": uid, "gid": gid },
+        "env": env,
+        "cwd": "/",
+        "capabilities": default_capabilities(),
+        "rlimits": [
+            { "type": "RLIMIT_NOFILE", "hard": 1024, "soft": 1024 }
+        ],
+        "noNewPrivileges": true,
+    });
+    if !args.is_empty() {
+        process["args"] = json!(args);
+    }
+
+    json!({
+        "ociVersion": "1.0.2-dev",
+        "process": process,
+        "root": { "path": "rootfs", "readonly": false },
+        "hostname": deployment.name,
+        "mounts": mounts,
+        "linux": {
+            "namespaces": default_namespaces(),
+            "maskedPaths": masked_paths(),
+            "readonlyPaths": readonly_paths(),
+        }
+    })
+}
+
+/// The canonical pseudo-filesystem mounts runc installs by default.
+fn default_mounts() -> Vec<Value> {
+    vec![
+        json!({ "destination": "/proc", "type": "proc", "source": "proc" }),
+        json!({
+            "destination": "/dev", "type": "tmpfs", "source": "tmpfs",
+            "options": ["nosuid", "strictatime", "mode=755", "size=65536k"]
+        }),
+        json!({
+            "destination": "/dev/pts", "type": "devpts", "source": "devpts",
+            "options": ["nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"]
+        }),
+        json!({
+            "destination": "/dev/shm", "type": "tmpfs", "source": "shm",
+            "options": ["nosuid", "noexec", "nodev", "mode=1777", "size=65536k"]
+        }),
+        json!({
+            "destination": "/dev/mqueue", "type": "mqueue", "source": "mqueue",
+            "options": ["nosuid", "noexec", "nodev"]
+        }),
+        json!({
+            "destination": "/sys", "type": "sysfs", "source": "sysfs",
+            "options": ["nosuid", "noexec", "nodev", "ro"]
+        }),
+        json!({
+            "destination": "/sys/fs/cgroup", "type": "cgroup", "source": "cgroup",
+            "options": ["nosuid", "noexec", "nodev", "relatime", "ro"]
+        }),
+    ]
+}
+
+/// Translate Ring's resolved mounts into OCI bind mounts. Named/bind volumes
+/// become host bind mounts; content/config/secret mounts are written to host
+/// temp files by the caller and bind-mounted read-only (the `config_files` pairs
+/// are `(host_path, destination)`).
+fn spec_mounts_from_resolved(
+    resolved_mounts: &[ResolvedMount],
+    config_files: &[(String, String)],
+) -> Vec<Value> {
+    let mut out = Vec::new();
+    for m in resolved_mounts {
+        match m {
+            ResolvedMount::Bind {
+                source,
+                destination,
+                read_only,
+            } => {
+                out.push(bind_mount(source, destination, *read_only));
+            }
+            ResolvedMount::Named {
+                name,
+                destination,
+                read_only,
+                ..
+            } => {
+                // Named volumes are materialized under a host directory keyed by
+                // the volume name. Bind that directory into the container.
+                let source = format!("/var/lib/ring/volumes/{}", name);
+                out.push(bind_mount(&source, destination, *read_only));
+            }
+            // Content mounts are handled via `config_files` (written to disk by
+            // the lifecycle before spec construction).
+            ResolvedMount::Content { .. } => {}
+        }
+    }
+    for (host_path, destination) in config_files {
+        out.push(bind_mount(host_path, destination, true));
+    }
+    out
+}
+
+fn bind_mount(source: &str, destination: &str, read_only: bool) -> Value {
+    let mut options = vec!["rbind".to_string()];
+    options.push(if read_only {
+        "ro".to_string()
+    } else {
+        "rw".to_string()
+    });
+    json!({
+        "destination": destination,
+        "type": "bind",
+        "source": source,
+        "options": options,
+    })
+}
+
+/// Standard Linux namespaces for an isolated container. Network is its own
+/// namespace so CNI can wire it up; sharing the host network would defeat the
+/// CNI bridge model.
+fn default_namespaces() -> Vec<Value> {
+    vec![
+        json!({ "type": "pid" }),
+        json!({ "type": "ipc" }),
+        json!({ "type": "uts" }),
+        json!({ "type": "mount" }),
+        json!({ "type": "network" }),
+    ]
+}
+
+/// runc's default capability set for an unprivileged container.
+fn default_capabilities() -> Value {
+    let caps = vec![
+        "CAP_CHOWN",
+        "CAP_DAC_OVERRIDE",
+        "CAP_FSETID",
+        "CAP_FOWNER",
+        "CAP_MKNOD",
+        "CAP_NET_RAW",
+        "CAP_SETGID",
+        "CAP_SETUID",
+        "CAP_SETFCAP",
+        "CAP_SETPCAP",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_SYS_CHROOT",
+        "CAP_KILL",
+        "CAP_AUDIT_WRITE",
+    ];
+    json!({
+        "bounding": caps,
+        "effective": caps,
+        "permitted": caps,
+    })
+}
+
+fn masked_paths() -> Vec<&'static str> {
+    vec![
+        "/proc/acpi",
+        "/proc/asound",
+        "/proc/kcore",
+        "/proc/keys",
+        "/proc/latency_stats",
+        "/proc/timer_list",
+        "/proc/timer_stats",
+        "/proc/sched_debug",
+        "/sys/firmware",
+        "/proc/scsi",
+    ]
+}
+
+fn readonly_paths() -> Vec<&'static str> {
+    vec![
+        "/proc/bus",
+        "/proc/fs",
+        "/proc/irq",
+        "/proc/sys",
+        "/proc/sysrq-trigger",
+    ]
+}
+
+/// Build an OCI process spec for an exec probe (used by health checks). Wrapped
+/// as an `Any` for `ExecProcessRequest.spec`.
+pub(crate) fn build_exec_process_spec(args: Vec<String>) -> Any {
+    let process = json!({
+        "terminal": false,
+        "user": { "uid": 0, "gid": 0 },
+        "args": args,
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "cwd": "/",
+        "capabilities": default_capabilities(),
+        "noNewPrivileges": true,
+    });
+    Any {
+        type_url: "types.containerd.io/opencontainers/runtime-spec/1/Process".to_string(),
+        value: serde_json::to_vec(&process).expect("exec process spec Value must serialize"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::deployments::DeploymentStatus;
+    use std::collections::HashMap;
+
+    fn make_deployment() -> Deployment {
+        Deployment {
+            id: "dep-1".to_string(),
+            created_at: "now".to_string(),
+            updated_at: None,
+            status: DeploymentStatus::Running,
+            restart_count: 0,
+            namespace: "default".to_string(),
+            name: "web".to_string(),
+            image: "nginx:latest".to_string(),
+            config: None,
+            runtime: "containerd".to_string(),
+            kind: "worker".to_string(),
+            replicas: 1,
+            command: vec![
+                "nginx".to_string(),
+                "-g".to_string(),
+                "daemon off;".to_string(),
+            ],
+            instances: vec![],
+            labels: HashMap::new(),
+            environment: HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: vec![],
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: None,
+            network: None,
+        }
+    }
+
+    #[test]
+    fn spec_includes_command_args() {
+        let mut d = make_deployment();
+        d.environment
+            .insert("FOO".to_string(), EnvValue::Plain("bar".to_string()));
+        let spec = build_spec_value(&d, &[], &[]);
+        assert_eq!(spec["process"]["args"][0], "nginx");
+        let env = spec["process"]["env"].as_array().unwrap();
+        assert!(env.iter().any(|e| e == "FOO=bar"));
+    }
+
+    #[test]
+    fn spec_omits_args_when_command_empty() {
+        let mut d = make_deployment();
+        d.command.clear();
+        let spec = build_spec_value(&d, &[], &[]);
+        assert!(spec["process"].get("args").is_none());
+    }
+
+    #[test]
+    fn spec_has_network_namespace() {
+        let d = make_deployment();
+        let spec = build_spec_value(&d, &[], &[]);
+        let namespaces = spec["linux"]["namespaces"].as_array().unwrap();
+        assert!(namespaces.iter().any(|n| n["type"] == "network"));
+    }
+
+    #[test]
+    fn spec_binds_resolved_mounts() {
+        let d = make_deployment();
+        let mounts = vec![ResolvedMount::Bind {
+            source: "/host/data".to_string(),
+            destination: "/data".to_string(),
+            read_only: true,
+        }];
+        let spec = build_spec_value(&d, &mounts, &[]);
+        let m = spec["mounts"].as_array().unwrap();
+        assert!(
+            m.iter()
+                .any(|x| x["destination"] == "/data" && x["source"] == "/host/data")
+        );
+    }
+}

--- a/src/runtime/containerd/stats.rs
+++ b/src/runtime/containerd/stats.rs
@@ -1,0 +1,237 @@
+//! Per-instance resource statistics via the Tasks `Metrics` RPC.
+//!
+//! `Tasks.Metrics` returns a `containerd.types.Metric` whose `data` is a
+//! protobuf `Any` carrying the cgroup metrics — for cgroup v2 hosts the type is
+//! `io.containerd.cgroups.v2.Metrics`, for v1 `io.containerd.cgroups.v1.Metrics`.
+//! Those message definitions live in the containerd `cgroups` crate, which this
+//! build does **not** depend on, so we cannot strongly-decode them here.
+//!
+//! Rather than pull in another proto crate, we decode the two fields Ring's
+//! dashboard cares about — memory usage and pids — directly from the cgroup v2
+//! `Metrics` wire format using prost's field-level reader. CPU percentage and
+//! network counters are not derivable from a single cgroup sample without a
+//! prior reading and an interface accounting source, so they are reported as
+//! zero (documented limitation; matches what cgroup v2 exposes for a container
+//! that has no per-interface accounting).
+
+use crate::api::dto::stats::*;
+use containerd_client::services::v1::MetricsRequest;
+use containerd_client::services::v1::tasks_client::TasksClient;
+use containerd_client::with_namespace;
+use prost::bytes::Buf;
+use prost::encoding::{DecodeContext, WireType, decode_key, skip_field};
+use tonic::Request;
+
+/// Fetch and map one instance's stats. Returns `None` when the task has no
+/// metrics (not running) so the caller simply omits it.
+pub(crate) async fn fetch_instance_stats(
+    client: &containerd_client::Client,
+    namespace: &str,
+    instance_id: &str,
+    instance_name: &str,
+) -> Option<InstanceStatsOutput> {
+    let mut tasks = TasksClient::new(client.channel());
+    let req = with_namespace!(
+        MetricsRequest {
+            filters: vec![format!("id=={}", instance_id)],
+        },
+        namespace
+    );
+    let resp = tasks.metrics(req).await.ok()?;
+    let metric = resp.into_inner().metrics.into_iter().next()?;
+    let data = metric.data?;
+
+    let (mem_usage, mem_limit, pids_current, pids_limit) = decode_cgroup_v2(&data.value);
+
+    Some(InstanceStatsOutput {
+        instance_id: instance_id.chars().take(12).collect(),
+        instance_name: instance_name.to_string(),
+        // CPU percentage needs a delta between two samples + system time; a
+        // single Metrics call cannot produce it. Reported as 0 until a
+        // sampling loop is added.
+        cpu_usage_percent: 0.0,
+        memory: MemoryStats {
+            usage_bytes: mem_usage,
+            limit_bytes: mem_limit,
+            usage_percent: if mem_limit > 0 {
+                (mem_usage as f64 / mem_limit as f64) * 100.0
+            } else {
+                0.0
+            },
+        },
+        // cgroup metrics carry no per-interface network accounting.
+        network: NetworkStats {
+            rx_bytes: 0,
+            tx_bytes: 0,
+            rx_packets: 0,
+            tx_packets: 0,
+        },
+        disk_io: DiskIoStats {
+            read_bytes: 0,
+            write_bytes: 0,
+        },
+        pids: PidStats {
+            current: pids_current,
+            limit: pids_limit,
+        },
+        // containerd tracks restarts via the shim, not the metrics RPC; Ring's
+        // own restart_count on the deployment is authoritative, so 0 here.
+        restart_count: 0,
+    })
+}
+
+/// Best-effort field-level decode of an `io.containerd.cgroups.v2.Metrics`
+/// message, extracting `(memory.usage, memory.usage_limit, pids.current,
+/// pids.limit)`.
+///
+/// The v2 `Metrics` layout (from containerd's `cgroups/v2/stats.proto`):
+///   field 4  = Pids   { current=1 (uint64), limit=2 (uint64) }
+///   field 5  = Memory { ... usage=10 (uint64), usage_limit=11 (uint64) ... }
+///
+/// We walk the top-level message, recurse into the Pids and Memory submessages,
+/// and read the specific tags. Unknown fields are skipped. Returns zeros for any
+/// field absent (e.g. on a cgroup v1 host, where the layout differs and nothing
+/// matches — the values stay 0, which the caller renders as "unknown").
+fn decode_cgroup_v2(mut buf: &[u8]) -> (u64, u64, u64, u64) {
+    let mut mem_usage = 0u64;
+    let mut mem_limit = 0u64;
+    let mut pids_current = 0u64;
+    let mut pids_limit = 0u64;
+
+    while buf.has_remaining() {
+        let Ok((tag, wire)) = decode_key(&mut buf) else {
+            break;
+        };
+        match (tag, wire) {
+            // Pids submessage (Metrics.pids, field 1).
+            (1, WireType::LengthDelimited) => {
+                if let Some(sub) = read_len_delimited(&mut buf) {
+                    let (c, l) = decode_pids(sub);
+                    pids_current = c;
+                    pids_limit = l;
+                }
+            }
+            // Memory submessage (Metrics.memory, field 4).
+            (4, WireType::LengthDelimited) => {
+                if let Some(sub) = read_len_delimited(&mut buf) {
+                    let (u, l) = decode_memory(sub);
+                    mem_usage = u;
+                    mem_limit = l;
+                }
+            }
+            _ => {
+                if skip_field(wire, tag, &mut buf, DecodeContext::default()).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    (mem_usage, mem_limit, pids_current, pids_limit)
+}
+
+fn decode_pids(mut buf: &[u8]) -> (u64, u64) {
+    let mut current = 0u64;
+    let mut limit = 0u64;
+    while buf.has_remaining() {
+        let Ok((tag, wire)) = decode_key(&mut buf) else {
+            break;
+        };
+        match (tag, wire) {
+            (1, WireType::Varint) => current = read_varint(&mut buf),
+            (2, WireType::Varint) => limit = read_varint(&mut buf),
+            _ => {
+                if skip_field(wire, tag, &mut buf, DecodeContext::default()).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    (current, limit)
+}
+
+fn decode_memory(mut buf: &[u8]) -> (u64, u64) {
+    let mut usage = 0u64;
+    let mut limit = 0u64;
+    while buf.has_remaining() {
+        let Ok((tag, wire)) = decode_key(&mut buf) else {
+            break;
+        };
+        match (tag, wire) {
+            // MemoryStat.usage = field 32, usage_limit = field 33 in
+            // io.containerd.cgroups.v2.MemoryStat (NOT 10/11 — those are
+            // anon_thp / inactive_anon and would report bogus values).
+            (32, WireType::Varint) => usage = read_varint(&mut buf),
+            (33, WireType::Varint) => limit = read_varint(&mut buf),
+            _ => {
+                if skip_field(wire, tag, &mut buf, DecodeContext::default()).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    (usage, limit)
+}
+
+fn read_varint(buf: &mut &[u8]) -> u64 {
+    prost::encoding::decode_varint(buf).unwrap_or(0)
+}
+
+fn read_len_delimited<'a>(buf: &mut &'a [u8]) -> Option<&'a [u8]> {
+    let len = prost::encoding::decode_varint(buf).ok()? as usize;
+    if buf.remaining() < len {
+        return None;
+    }
+    let (head, tail) = buf.split_at(len);
+    *buf = tail;
+    Some(head)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::encoding::{encode_key, encode_varint};
+
+    fn encode_pids(current: u64, limit: u64) -> Vec<u8> {
+        let mut b = Vec::new();
+        encode_key(1, WireType::Varint, &mut b);
+        encode_varint(current, &mut b);
+        encode_key(2, WireType::Varint, &mut b);
+        encode_varint(limit, &mut b);
+        b
+    }
+
+    #[test]
+    fn decode_pids_roundtrip() {
+        let bytes = encode_pids(7, 100);
+        assert_eq!(decode_pids(&bytes), (7, 100));
+    }
+
+    #[test]
+    fn decode_top_level_pids_and_memory() {
+        // Build a minimal v2 Metrics matching the real proto field numbers:
+        // Metrics.pids = field 1, Metrics.memory = field 4; inside MemoryStat,
+        // usage = field 32, usage_limit = field 33.
+        let pids = encode_pids(3, 50);
+        let mut mem = Vec::new();
+        encode_key(32, WireType::Varint, &mut mem);
+        encode_varint(2048, &mut mem);
+        encode_key(33, WireType::Varint, &mut mem);
+        encode_varint(4096, &mut mem);
+
+        let mut top = Vec::new();
+        encode_key(1, WireType::LengthDelimited, &mut top);
+        encode_varint(pids.len() as u64, &mut top);
+        top.extend_from_slice(&pids);
+        encode_key(4, WireType::LengthDelimited, &mut top);
+        encode_varint(mem.len() as u64, &mut top);
+        top.extend_from_slice(&mem);
+
+        let (mu, ml, pc, pl) = decode_cgroup_v2(&top);
+        assert_eq!((mu, ml, pc, pl), (2048, 4096, 3, 50));
+    }
+
+    #[test]
+    fn decode_empty_is_zeros() {
+        assert_eq!(decode_cgroup_v2(&[]), (0, 0, 0, 0));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 //! runtime contract live in the sibling [`crate::hypervisor`] module.
 
 pub(crate) mod cloud_hypervisor;
+pub(crate) mod containerd;
 pub(crate) mod docker;
 pub(crate) mod firecracker;
 pub(crate) mod podman;

--- a/tests/e2e/containerd/setup.sh
+++ b/tests/e2e/containerd/setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Preflight for the containerd e2e suite.
+#
+# Verifies the host can actually drive containerd through Ring's native gRPC
+# runtime: the containerd socket must be reachable, `ctr` must be on PATH (the
+# tests use it to assert containerd state independently of Ring), and the CNI
+# plugins must be installed (Ring writes a default conflist but cannot supply
+# the plugin binaries). Sourced by tests/e2e/containerd/t*.sh.
+#
+# Running containerd's socket is owned by root, so these tests typically run as
+# root (or a user in a group with socket access). The suite fails fast with an
+# actionable message rather than producing confusing mid-test errors.
+
+set -euo pipefail
+
+RING_CONTAINERD_SOCKET="${RING_CONTAINERD_SOCKET:-/run/containerd/containerd.sock}"
+RING_CONTAINERD_NS="${RING_CONTAINERD_NS:-ring}"
+CNI_BIN_DIR="${CNI_BIN_DIR:-/opt/cni/bin}"
+
+check_containerd_prereqs() {
+  if ! command -v ctr > /dev/null 2>&1; then
+    echo "[containerd-setup] FAIL: 'ctr' not found in PATH" >&2
+    echo "                   install containerd (provides ctr)" >&2
+    return 1
+  fi
+
+  if [ ! -S "$RING_CONTAINERD_SOCKET" ]; then
+    echo "[containerd-setup] FAIL: containerd socket not found at $RING_CONTAINERD_SOCKET" >&2
+    echo "                   start containerd: sudo systemctl start containerd" >&2
+    return 1
+  fi
+
+  # A namespaces call proves the socket actually answers (not just that the file
+  # exists). Permission errors surface here with a clear hint.
+  if ! ctr -n "$RING_CONTAINERD_NS" namespaces list > /dev/null 2>&1; then
+    echo "[containerd-setup] FAIL: cannot talk to containerd at $RING_CONTAINERD_SOCKET" >&2
+    echo "                   the socket is root-owned; run the suite as root (sudo -E)" >&2
+    return 1
+  fi
+
+  # CNI plugins are required for container networking. Without them Ring boots
+  # the container with no address and the networking/health-check tests fail.
+  if [ ! -x "$CNI_BIN_DIR/bridge" ] || [ ! -x "$CNI_BIN_DIR/host-local" ]; then
+    echo "[containerd-setup] FAIL: CNI plugins missing under $CNI_BIN_DIR (need bridge + host-local)" >&2
+    echo "                   install the containernetworking-plugins package, or download from" >&2
+    echo "                   https://github.com/containernetworking/plugins/releases" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Pull the test image into Ring's containerd namespace ahead of time so the
+# first test isn't dominated by a cold registry pull (and so a registry outage
+# fails preflight, not an individual test).
+RING_CONTAINERD_IMAGE="${RING_CONTAINERD_IMAGE:-docker.io/library/nginx:1.25-alpine}"
+
+setup_containerd() {
+  check_containerd_prereqs || exit 1
+
+  # Drive containerd instead of Docker for this suite: disable the default
+  # Docker runtime and inject the [server.runtime.containerd] block that
+  # start_ring appends via RING_EXTRA_CONFIG.
+  export RING_E2E_ENABLE_DOCKER=false
+  RING_EXTRA_CONFIG=$(cat <<EOF
+[server.runtime.containerd]
+enabled = true
+socket = "$RING_CONTAINERD_SOCKET"
+namespace = "$RING_CONTAINERD_NS"
+EOF
+)
+  export RING_EXTRA_CONFIG
+  export RING_CONTAINERD_NS
+
+  log "containerd preflight OK (socket=$RING_CONTAINERD_SOCKET, ns=$RING_CONTAINERD_NS)"
+}

--- a/tests/e2e/containerd/t1_create_delete.sh
+++ b/tests/e2e/containerd/t1_create_delete.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# T1-containerd: apply a minimal nginx deployment, assert it becomes Running with
+# a real containerd container + task, then delete it and assert the container is
+# gone (task killed, container + snapshot removed).
+#
+# Requires: a reachable containerd socket, `ctr`, and CNI plugins. See setup.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T1-containerd: create / delete =="
+
+setup_containerd
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/nginx-ctr.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  nginx-ctr:
+    name: nginx-ctr
+    namespace: ring-e2e
+    runtime: containerd
+    image: nginx:1.25-alpine
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "nginx-ctr" "running" 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-ctr")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+assert_containerd_container_exists "$DEPLOYMENT_ID"
+wait_containerd_task_running "$DEPLOYMENT_ID" 30
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+wait_containerd_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T1-containerd: PASS =="

--- a/tests/e2e/containerd/t2_replicas.sh
+++ b/tests/e2e/containerd/t2_replicas.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# T2-containerd: apply a deployment with replicas=3, assert the scheduler
+# converges to exactly 3 containerd containers, then delete and assert cleanup.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T2-containerd: replicas (3 containers per deployment) =="
+
+setup_containerd
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/nginx-ctr-replicas.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  nginx-ctr-scaled:
+    name: nginx-ctr-scaled
+    namespace: ring-e2e
+    runtime: containerd
+    image: nginx:1.25-alpine
+    replicas: 3
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "nginx-ctr-scaled" "running" 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "nginx-ctr-scaled")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+# Scheduler creates one container per cycle; with interval=1s, converging to
+# 3 replicas should take a few seconds.
+wait_containerd_container_count "$DEPLOYMENT_ID" 3 45
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+wait_containerd_container_count "$DEPLOYMENT_ID" 0 45
+
+log "== T2-containerd: PASS =="

--- a/tests/e2e/containerd/t3_logs.sh
+++ b/tests/e2e/containerd/t3_logs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# T3-containerd: `ring deployment logs <id>` on a containerd deployment must
+# return the task's stdout. Ring directs the task's stdio to a per-instance log
+# file and tails it. We emit two recognisable markers then sleep so the task
+# stays around for the assertions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T3-containerd: logs =="
+
+setup_containerd
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/log-emitter-ctr.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  log-emitter-ctr:
+    name: log-emitter-ctr
+    namespace: ring-e2e
+    runtime: containerd
+    image: alpine:3
+    replicas: 1
+    command: ["sh", "-c", "echo RING-LOG-MARKER-1; echo RING-LOG-MARKER-2; sleep 600"]
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "log-emitter-ctr" "running" 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "log-emitter-ctr")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# Give the shim a moment to flush stdout to the log file.
+sleep 2
+
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 50 2>&1 || true)
+if ! echo "$LOGS_OUT" | grep -q "RING-LOG-MARKER-1"; then
+  echo "$LOGS_OUT" >&2
+  fail "first marker missing from logs output"
+fi
+if ! echo "$LOGS_OUT" | grep -q "RING-LOG-MARKER-2"; then
+  echo "$LOGS_OUT" >&2
+  fail "second marker missing from logs output"
+fi
+log "both stdout markers present in 'ring deployment logs --tail 50'"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_containerd_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T3-containerd: PASS =="

--- a/tests/e2e/containerd/t4_health_check_command.sh
+++ b/tests/e2e/containerd/t4_health_check_command.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# T4-containerd: a `command` health check runs inside the task via Tasks.Exec
+# (the containerd equivalent of `docker exec`). A check that always exits 0 must
+# be reported as successful by Ring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T4-containerd: command health check (Tasks.Exec) =="
+
+setup_containerd
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/hc-command-ctr.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  hc-command-ctr:
+    name: hc-command-ctr
+    namespace: ring-e2e
+    runtime: containerd
+    image: alpine:3
+    replicas: 1
+    command: ["sh", "-c", "sleep 600"]
+    health_checks:
+      - type: command
+        command: "true"
+        interval: 2s
+        timeout: 5s
+        on_failure: restart
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "hc-command-ctr" "running" 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "hc-command-ctr")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+wait_health_check_success "$DEPLOYMENT_ID" 30
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_containerd_container_gone "$DEPLOYMENT_ID" 30
+
+log "== T4-containerd: PASS =="

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -312,3 +312,92 @@ wait_docker_container_gone() {
   done
   fail "containers still present for deployment $id after ${timeout}s"
 }
+
+# --- containerd helpers -----------------------------------------------------
+#
+# These mirror the docker helpers above but query containerd directly via `ctr`
+# in Ring's namespace ($RING_CONTAINERD_NS, default "ring"). Ring tags every
+# container it creates with a `ring_deployment=<id>` containerd label, so we
+# filter on that the same way the docker helpers filter on the Docker label.
+
+RING_CONTAINERD_NS="${RING_CONTAINERD_NS:-ring}"
+
+# Count containerd containers belonging to a deployment.
+_ctr_container_count() {
+  local id="$1"
+  ctr -n "$RING_CONTAINERD_NS" containers list -q "labels.\"ring_deployment\"==$id" 2>/dev/null \
+    | grep -c . || true
+}
+
+# Usage: assert_containerd_container_exists <deployment_id>
+assert_containerd_container_exists() {
+  local id="$1"
+  local count
+  count=$(_ctr_container_count "$id")
+  if [ "${count:-0}" -lt 1 ]; then
+    fail "expected at least 1 containerd container for deployment $id, got ${count:-0}"
+  fi
+  log "containerd container exists for deployment $id (count=$count)"
+}
+
+# Usage: wait_containerd_container_count <deployment_id> <expected> [timeout]
+wait_containerd_container_count() {
+  local id="$1"
+  local expected="$2"
+  local timeout="${3:-30}"
+  local count=0
+  for _ in $(seq 1 "$timeout"); do
+    count=$(_ctr_container_count "$id")
+    if [ "${count:-0}" -eq "$expected" ]; then
+      log "deployment $id has $expected containerd container(s) as expected"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "deployment $id has ${count:-0} containerd container(s), expected $expected (timeout ${timeout}s)"
+}
+
+# Usage: wait_containerd_task_running <deployment_id> [timeout]
+# Asserts that at least one task for the deployment reports RUNNING.
+wait_containerd_task_running() {
+  local id="$1"
+  local timeout="${2:-30}"
+  for _ in $(seq 1 "$timeout"); do
+    # `ctr tasks ls` is global to the namespace; cross-reference against the
+    # deployment's container ids.
+    local cids
+    cids=$(ctr -n "$RING_CONTAINERD_NS" containers list -q "labels.\"ring_deployment\"==$id" 2>/dev/null)
+    if [ -n "$cids" ]; then
+      local running
+      running=$(ctr -n "$RING_CONTAINERD_NS" tasks list 2>/dev/null \
+        | awk 'NR>1 {print $1, $3}' \
+        | while read -r tid status; do
+            if echo "$cids" | grep -qx "$tid" && [ "$status" = "RUNNING" ]; then
+              echo "$tid"
+            fi
+          done | grep -c . || true)
+      if [ "${running:-0}" -ge 1 ]; then
+        log "deployment $id has a RUNNING containerd task"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  fail "no RUNNING containerd task for deployment $id after ${timeout}s"
+}
+
+# Usage: wait_containerd_container_gone <deployment_id> [timeout]
+wait_containerd_container_gone() {
+  local id="$1"
+  local timeout="${2:-30}"
+  for _ in $(seq 1 "$timeout"); do
+    local count
+    count=$(_ctr_container_count "$id")
+    if [ "${count:-0}" -eq 0 ]; then
+      log "no containerd container left for deployment $id"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "containerd containers still present for deployment $id after ${timeout}s"
+}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -5,7 +5,12 @@
 #   tests/e2e/run.sh                    # run every suite
 #   tests/e2e/run.sh docker             # run only Docker tests
 #   tests/e2e/run.sh podman             # run only Podman tests
+#   tests/e2e/run.sh containerd         # run only containerd tests (root + CNI)
 #   tests/e2e/run.sh cloud-hypervisor   # run only Cloud Hypervisor tests
+#
+# The containerd suite is not in the default set: it needs access to the
+# root-owned containerd socket and CNI plugins, so run it explicitly
+# (e.g. `sudo -E tests/e2e/run.sh containerd`).
 #
 # The script doesn't `set -e` on the loop so a single failing test does not
 # abort the rest of the run; the summary at the end reports pass/fail per
@@ -31,6 +36,17 @@ cleanup_between_tests() {
   if command -v docker > /dev/null 2>&1; then
     docker ps -aq --filter "label=ring_deployment" 2>/dev/null \
       | xargs -r docker rm -f > /dev/null 2>&1 || true
+  fi
+  # containerd: kill leftover tasks and delete Ring-labelled containers in the
+  # ring namespace, best-effort (only if the socket is reachable).
+  if command -v ctr > /dev/null 2>&1 \
+     && ctr -n "${RING_CONTAINERD_NS:-ring}" namespaces list > /dev/null 2>&1; then
+    for cid in $(ctr -n "${RING_CONTAINERD_NS:-ring}" containers list -q \
+                   'labels."ring_deployment"!=""' 2>/dev/null); do
+      ctr -n "${RING_CONTAINERD_NS:-ring}" tasks kill -s SIGKILL "$cid" 2>/dev/null || true
+      ctr -n "${RING_CONTAINERD_NS:-ring}" tasks delete "$cid" 2>/dev/null || true
+      ctr -n "${RING_CONTAINERD_NS:-ring}" containers delete "$cid" 2>/dev/null || true
+    done
   fi
   rm -rf /tmp/ring-e2e-?????? 2>/dev/null || true
   sleep 1


### PR DESCRIPTION
## Summary

Adds **containerd** as a first-class Ring runtime, driven directly over its native gRPC API (no Docker daemon in between). This targets hosts that already run containerd for Kubernetes (k3s, RKE2, stock containerd) and don't want a second container engine.

The runtime sits behind the same `RuntimeLifecycle` trait as Docker/Podman/CH/Firecracker and reproduces the Docker runtime's reconciliation semantics (job vs worker, scale up/down, terminal states).

## What's included

- **gRPC client** via `containerd-client` (tonic/prost), namespace-scoped (`ring` by default) so Ring's objects never collide with `k8s.io`/`moby`/`default`.
- **Full instance lifecycle**: image pull through the transfer service → writable snapshot off the image's layer chain id → OCI runtime spec → task under the `runc` shim → start.
- **CNI networking**: writes a default `bridge` + `host-local` conflist and drives the standard CNI plugin protocol; `instance_address` resolves the assigned IP for TCP/HTTP probes.
- **Logs** tailed from the task's stdio file; **stats** from cgroup v2 (memory + pids); **`command` health checks** via `Tasks.Exec`.
- Opt-in config `[server.runtime.containerd] { enabled, socket, namespace }`, fail-fast on an unreachable socket at startup.
- Accepted in API validation, CLI `apply`, and `ring init`.
- Docs (`concepts/runtimes.md`, `reference/config-toml.md`) and an e2e suite under `tests/e2e/containerd/`.

## Testing

- `cargo test`: 580 passing.
- `cargo clippy -- -D warnings`: clean.
- **e2e suite added but not yet executed in this environment** (the containerd socket is root-owned and CNI plugins were unavailable). Run on a host with containerd + `/opt/cni/bin`:
  ```
  sudo -E tests/e2e/run.sh containerd
  ```

## Known limitations

- CPU% and per-interface network/disk stats read as zero (not derivable from a single cgroup sample).
- CNI plugins (`/opt/cni/bin`: `bridge`, `host-local`, `loopback`) must be installed; without them a container boots with no address.
- The containerd event stream is not consumed yet, so crash detection is tick-bound.
- Host networking (`network.mode: host`) is not allowed on containerd yet.


fix #21 