### PR TITLE
feat(config): load config.toml from --config flag or RING_CONFIG_FILE

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -23,6 +23,17 @@ ring --context production deployment list
 ring -c staging deployment list
 ```
 
+#### `--config`
+
+Load a specific `config.toml` instead of the default `$RING_CONFIG_DIR/config.toml`. Useful for keeping several explicitly-named files (`config_dev.toml`, `config_prod.toml`) and switching between them. Overrides the `RING_CONFIG_FILE` environment variable.
+
+This overrides **only** the config file — `auth.json`, Cloud Hypervisor firmware, and other assets still come from `$RING_CONFIG_DIR`. If the given file does not exist, Ring logs an error rather than silently falling back to the default.
+
+```bash
+ring --config ~/.config/kemeter/ring/config_dev.toml deployment list
+ring --config /etc/ring/config.toml server start
+```
+
 ## System
 
 ### `ring init`
@@ -605,6 +616,7 @@ The default context (the one with `current = true`) is used when no `--context` 
 ### CLI
 
 - `RING_TOKEN` — bearer token used for API requests. When set and non-empty, the CLI ignores `auth.json`. Useful for CI pipelines that should not depend on `ring login`.
+- `RING_CONFIG_FILE` — path to a specific `config.toml` to load (default: `$RING_CONFIG_DIR/config.toml`). The `--config` flag takes precedence.
 
 ```bash
 # Generate a server-side key

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -1,6 +1,6 @@
 # config.toml reference
 
