### PR TITLE
Run doctor pre-flight checks at the end of ring init

### DIFF
--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -38,29 +38,38 @@ ring --config /etc/ring/config.toml server start
 
 ### `ring init`
 
-Initialize the Ring config directory.
+Initialize the Ring config directory: write `config.toml` and a freshly generated `RING_SECRET_KEY` (persisted to `secret-key`, mode `0600`) under `~/.config/kemeter/ring/` (or `$RING_CONFIG_DIR`).
 
 ```bash
 ring init
 ```
 
-Creates `~/.config/kemeter/ring/` (or `$RING_CONFIG_DIR`) and writes an empty `auth.json`. Produces no output on success.
+Interactive on a TTY (prompts for runtime and API port); scriptable via flags otherwise:
+
+- `--runtime` — `docker`, `podman`, `cloud-hypervisor`, `firecracker` (experimental), or `both` (Docker + Cloud Hypervisor). `both` never enables Firecracker.
+- `--port` — the API port (default `3030`).
+- `--force` — overwrite an existing `config.toml` / `secret-key`. Regenerates the key, making every secret stored under the old one undecryptable.
+
+Flags win over prompts and over the non-interactive defaults (Docker, port `3030`), and compose per-field. When stdin is not a TTY and no flags are given, `init` uses the defaults instead of hanging on a prompt.
+
+After writing the files, `init` runs the same diagnostics as [`ring doctor`](#ring-doctor) on the selected runtime as a **pre-flight check**. Failing checks are surfaced as warnings but do **not** change the exit code — `init` already succeeded. Only the selected runtime is checked.
 
 > `ring init` does **not** create the SQLite database or seed the admin user. That happens automatically the first time `ring server start` runs the migrations.
 
 ### `ring doctor`
 
-Run diagnostic checks against the host:
+Run diagnostic checks against the host. Runtime checks only run for runtimes enabled in `config.toml`; with no runtime enabled, all of them run.
 
 - **Server-side env** — `RING_SECRET_KEY` is set, decodes to base64, and is exactly 32 bytes.
-- **Docker** — `docker --version` succeeds (the binary is present and the daemon is reachable).
+- **Docker / Podman** — `docker --version` succeeds (the binary is present and the daemon is reachable). Podman reuses this check since it speaks the Docker API.
 - **Cloud Hypervisor** — the binary is on `$PATH`, `/dev/kvm` is readable+writable, the binary has `cap_net_admin,cap_net_raw` set (printed by `getcap`), `xorriso` is on `$PATH` (needed for the cloud-init NoCloud ISO when a CH deployment ships `environment`), the firmware file at the configured `firmware_path` exists, and a `virtiofsd` binary is found at `/usr/libexec/virtiofsd`, `/usr/lib/qemu/virtiofsd`, or whatever `RING_VIRTIOFSD` points to.
+- **Firecracker** (experimental, only when enabled) — the binary is on `$PATH`, `/dev/kvm` is readable+writable, the binary has `cap_net_admin,cap_net_raw` set, the kernel image at the configured `kernel_path` (an uncompressed `vmlinux`, not a firmware blob) exists, and `socat` is on `$PATH` for port forwarding.
 
 ```bash
 ring doctor
 ```
 
-Use this as the first step when something doesn't work as expected.
+Use this as the first step when something doesn't work as expected. Exits non-zero if any check fails.
 
 ## Server
 

--- a/documentation/tutorials/install-and-run.md
+++ b/documentation/tutorials/install-and-run.md
@@ -66,7 +66,7 @@ ring init
 
 Ring will prompt you for two things:
 
-- **Which runtime to use** — Docker, Cloud Hypervisor, or both
+- **Which runtime to use** — Docker, Podman, Cloud Hypervisor, Firecracker (experimental), or both (Docker + Cloud Hypervisor)
 - **Which port the API should listen on** — defaults to `3030`
 
 It then writes `~/.config/kemeter/ring/config.toml`, persists a freshly generated `RING_SECRET_KEY` to `~/.config/kemeter/ring/secret-key` (mode `0600`), and prints the same key on stdout for convenience:
@@ -90,12 +90,22 @@ $ ring init
   Treat that file like a private key: chmod 0600, never commit, never back up unencrypted.
 ────────────────────────────────────────────────────────────────────────
 
+→ Pre-flight checks (ring doctor):
+
+Server
+  [+] RING_SECRET_KEY: set, decodes to a 32-byte AES-256 key
+
+Docker
+  [+] docker: Docker version 28.5.0, build 887030f
+
 → Next steps:
   1. Export the key above
   2. ring server start             # first boot creates the admin user (admin/changeme)
   3. ring login -u admin -p changeme
   4. ring user update --password "<your password>"  # rotate the default password
 ```
+
+At the end, `ring init` runs the same diagnostics as [`ring doctor`](/documentation/reference/cli) on the runtime you just selected — so you find out *now* that Docker isn't running, KVM is missing, or a kernel image is absent, instead of at your first `ring apply`. A failing check (`[-]`) is only a warning: `init` already wrote your config, so it still exits `0`. Fix the flagged items and re-run `ring doctor` to confirm. Only the selected runtime is checked, so a Docker-only init won't nag about Cloud Hypervisor dependencies.
 
 Copy the `export RING_SECRET_KEY=...` line into your shell, or pin it to a `systemd EnvironmentFile=` for a production install. The on-disk copy under `~/.config/kemeter/ring/secret-key` is a recovery aid if the terminal scrolls past or the install is interrupted — **it is not a substitute for setting the environment variable**, since `ring server start` only reads `RING_SECRET_KEY` from the environment. Lose the key (file deleted *and* env forgotten) and every secret you store becomes unrecoverable; leak it and every secret is compromised. See [Secrets and encryption](/documentation/concepts/secrets-encryption) for the threat model.
 
@@ -111,7 +121,7 @@ To configure a non-default runtime or port without a prompt (CI, Ansible, etc.),
 ring init --runtime cloud-hypervisor --port 4030
 ```
 
-- `--runtime` — `docker`, `cloud-hypervisor`, or `both`.
+- `--runtime` — `docker`, `podman`, `cloud-hypervisor`, `firecracker` (experimental), or `both` (Docker + Cloud Hypervisor).
 - `--port` — the API port (default `3030`).
 
 Flags take precedence over prompts and over the non-interactive defaults, and compose per-field: passing only `--port` still prompts for the runtime on a TTY (or defaults to Docker when there's no TTY), and vice versa.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -6,7 +6,7 @@ pub(crate) fn command_config() -> Command {
     Command::new("doctor").about("Check system dependencies for configured runtimes")
 }
 
-struct Check {
+pub(crate) struct Check {
     name: String,
     passed: bool,
     detail: String,
@@ -135,6 +135,43 @@ fn check_docker() -> Vec<Check> {
     vec![check_binary("docker", "--version")]
 }
 
+/// Firecracker boots a kernel directly (no firmware step like Cloud
+/// Hypervisor), so its dependencies are: the `firecracker` binary, an
+/// uncompressed `vmlinux` kernel, `/dev/kvm`, and the same TAP network
+/// capabilities CH needs (Ring sets up the tap in-process via
+/// `CAP_NET_ADMIN`/`CAP_NET_RAW`). Firecracker is experimental — these checks
+/// only run when the runtime is explicitly enabled.
+fn check_firecracker(config: &Config) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    let binary = config
+        .server
+        .runtime
+        .firecracker
+        .binary_path
+        .as_deref()
+        .unwrap_or("firecracker");
+    checks.push(check_binary(binary, "--version"));
+
+    checks.push(check_kvm());
+    checks.push(check_capabilities(binary));
+
+    let default_kernel = format!("{}/firecracker/vmlinux", get_config_dir());
+    let kernel = config
+        .server
+        .runtime
+        .firecracker
+        .kernel_path
+        .as_deref()
+        .unwrap_or(&default_kernel);
+    checks.push(check_file("Kernel", kernel));
+
+    // Port forwarding is socat-based, same as CH.
+    checks.push(check_socat());
+
+    checks
+}
+
 fn check_cloud_hypervisor(config: &Config) -> Vec<Check> {
     let mut checks = Vec::new();
 
@@ -246,16 +283,44 @@ fn check_server() -> Vec<Check> {
     }]
 }
 
-pub(crate) fn execute(_args: &ArgMatches, config: Config) {
-    let all_checks: Vec<(&str, Vec<Check>)> = vec![
-        ("Server", check_server()),
-        ("Docker", check_docker()),
-        ("Cloud Hypervisor", check_cloud_hypervisor(&config)),
-    ];
+/// Collect every diagnostic group. `Server` checks always run; runtime checks
+/// only run for runtimes enabled in the config, so `ring init --runtime docker`
+/// doesn't drown the operator in irrelevant Cloud Hypervisor failures. When no
+/// runtime is enabled (e.g. a stub config) we fall back to checking all of them
+/// — that matches the old behaviour and is the most useful default for a bare
+/// `ring doctor`.
+pub(crate) fn collect_checks(config: &Config) -> Vec<(&'static str, Vec<Check>)> {
+    let docker_enabled = config.server.runtime.docker.enabled;
+    let podman_enabled = config.server.runtime.podman.enabled;
+    let ch_enabled = config.server.runtime.cloud_hypervisor.enabled;
+    let fc_enabled = config.server.runtime.firecracker.enabled;
+    let none_enabled = !docker_enabled && !podman_enabled && !ch_enabled && !fc_enabled;
 
+    let mut groups: Vec<(&'static str, Vec<Check>)> = vec![("Server", check_server())];
+
+    // Podman speaks the Docker API, so its host-side dependency is the same
+    // `docker`/`podman` CLI presence check we already have for Docker.
+    if docker_enabled || podman_enabled || none_enabled {
+        groups.push(("Docker", check_docker()));
+    }
+    if ch_enabled || none_enabled {
+        groups.push(("Cloud Hypervisor", check_cloud_hypervisor(config)));
+    }
+    // Firecracker is experimental, so it's only diagnosed when explicitly
+    // enabled — never as part of the bare `ring doctor` fallback.
+    if fc_enabled {
+        groups.push(("Firecracker", check_firecracker(config)));
+    }
+
+    groups
+}
+
+/// Print a collected set of checks. Returns `true` if any check failed, so the
+/// caller decides what a failure means: `ring doctor` exits non-zero, while
+/// `ring init` only warns (init itself succeeded).
+pub(crate) fn report_checks(groups: &[(&str, Vec<Check>)]) -> bool {
     let mut has_failure = false;
-
-    for (runtime, checks) in &all_checks {
+    for (runtime, checks) in groups {
         println!("{}", runtime);
         for check in checks {
             let icon = if check.passed { "+" } else { "-" };
@@ -266,6 +331,12 @@ pub(crate) fn execute(_args: &ArgMatches, config: Config) {
         }
         println!();
     }
+    has_failure
+}
+
+pub(crate) fn execute(_args: &ArgMatches, config: Config) {
+    let groups = collect_checks(&config);
+    let has_failure = report_checks(&groups);
 
     if has_failure {
         std::process::exit(1);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -36,7 +36,7 @@ pub(crate) fn command_config() -> Command {
                 .long("runtime")
                 .value_name("RUNTIME")
                 .help(
-                    "Runtime to configure, skipping the prompt: docker, podman, cloud-hypervisor, or both",
+                    "Runtime to configure, skipping the prompt: docker, podman, cloud-hypervisor, firecracker, or both",
                 )
                 .value_parser(clap::value_parser!(RuntimeChoice)),
         )
@@ -64,6 +64,7 @@ pub(crate) enum RuntimeChoice {
     Docker,
     Podman,
     CloudHypervisor,
+    Firecracker,
     Both,
 }
 
@@ -73,6 +74,7 @@ impl RuntimeChoice {
             RuntimeChoice::Docker => "Docker",
             RuntimeChoice::Podman => "Podman",
             RuntimeChoice::CloudHypervisor => "Cloud Hypervisor",
+            RuntimeChoice::Firecracker => "Firecracker (experimental)",
             RuntimeChoice::Both => "Both",
         }
     }
@@ -133,7 +135,51 @@ pub(crate) fn init(args: &ArgMatches) {
     println!("✓ Wrote {} (mode 0600)", secret_key_path);
 
     print_secret_key_block(&key, &secret_key_path);
+    run_preflight_checks(&key);
     print_next_steps();
+}
+
+/// Run `ring doctor`'s diagnostics on the config we just wrote, so the operator
+/// learns *now* that Docker isn't running or KVM is missing — instead of at the
+/// first `ring apply`, which is where these failures used to surface.
+///
+/// This is purely informative: `init` already succeeded (the files are on
+/// disk), so a failing dependency must NOT make the command exit non-zero or
+/// look like the init itself broke. We reload the freshly-written config so the
+/// checks see the runtimes the user just selected, and we set
+/// `RING_SECRET_KEY` in-process so the `RING_SECRET_KEY` server check passes
+/// (the operator hasn't had a chance to export it yet — it was printed seconds
+/// ago).
+fn run_preflight_checks(key: &str) {
+    use crate::commands::doctor;
+    use crate::config::config::load_config;
+
+    // The secret-key check reads RING_SECRET_KEY from the environment. We just
+    // generated a valid key; make the check reflect that rather than reporting
+    // a "missing key" that the operator is about to export anyway.
+    if std::env::var_os("RING_SECRET_KEY").is_none() {
+        // SAFETY: single-threaded at this point (CLI dispatch, no spawned
+        // threads reading the environment concurrently).
+        unsafe {
+            std::env::set_var("RING_SECRET_KEY", key);
+        }
+    }
+
+    let config = load_config("default", None);
+    let groups = doctor::collect_checks(&config);
+
+    println!();
+    println!("→ Pre-flight checks (ring doctor):");
+    println!();
+    let has_failure = doctor::report_checks(&groups);
+
+    if has_failure {
+        println!("Some dependencies are missing. Ring is configured, but the server may not");
+        println!(
+            "start until you resolve the [-] items above. Re-run `ring doctor` after fixing them."
+        );
+        println!();
+    }
 }
 
 const DEFAULT_PORT: u16 = 3030;
@@ -176,6 +222,7 @@ fn collect_settings(args: &ArgMatches) -> InitSettings {
                 RuntimeChoice::Docker,
                 RuntimeChoice::Podman,
                 RuntimeChoice::CloudHypervisor,
+                RuntimeChoice::Firecracker,
                 RuntimeChoice::Both,
             ],
         )
@@ -241,6 +288,9 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         settings.runtime,
         RuntimeChoice::CloudHypervisor | RuntimeChoice::Both
     );
+    // Firecracker is experimental and not part of `Both` (which stays the
+    // mainstream Docker+CH pairing). It's only enabled when picked explicitly.
+    let firecracker = matches!(settings.runtime, RuntimeChoice::Firecracker);
 
     if docker {
         out.push('\n');
@@ -269,6 +319,20 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
         // don't need it, but the comment saves an hour of debugging when
         // they do.
         out.push_str("# seccomp = \"false\"  # only if VMs die with SIGSYS on boot\n");
+    }
+
+    if firecracker {
+        out.push('\n');
+        out.push_str("# Firecracker is experimental: no volumes, no command health checks,\n");
+        out.push_str("# no kind: job (treated as a worker). See the runtime docs.\n");
+        out.push_str("[server.runtime.firecracker]\n");
+        out.push_str("enabled = true\n");
+        out.push_str("# Uncomment and adjust if firecracker isn't on $PATH:\n");
+        out.push_str("# binary_path = \"/usr/local/bin/firecracker\"\n");
+        // Firecracker boots a kernel directly — there is no firmware step.
+        out.push_str("# kernel_path = \"/var/lib/ring/firecracker/vmlinux\"\n");
+        out.push_str("# socket_dir = \"/var/lib/ring/firecracker/sockets\"\n");
+        out.push_str("# boot_args = \"console=ttyS0 reboot=k panic=1 pci=off\"\n");
     }
 
     out
@@ -370,6 +434,15 @@ mod tests {
             RuntimeChoice::Podman
         );
 
+        // firecracker (experimental) is a valid runtime choice.
+        let m = command_config()
+            .try_get_matches_from(["init", "--runtime", "firecracker"])
+            .expect("firecracker must parse");
+        assert_eq!(
+            *m.get_one::<RuntimeChoice>("runtime").unwrap(),
+            RuntimeChoice::Firecracker
+        );
+
         // Unknown runtime is rejected by ValueEnum.
         assert!(
             command_config()
@@ -426,6 +499,35 @@ mod tests {
         assert!(out.contains("seccomp"));
         // No Docker block when CH only.
         assert!(!out.contains("[server.runtime.docker]"));
+    }
+
+    #[test]
+    fn build_config_firecracker_only_emits_firecracker_section() {
+        let s = InitSettings {
+            runtime: RuntimeChoice::Firecracker,
+            port: 5050,
+        };
+        let out = build_config_toml(&s);
+        assert!(out.contains("[server.runtime.firecracker]"));
+        assert!(out.contains("enabled = true"));
+        // Firecracker boots a kernel directly — the hint must mention kernel_path,
+        // not a firmware path.
+        assert!(out.contains("kernel_path"));
+        // Firecracker is exclusive and not part of `Both`: no docker/CH block.
+        assert!(!out.contains("[server.runtime.docker]"));
+        assert!(!out.contains("runtime.cloud_hypervisor"));
+    }
+
+    #[test]
+    fn build_config_both_excludes_firecracker() {
+        // `Both` is the mainstream Docker+CH pairing; the experimental
+        // Firecracker runtime must never be enabled implicitly.
+        let s = InitSettings {
+            runtime: RuntimeChoice::Both,
+            port: 3030,
+        };
+        let out = build_config_toml(&s);
+        assert!(!out.contains("[server.runtime.firecracker]"));
     }
 
     #[test]

--- a/tests/e2e/server/t10_init_preflight.sh
+++ b/tests/e2e/server/t10_init_preflight.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# T10-server: `ring init` runs `ring doctor`'s diagnostics at the end so the
+# operator learns about missing dependencies (Docker down, KVM/firmware absent,
+# ...) right away instead of at the first `ring apply`. Validates against the
+# real binary.
+#
+# Invariants:
+#   1. After a successful init, a "Pre-flight checks (ring doctor)" block is
+#      printed, and the in-process RING_SECRET_KEY check passes (the key was
+#      just generated, so it must not report as missing).
+#   2. The checks only cover the selected runtime: `--runtime cloud-hypervisor`
+#      prints a "Cloud Hypervisor" group and NOT a "Docker" group (no noise from
+#      irrelevant runtimes).
+#   3. A failing dependency does NOT make init exit non-zero — init succeeded,
+#      the files are on disk; the missing dep is only a warning. We force a
+#      guaranteed CH failure (firmware never exists in a fresh temp dir) and
+#      assert the warning text appears AND exit code is 0.
+#   4. `--runtime docker` prints a "Docker" group and NOT a "Cloud Hypervisor"
+#      group.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+log "== T10-server: ring init pre-flight checks (ring doctor) =="
+
+# Make sure no inherited RING_SECRET_KEY masks invariant 1: init must inject the
+# key it just generated so the Server check passes on its own.
+unset RING_SECRET_KEY || true
+
+# --- Invariants 1 + 2 + 3: CH init (firmware guaranteed missing) ---
+D1=$(mktemp -d -t ring-e2e-preflight-XXXXXX)
+set +e
+OUT1=$(RING_CONFIG_DIR="$D1" "$RING_BIN" init --runtime cloud-hypervisor --port 4030 </dev/null 2>&1)
+RC1=$?
+set -e
+
+# Invariant 3: a missing dependency must not fail init.
+[ "$RC1" -eq 0 ] || { echo "$OUT1" >&2; fail "3: init must exit 0 even with a failing dependency (got $RC1)"; }
+
+echo "$OUT1" | grep -qiF "Pre-flight checks" \
+  || { echo "$OUT1" >&2; fail "1: expected a 'Pre-flight checks' block"; }
+
+# Invariant 1: the freshly generated key must register as set, not missing.
+echo "$OUT1" | grep -qF "[+] RING_SECRET_KEY: set" \
+  || { echo "$OUT1" >&2; fail "1: RING_SECRET_KEY should report as set (init injects the generated key)"; }
+
+# Invariant 2: CH selected → CH group present, Docker group absent.
+echo "$OUT1" | grep -qF "Cloud Hypervisor" \
+  || { echo "$OUT1" >&2; fail "2: expected a 'Cloud Hypervisor' group for --runtime cloud-hypervisor"; }
+if echo "$OUT1" | grep -qE "^Docker$"; then
+  echo "$OUT1" >&2; fail "2: 'Docker' group must not appear when only CH is selected"
+fi
+
+# Invariant 3: the firmware check fails (never present in a fresh dir) and the
+# warning is surfaced.
+echo "$OUT1" | grep -qF "[-] Firmware" \
+  || { echo "$OUT1" >&2; fail "3: expected a failing Firmware check in a fresh config dir"; }
+echo "$OUT1" | grep -qiF "dependencies are missing" \
+  || { echo "$OUT1" >&2; fail "3: expected the 'dependencies are missing' warning"; }
+log "1+2+3 (CH init: block printed, key set, CH-only, failing dep → warning + exit 0): ok"
+
+# --- Invariant 4: Docker init shows Docker group, not CH ---
+D2=$(mktemp -d -t ring-e2e-preflight-XXXXXX)
+set +e
+OUT2=$(RING_CONFIG_DIR="$D2" "$RING_BIN" init --runtime docker --port 3030 </dev/null 2>&1)
+RC2=$?
+set -e
+[ "$RC2" -eq 0 ] || { echo "$OUT2" >&2; fail "4: docker init exited non-zero ($RC2)"; }
+echo "$OUT2" | grep -qE "^Docker$" \
+  || { echo "$OUT2" >&2; fail "4: expected a 'Docker' group for --runtime docker"; }
+if echo "$OUT2" | grep -qF "Cloud Hypervisor"; then
+  echo "$OUT2" >&2; fail "4: 'Cloud Hypervisor' group must not appear when only Docker is selected"
+fi
+log "4 (Docker init: Docker-only group): ok"
+
+rm -rf "$D1" "$D2"
+log "== T10-server: all invariants passed =="

--- a/tests/e2e/server/t8_init_non_interactive.sh
+++ b/tests/e2e/server/t8_init_non_interactive.sh
@@ -13,6 +13,9 @@
 #   4. re-running without --force refuses to overwrite (non-zero exit).
 #   5. `init --runtime podman --port 4040` writes a [server.runtime.podman]
 #      block (exclusive: no docker block).
+#   6. `init --runtime firecracker --port 5050` writes a
+#      [server.runtime.firecracker] block (experimental, exclusive: no docker
+#      or cloud_hypervisor block, and never enabled by `both`).
 
 set -euo pipefail
 
@@ -54,7 +57,7 @@ OUT=$(RING_CONFIG_DIR="$D3" "$RING_BIN" init --runtime lxc 2>&1)
 RC=$?
 set -e
 [ "$RC" -ne 0 ] || fail "3: invalid --runtime must exit non-zero"
-echo "$OUT" | grep -qiE "docker, podman, cloud-hypervisor, both" \
+echo "$OUT" | grep -qiE "docker, podman, cloud-hypervisor, firecracker, both" \
   || { echo "$OUT" >&2; fail "3: expected accepted runtime values in the error"; }
 [ -f "$D3/config.toml" ] && fail "3: no config.toml should be written on rejection"
 log "3 (invalid runtime rejected): exit $RC, no config written"
@@ -70,6 +73,17 @@ if grep -qF "[server.runtime.docker]" "$D5/config.toml"; then
 fi
 log "5 (scripted Podman init): config.toml correct"
 
+# --- Invariant 6: scripted Firecracker init (experimental, exclusive) ---
+D6=$(mktemp -d -t ring-e2e-init-XXXXXX)
+RING_CONFIG_DIR="$D6" "$RING_BIN" init --runtime firecracker --port 5050 </dev/null >/dev/null 2>&1 \
+  || fail "6: init --runtime firecracker exited non-zero"
+grep -qF "[server.runtime.firecracker]" "$D6/config.toml" \
+  || { cat "$D6/config.toml" >&2; fail "6: firecracker block missing"; }
+if grep -qE "\[server.runtime.docker\]|cloud_hypervisor" "$D6/config.toml"; then
+  fail "6: firecracker is exclusive, no docker/cloud_hypervisor block expected"
+fi
+log "6 (scripted Firecracker init): config.toml correct"
+
 # --- Invariant 4: refuse to overwrite without --force ---
 set +e
 OUT=$(RING_CONFIG_DIR="$D1" "$RING_BIN" init --runtime docker --port 3030 2>&1)
@@ -79,5 +93,5 @@ set -e
 echo "$OUT" | grep -qiF "already exists" || { echo "$OUT" >&2; fail "4: expected 'already exists'"; }
 log "4 (no clobber without --force): refused"
 
-rm -rf "$D1" "$D2" "$D3" "$D5"
+rm -rf "$D1" "$D2" "$D3" "$D5" "$D6"
 log "== T8-server: all invariants passed =="


### PR DESCRIPTION
## What

After `ring init` writes `config.toml` and the secret key, it now runs `ring doctor`'s diagnostics on the **selected runtime** as a pre-flight check. Operators learn immediately that Docker isn't running, KVM is missing, a kernel/firmware image is absent, or the NAT capabilities aren't set — instead of discovering it at their first `ring apply`.

Closes the last open item of the `ring init` pillar (Pilier 1).

## Behavior

- **Informative only**: `init` already succeeded (files are on disk), so a failing check is a warning — `init` still exits `0`. Only `ring doctor` exits non-zero on failure.
- **Scoped to the selected runtime**: a Docker-only init doesn't report irrelevant Cloud Hypervisor failures. With no runtime enabled, all runtimes are checked (preserves the bare `ring doctor` default).
- **Key injection**: the freshly generated `RING_SECRET_KEY` is set in-process so the server check passes (the operator hasn't had a chance to export it yet).

## Scope: Firecracker promoted to a first-class runtime

Firecracker was absent from both `ring init` and `ring doctor` (a pre-existing gap). It is now exposed:

- `ring init --runtime firecracker` (experimental, exclusive — never enabled by `both`)
- `check_firecracker()`: binary, `/dev/kvm`, `cap_net_admin,cap_net_raw`, the `vmlinux` kernel at `kernel_path`, and `socat` for port forwarding

## Refactor

`doctor.rs` now exposes reusable `collect_checks()` / `report_checks()`; `execute()` keeps its `exit(1)`. `init` reuses both.

## Tests & docs

- New e2e `tests/e2e/server/t10_init_preflight.sh` (4 invariants: block printed, key set, runtime-scoped, failing dep → warning + exit 0), stable over 3 runs.
- `t8_init_non_interactive.sh` extended with a scripted Firecracker invariant.
- Unit tests for the new `RuntimeChoice::Firecracker` parsing and config generation.
- `documentation/reference/cli.md` — the `ring init` section was stale (described an empty `auth.json`); rewritten. Firecracker added to the doctor checks.
- `documentation/tutorials/install-and-run.md` — documents the pre-flight step and the full runtime list.

578 cargo tests pass, clippy clean.