-Ring reads `~/.config/kemeter/ring/config.toml` (or `$RING_CONFIG_DIR/config.toml`) at startup. It is split in two:
+Ring reads `~/.config/kemeter/ring/config.toml` (or `$RING_CONFIG_DIR/config.toml`) at startup. To load a different file — e.g. to keep `config_dev.toml` and `config_prod.toml` side by side — pass `--config <path>` or set `RING_CONFIG_FILE` (see [CLI reference](cli.md#--config)). It is split in two:
 
 - **`[contexts.<name>]`** — *client* config: how a CLI reaches a server (host, API, auth). There can be several (e.g. `local`, `staging`, `prod`), like kubectl contexts.
 - **`[server]`** — *daemon* config: what the Ring **server** does (which runtimes it enables, scheduler interval, dashboard). One shared table, outside `[contexts.*]`.

--- a/documentation/reference/environment-variables.md
+++ b/documentation/reference/environment-variables.md
@@ -8,6 +8,7 @@ Variables Ring reads from the process environment. Set them in your shell, a sys
 | `RING_DATABASE_PATH` | No | `./ring.db` | Path to the SQLite database file. The path is created on first start; parent directory must exist and be writable |
 | `RING_DB_POOL_SIZE` | No | `5` | Maximum SQLite connections in the pool |
 | `RING_CONFIG_DIR` | No | `~/.config/kemeter/ring` | Where Ring reads `config.toml` and `auth.json`. Also the default location for Cloud Hypervisor firmware/sockets |
+| `RING_CONFIG_FILE` | No | `$RING_CONFIG_DIR/config.toml` | Path to a specific `config.toml` to load. Overrides **only** the config file, not `RING_CONFIG_DIR` (`auth.json`, firmware, etc. still come from the directory). The `--config` flag takes precedence over this. If set but the file is missing, Ring logs an error instead of silently using the default |
 | `RING_APPLY_TIMEOUT` | No | `300` | Timeout in seconds for a single deployment's `runtime.apply()` call inside one scheduler tick. **Does not** bound the whole scheduler cycle or the client-side `ring apply` command |
 | `RING_SCHEDULER_INTERVAL` | No | `10` | Scheduler tick interval in seconds. Overrides `[scheduler] interval` in `config.toml` |
 | `RING_VIRTIOFSD` | No | autodiscover | Path to the `virtiofsd` binary on the host. Ring tries `/usr/libexec/virtiofsd` then `/usr/lib/qemu/virtiofsd` if unset |

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -5,7 +5,6 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use toml::de::Error as TomlError;
 
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct Contexts {
@@ -76,32 +75,63 @@ pub(crate) fn get_config_dir() -> String {
     }
 }
 
-pub(crate) fn load_config(context_current: &str) -> Config {
-    let home_dir = get_config_dir();
+/// Resolve which `config.toml` to load. An explicit override wins: the
+/// `--config` flag (`explicit`) takes precedence over the `RING_CONFIG_FILE`
+/// env var, which in turn beats the conventional `{config_dir}/config.toml`.
+pub(crate) fn resolve_config_path(explicit: Option<&str>) -> String {
+    if let Some(path) = explicit {
+        return path.to_string();
+    }
 
-    let file = format!("{}/config.toml", home_dir);
+    if let Some(value) = env::var_os("RING_CONFIG_FILE") {
+        match value.into_string() {
+            Ok(path) => return path,
+            Err(_) => error!("RING_CONFIG_FILE contains invalid Unicode — ignoring it"),
+        }
+    }
+
+    format!("{}/config.toml", get_config_dir())
+}
+
+pub(crate) fn load_config(context_current: &str, config_file: Option<&str>) -> Config {
+    // An explicitly requested file (flag or env) must exist: silently falling
+    // back to the default would hide a typo in the path the user just gave us.
+    let explicit = config_file.is_some() || env::var_os("RING_CONFIG_FILE").is_some();
+    let file = resolve_config_path(config_file);
 
     debug!("load config file {}", file);
 
-    if fs::metadata(file.clone()).is_ok() {
-        let contents = match fs::read_to_string(file) {
-            Ok(c) => c,
-            Err(e) => {
-                error!("Failed to read config file: {}", e);
-                return Config::default();
-            }
-        };
-        let contexts: Result<Contexts, TomlError> = toml::from_str(&contents);
+    if fs::metadata(&file).is_err() {
+        if explicit {
+            error!(
+                "Config file '{}' does not exist (set via --config or RING_CONFIG_FILE)",
+                file
+            );
+        } else {
+            debug!(
+                "No config file at {}, switching to default configuration",
+                file
+            );
+        }
+        return Config::default();
+    }
 
-        match contexts {
-            Ok(contexts) => {
-                if let Some(config) = pick_context(contexts, context_current) {
-                    return config;
-                }
+    let contents = match fs::read_to_string(&file) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to read config file '{}': {}", file, e);
+            return Config::default();
+        }
+    };
+
+    match toml::from_str::<Contexts>(&contents) {
+        Ok(contexts) => {
+            if let Some(config) = pick_context(contexts, context_current) {
+                return config;
             }
-            Err(err) => {
-                error!("Error while deserializing the TOML file : {}", err);
-            }
+        }
+        Err(err) => {
+            error!("Error while deserializing the TOML file : {}", err);
         }
     }
 
@@ -265,5 +295,52 @@ api.port = 3030
         // dev has current=true, prod is the named target. Named must win.
         let picked = pick_context(contexts, "prod").expect("prod should match");
         assert_eq!(picked.name, "prod");
+    }
+
+    // `resolve_config_path` reads RING_CONFIG_FILE, a process-global env var, so
+    // these tests must not run concurrently. A shared mutex serialises them.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_config_file_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("RING_CONFIG_FILE").ok();
+        match value {
+            Some(v) => unsafe { std::env::set_var("RING_CONFIG_FILE", v) },
+            None => unsafe { std::env::remove_var("RING_CONFIG_FILE") },
+        }
+        f();
+        match saved {
+            Some(v) => unsafe { std::env::set_var("RING_CONFIG_FILE", v) },
+            None => unsafe { std::env::remove_var("RING_CONFIG_FILE") },
+        }
+    }
+
+    #[test]
+    fn resolve_config_path_explicit_flag_wins_over_env() {
+        with_config_file_env(Some("/from/env.toml"), || {
+            let path = resolve_config_path(Some("/from/flag.toml"));
+            assert_eq!(path, "/from/flag.toml");
+        });
+    }
+
+    #[test]
+    fn resolve_config_path_uses_env_when_no_flag() {
+        with_config_file_env(Some("/from/env.toml"), || {
+            let path = resolve_config_path(None);
+            assert_eq!(path, "/from/env.toml");
+        });
+    }
+
+    #[test]
+    fn resolve_config_path_falls_back_to_default_when_no_override() {
+        with_config_file_env(None, || {
+            let path = resolve_config_path(None);
+            assert!(
+                path.ends_with("/config.toml"),
+                "default must point at config.toml inside the config dir, got {}",
+                path
+            );
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,12 @@ async fn main() {
                 .long("context")
                 .short('c'),
         )
+        .arg(
+            Arg::new("config")
+                .required(false)
+                .help("Path to a config.toml to load (overrides RING_CONFIG_FILE and the default)")
+                .long("config"),
+        )
         .subcommand(commands::context::command_config())
         .subcommand(commands::init::command_config())
         .subcommand(
@@ -141,8 +147,10 @@ async fn main() {
         .map(|s| s.as_str())
         .unwrap_or("default");
 
+    let config_file = matches.get_one::<String>("config").map(|s| s.as_str());
+
     let subcommand_name = matches.subcommand();
-    let config = config::config::load_config(context);
+    let config = config::config::load_config(context, config_file);
     let client = reqwest::Client::builder()
         .default_headers({
             let mut headers = reqwest::header::HeaderMap::new();


### PR DESCRIPTION
## What

Adds two ways to point ring-server at a specific `config.toml` instead of relying solely on `RING_CONFIG_DIR`:

- a `--config <path>` CLI flag
- a `RING_CONFIG_FILE` environment variable

Precedence: `--config` (explicit) > `RING_CONFIG_FILE` > the existing `RING_CONFIG_DIR`/default lookup.

## Why

Pointing at a single config file is more ergonomic than managing a config directory, especially for local development and CI where the config lives at a known path.

## Changes

- `src/config/config.rs`: resolve the config path from the flag/env var with documented precedence
- `src/main.rs`: wire the `--config` flag
- docs: CLI reference, config-toml reference, environment-variables reference