### PR TITLE
Unify the login session into the token table, drop user.token

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -256,6 +256,18 @@ export async function login(username: string, password: string): Promise<string>
   return data.token;
 }
 
+// Revoke the current session server-side. Best-effort: the caller clears the
+// local token regardless, but this ensures the token can't be replayed after
+// sign-out. A 401 (token already invalid) is treated as success.
+export async function logout(): Promise<void> {
+  try {
+    await request<void>('/logout', { method: 'POST' });
+  } catch {
+    // Already invalid or unreachable — the local clearToken() that follows is
+    // what the user sees, so swallow and let sign-out proceed.
+  }
+}
+
 export function listDeployments(): Promise<Deployment[]> {
   return request<Deployment[]>('/deployments');
 }

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getCurrentUser, type CurrentUser } from '$lib/api';
+  import { getCurrentUser, logout as apiLogout, type CurrentUser } from '$lib/api';
   import { clearToken, getToken } from '$lib/auth';
   import { applyTheme, loadTheme, saveTheme, type Theme } from '$lib/theme';
 
@@ -62,7 +62,10 @@
     }
   });
 
-  function logout() {
+  async function logout() {
+    // Revoke the session server-side first so the token can't be replayed,
+    // then drop it locally and leave for the login page.
+    await apiLogout();
     clearToken();
     goto('/login');
   }

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -18,7 +18,7 @@ All requests except `POST /login` and `GET /healthz` require a Bearer token.
 curl -H "Authorization: Bearer $TOKEN" http://localhost:3030/deployments
 ```
 
-The Bearer token is either a **login session token** (from `POST /login`, full access) or a **scoped API token** (`ring_pat_…`, limited to its scopes and namespaces — see [Tokens](#tokens)). Both travel in the same `Authorization: Bearer` header.
+There is a single token format and a single auth path. The Bearer token is either a **login session** (from `POST /login`) or a **scoped API token / PAT** (from `ring token create`). Both are rows in the same `token` table, both are `ring_pat_…` values hashed at rest, and both travel in the same `Authorization: Bearer` header. The two are distinguished by a `kind` column (`session` vs `pat`), not by their name. A login session is a token of kind `session` scoped `admin` (full access) with no namespace restriction; a PAT is limited to its scopes and namespaces (see [Tokens](#tokens)). Sessions do not appear in the token list, cannot be managed by id, and are revoked with `POST /logout`.
 
 ### Get a token
 
@@ -36,16 +36,25 @@ Content-Type: application/json
 
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  "token": "ring_pat_3f9a…"
 }
 ```
 
-Tokens are stable per user; the CLI saves them in `~/.config/kemeter/ring/auth.json` after `ring login`.
+Every login mints a **new** session token (they are not shared across logins), so the value differs each time. The clear token is returned once and only its SHA-256 hash is stored. The CLI saves it in `~/.config/kemeter/ring/auth.json` after `ring login`. The session has no expiry; it lives until revoked with `POST /logout`.
 
 **Errors** (all in `application/problem+json`):
 
 - `401 Unauthorized` — `{"title": "Unauthorized", "detail": "invalid credentials"}` for both unknown username and wrong password.
-- `500 Internal Server Error` — token persistence or credential verification failure.
+- `500 Internal Server Error` — session persistence or credential verification failure.
+
+### Log out
+
+```
+POST /logout
+Authorization: Bearer <token>
+```
+
+Revokes the token presented in the `Authorization` header — a caller can only revoke the credential it is currently holding. Always returns `204 No Content`, whether or not the token existed (it never reveals token state). After logout the token is rejected with `401`. This works for any token, but is primarily how a login session is ended; to revoke a PAT, use `DELETE /tokens/{id}` or `ring token revoke`.
 
 ## CORS
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -87,7 +87,7 @@ On first start the server runs SQLite migrations, creates `ring.db` in the worki
 
 ### `ring login`
 
-Log in to a Ring server. The token is saved in `~/.config/kemeter/ring/auth.json` and reused by subsequent commands.
+Log in to a Ring server. Each login mints a fresh session token (a `ring_pat_…` value, full access) saved in `~/.config/kemeter/ring/auth.json` and reused by subsequent commands. The session does not expire; end it with `ring logout`. Logging in again creates an independent session — earlier ones stay valid until they are logged out.
 
 ```bash
 ring login --username <USERNAME> --password <PASSWORD>
@@ -116,6 +116,16 @@ error: cannot reach the server at http://localhost:3030 — is it running? (conn
 
 A timeout (`the server ... did not respond in time`) and a malformed
 request are reported the same way: one line, no nested error chain.
+
+### `ring logout`
+
+Revoke the current context's session on the server and remove its token from `auth.json`.
+
+```bash
+ring logout
+```
+
+The server-side revocation is best-effort: if the server is unreachable the local token is still removed, so the command never leaves you "stuck logged in" locally. Only the current context's entry is touched — other contexts in `auth.json` are left intact. Revoking a PAT (rather than a login session) is done with `ring token revoke <id>`, not this command.
 
 ## Deployments
 
@@ -322,6 +332,8 @@ ring user delete <ID>
 Scoped API tokens (Personal Access Tokens) let scripts, CI and external agents call the API without using a human's login session. A token carries a set of `verb:resource` scopes, an optional namespace boundary and an optional expiry, and can be revoked or rotated individually.
 
 The clear token (`ring_pat_…`) is shown **once**, at creation, and never again — only its prefix is stored in clear for display. Present it as `Authorization: Bearer ring_pat_…`.
+
+Login sessions (`ring login`) use the same storage and format — a session is a token scoped `admin`, created automatically on login and revoked on `ring logout`. It is distinguished from a PAT by its **kind** (not by its name), so naming a PAT `session` is fine and has no special effect. Sessions are **not** shown by `ring token list` and cannot be managed by id (`ring token revoke`/`rotate`); that command lists and acts only on the PATs you created. End a session with `ring logout`.
 
 **Scopes:** `deployments:read`, `deployments:write`, `secrets:read`, `secrets:write`, `configs:read`, `configs:write`, `namespaces:read`, `namespaces:write`, `users:read`, `users:write`, and `admin` (grants everything).
 

--- a/migrations/20220101000022_drop_user_token.sql
+++ b/migrations/20220101000022_drop_user_token.sql
@@ -1,0 +1,25 @@
+-- The plaintext per-user session token (`user.token`) is gone. Login sessions
+-- now live in the `token` table (the same table as PATs): hashed at rest,
+-- regenerated on every login, revocable via /logout. See migration
+-- 20220101000018_scoped_api_tokens.sql and src/api/action/login.rs.
+--
+-- Existing `user.token` values were never real sessions worth keeping (UUID
+-- seeds / a single shared secret), so there is nothing to migrate — active
+-- clients simply log in again.
+ALTER TABLE user DROP COLUMN token;
+
+-- Distinguish a login session from a PAT with a first-class `kind` column
+-- instead of overloading the free-text `name` (where a user-created PAT named
+-- "session" would have silently collided with the session-hiding filter). A
+-- session is `kind = 'session'`, every other token is `kind = 'pat'`.
+--
+--   * minted by /login          -> 'session'  (src/api/action/login.rs)
+--   * minted by `ring token`    -> 'pat'      (src/api/action/token/create.rs)
+--   * listed by `ring token list`-> WHERE kind = 'pat' (sessions stay hidden)
+--   * addressable by id         -> sessions are managed only via /logout
+--
+-- DEFAULT 'pat' reclassifies every pre-existing PAT correctly; the backfill
+-- below promotes any session rows already minted on this branch (which used
+-- name = 'session' as the old marker) to the new kind.
+ALTER TABLE token ADD COLUMN kind TEXT NOT NULL DEFAULT 'pat';
+UPDATE token SET kind = 'session' WHERE name = 'session';

--- a/src/api/action/login.rs
+++ b/src/api/action/login.rs
@@ -1,12 +1,10 @@
 use crate::api::server::Db;
 use crate::api::validation::problem_response;
+use crate::models::token as token_model;
 use crate::models::users as users_model;
 use axum::extract::State;
 use axum::response::Response;
 use axum::{Json, http::StatusCode, response::IntoResponse};
-use rand::Rng;
-use rand::distr::Alphanumeric;
-use rand::rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -16,7 +14,7 @@ pub(crate) async fn login(State(pool): State<Db>, Json(input): Json<LoginInput>)
     let option = users_model::find_by_username(&pool, &input.username).await;
 
     match option {
-        Ok(Some(mut user)) => {
+        Ok(Some(user)) => {
             let matches = match argon2::verify_encoded(&user.password, input.password.as_bytes()) {
                 Ok(m) => m,
                 Err(_) => {
@@ -36,19 +34,43 @@ pub(crate) async fn login(State(pool): State<Db>, Json(input): Json<LoginInput>)
                 );
             }
 
-            if user.token.is_empty() {
-                user.token = generate_token();
-            }
-
-            let token: String = user.token.clone();
-
-            if users_model::login(&pool, user).await.is_err() {
+            // Stamp the login first, then mint the session. If the stamp fails
+            // we bail before creating any token, so a failed login never leaves
+            // an orphan session row (an admin-scoped credential nobody holds and
+            // nothing can revoke) behind in the table.
+            if users_model::login(&pool, &user).await.is_err() {
                 return problem_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Internal Server Error",
                     "failed to record login",
                 );
             }
+
+            // Mint a fresh session: a row in the `token` table, `kind = session`,
+            // scoped `admin` (full access, matching the old session semantics),
+            // all namespaces, no expiry (revoked on logout). Every login gets its
+            // own token, so two logins no longer share a secret. The clear value
+            // is returned once and only its SHA-256 hash is persisted.
+            let token = match token_model::create(
+                &pool,
+                &user.id,
+                "session",
+                token_model::TokenKind::Session,
+                &["admin".to_string()],
+                &[],
+                None,
+            )
+            .await
+            {
+                Ok((clear, _)) => clear,
+                Err(_) => {
+                    return problem_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Internal Server Error",
+                        "failed to create session",
+                    );
+                }
+            };
 
             (StatusCode::OK, Json(json!({ "token": token }))).into_response()
         }
@@ -63,17 +85,6 @@ pub(crate) async fn login(State(pool): State<Db>, Json(input): Json<LoginInput>)
             "lookup failed",
         ),
     }
-}
-
-fn generate_token() -> String {
-    format!(
-        "tk_{}",
-        rng()
-            .sample_iter(&Alphanumeric)
-            .take(64)
-            .map(char::from)
-            .collect::<String>()
-    )
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -95,23 +106,168 @@ mod tests {
         token: String,
     }
 
+    async fn login_token(server: &TestServer) -> String {
+        let response: TestResponse = server
+            .post("/login")
+            .json(&json!({ "username": "admin", "password": "changeme" }))
+            .await;
+        response.json::<ResponseBody>().token
+    }
+
     #[tokio::test]
     async fn login_success() {
         let server = TestServer::new(new_test_app().await).unwrap();
-
-        let response: TestResponse = server
-            .post("/login")
-            .json(&json!({
-                "username": "admin",
-                "password": "changeme",
-            }))
-            .await;
-
-        let response_body: ResponseBody = response.json::<ResponseBody>();
+        let token = login_token(&server).await;
+        assert!(!token.is_empty(), "Token key is missing in the response");
+        // The session is now a row in the `token` table, so it carries the same
+        // `ring_pat_` prefix as a PAT — there is one token format and one auth
+        // path.
         assert!(
-            !response_body.token.is_empty(),
-            "Token key is missing in the response"
+            token.starts_with(crate::models::token::TOKEN_PREFIX),
+            "session token should be a ring_pat_ token, got: {}",
+            token
         );
+    }
+
+    #[tokio::test]
+    async fn session_token_authenticates_a_protected_route() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let token = login_token(&server).await;
+
+        // A session is scoped `admin`, so it must reach every protected route —
+        // here a plain read.
+        let ok = server
+            .get("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(ok.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn each_login_mints_a_distinct_session() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let first = login_token(&server).await;
+        let second = login_token(&server).await;
+
+        // The old bug: a 2nd login returned the *same* secret. Now every login
+        // mints its own row, so the two differ and both authenticate.
+        assert_ne!(first, second, "two logins must not share a token");
+        for token in [&first, &second] {
+            let res = server
+                .get("/deployments")
+                .add_header("Authorization", format!("Bearer {}", token))
+                .await;
+            assert_eq!(res.status_code(), StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn session_is_hidden_from_the_token_list() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let token = login_token(&server).await;
+
+        // The session lives in the `token` table, but it is not a PAT the user
+        // manages: `GET /tokens` must not surface it. A fresh admin has no PATs,
+        // so the list is empty even though a session row exists.
+        let res = server
+            .get("/tokens")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .await;
+        assert_eq!(res.status_code(), StatusCode::OK);
+        let list = res.json::<serde_json::Value>();
+        assert_eq!(
+            list.as_array().map(|a| a.len()),
+            Some(0),
+            "session token must not appear in /tokens, got: {}",
+            list
+        );
+    }
+
+    #[tokio::test]
+    async fn pat_named_session_stays_visible_and_manageable() {
+        // Sessions are distinguished by `kind`, not by the name "session", so a
+        // user is free to name a PAT "session" — it must NOT be hidden from the
+        // list or treated as a session. This is the regression the magic-name
+        // model had: such a PAT used to vanish from `ring token list`.
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let session = login_token(&server).await;
+
+        let mint = server
+            .post("/tokens")
+            .add_header("Authorization", format!("Bearer {}", session))
+            .json(&json!({ "name": "session", "scopes": ["deployments:read"], "namespaces": [] }))
+            .await;
+        assert_eq!(mint.status_code(), StatusCode::CREATED);
+
+        // The PAT named "session" appears in the list (the session row does not).
+        let list = server
+            .get("/tokens")
+            .add_header("Authorization", format!("Bearer {}", session))
+            .await
+            .json::<serde_json::Value>();
+        let arr = list.as_array().expect("list");
+        assert_eq!(
+            arr.len(),
+            1,
+            "the PAT named 'session' must be listed: {}",
+            list
+        );
+        assert_eq!(arr[0]["name"], "session");
+    }
+
+    #[tokio::test]
+    async fn session_is_not_addressable_by_id_through_the_token_api() {
+        // A session is hidden from the list AND off-limits by id: get/revoke/
+        // rotate on /tokens/{id} must 404 for a session row, so it is managed
+        // only via /login and /logout. We mint a session directly on the pool
+        // (so we hold its id) and prove every id-based token route rejects it.
+        use crate::models::token as token_model;
+        let (pool, router) = crate::api::server::tests::new_test_app_with_pool().await;
+        let server = TestServer::new(router).unwrap();
+        let admin = login_token(&server).await;
+        let auth = || ("Authorization", format!("Bearer {}", admin));
+
+        // The session must be owned by the logged-in admin, otherwise find_owned
+        // would 404 on ownership and mask the session-boundary check. Resolve the
+        // caller's own id via /users/me, then mint a session row for it.
+        let (h, v) = auth();
+        let me = server.get("/users/me").add_header(h, v).await;
+        let admin_id = me.json::<serde_json::Value>()["id"]
+            .as_str()
+            .expect("own user id")
+            .to_string();
+        let (_clear, session) = token_model::create(
+            &pool,
+            &admin_id,
+            "session",
+            token_model::TokenKind::Session,
+            &["admin".to_string()],
+            &[],
+            None,
+        )
+        .await
+        .unwrap();
+
+        let (h, v) = auth();
+        let get = server
+            .get(&format!("/tokens/{}", session.id))
+            .add_header(h, v)
+            .await;
+        assert_eq!(get.status_code(), StatusCode::NOT_FOUND);
+
+        let (h, v) = auth();
+        let del = server
+            .delete(&format!("/tokens/{}", session.id))
+            .add_header(h, v)
+            .await;
+        assert_eq!(del.status_code(), StatusCode::NOT_FOUND);
+
+        let (h, v) = auth();
+        let rot = server
+            .post(&format!("/tokens/{}/rotate", session.id))
+            .add_header(h, v)
+            .await;
+        assert_eq!(rot.status_code(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/src/api/action/logout.rs
+++ b/src/api/action/logout.rs
@@ -1,0 +1,123 @@
+use crate::api::server::Db;
+use crate::models::token as token_model;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+/// `POST /logout` — revoke the session (or PAT) presented as the Bearer
+/// credential. The route is behind the auth middleware, so the caller is
+/// already authenticated; we resolve their own token row from the presented
+/// secret and revoke that exact row. A caller can therefore only ever revoke
+/// the credential they are currently holding — no id, no scope gate beyond
+/// being authenticated.
+///
+/// Idempotent and non-revealing: an unknown or already-revoked token still
+/// returns 204, so logout never leaks whether a token exists or its state.
+pub(crate) async fn logout(State(pool): State<Db>, headers: HeaderMap) -> Response {
+    let Some(clear) = bearer_from_headers(&headers) else {
+        // Behind auth middleware this shouldn't happen, but fail safe: nothing
+        // to revoke, nothing to report.
+        return StatusCode::NO_CONTENT.into_response();
+    };
+
+    let hash = token_model::hash_token(&clear);
+    match token_model::find_by_token_hash(&pool, &hash).await {
+        Ok(Some(token)) => {
+            // Best-effort: a failed revoke is logged but still returns 204 — the
+            // client is logging out regardless, and we don't surface token state.
+            if let Err(e) = token_model::revoke(&pool, &token.id).await {
+                error!("Failed to revoke token on logout: {}", e);
+            }
+        }
+        // Unknown token: nothing to revoke. Still 204 (non-revealing).
+        Ok(None) => {}
+        // A DB read error must not masquerade as "no token found": the row may
+        // still be live and replayable. We log it (so a swallowed revoke is
+        // diagnosable) but keep the 204 contract — the client logs out locally
+        // regardless and we never leak token state.
+        Err(e) => error!("Failed to look up token on logout: {}", e),
+    }
+
+    StatusCode::NO_CONTENT.into_response()
+}
+
+/// Extract the raw Bearer credential from the `Authorization` header.
+fn bearer_from_headers(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    value
+        .strip_prefix("Bearer ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::server::tests::new_test_app;
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use serde_json::json;
+
+    async fn login(server: &TestServer) -> String {
+        let res = server
+            .post("/login")
+            .json(&json!({ "username": "admin", "password": "changeme" }))
+            .await;
+        res.json::<serde_json::Value>()["token"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn auth(token: &str) -> (&'static str, String) {
+        ("Authorization", format!("Bearer {}", token))
+    }
+
+    #[tokio::test]
+    async fn logout_revokes_the_presented_session() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let token = login(&server).await;
+        let (h, v) = auth(&token);
+
+        // Token works before logout.
+        let before = server.get("/deployments").add_header(h, v.clone()).await;
+        assert_eq!(before.status_code(), StatusCode::OK);
+
+        let out = server.post("/logout").add_header(h, v.clone()).await;
+        assert_eq!(out.status_code(), StatusCode::NO_CONTENT);
+
+        // Same token is now rejected — the session row was revoked.
+        let after = server.get("/deployments").add_header(h, v).await;
+        assert_eq!(after.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn second_logout_with_revoked_token_is_rejected_by_middleware() {
+        // After the first logout the token is dead, so a replay can't even reach
+        // the handler — the auth middleware rejects it with 401. (The handler's
+        // own idempotency — unknown token → 204 — is unreachable here precisely
+        // because a revoked token never gets past auth, which is the point.)
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let token = login(&server).await;
+        let (h, v) = auth(&token);
+
+        let first = server.post("/logout").add_header(h, v.clone()).await;
+        assert_eq!(first.status_code(), StatusCode::NO_CONTENT);
+        let second = server.post("/logout").add_header(h, v).await;
+        assert_eq!(second.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn fresh_login_after_logout_works() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let first = login(&server).await;
+        let (h, v) = auth(&first);
+        server.post("/logout").add_header(h, v).await;
+
+        // A new login mints a new, valid session.
+        let second = login(&server).await;
+        let (h2, v2) = auth(&second);
+        let res = server.get("/deployments").add_header(h2, v2).await;
+        assert_eq!(res.status_code(), StatusCode::OK);
+    }
+}

--- a/src/api/action/mod.rs
+++ b/src/api/action/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod config;
 pub(crate) mod deployment;
 pub(crate) mod healthz;
 pub(crate) mod login;
+pub(crate) mod logout;
 pub(crate) mod namespace;
 pub(crate) mod node;
 pub(crate) mod secret;

--- a/src/api/action/token/create.rs
+++ b/src/api/action/token/create.rs
@@ -77,6 +77,7 @@ pub(crate) async fn create(
         &pool,
         &auth.user.id,
         &input.name,
+        token::TokenKind::Pat,
         &input.scopes,
         &input.namespaces,
         input.expire_at.as_deref(),

--- a/src/api/action/token/mod.rs
+++ b/src/api/action/token/mod.rs
@@ -18,18 +18,20 @@ use axum::http::StatusCode;
 use axum::response::Response;
 use serde::{Deserialize, Serialize};
 
-/// Load a token by id, enforcing the ownership rule shared by get/revoke/rotate:
-/// a user may only act on their own tokens. A non-owner gets the same 404 as a
-/// missing id, so the endpoint never confirms another user's token exists. The
-/// `Err` is a ready-to-return response (404 / 500) so callers can `?` it.
+/// Load a token by id, enforcing the rules shared by get/revoke/rotate: a user
+/// may only act on their own tokens, and login sessions are off-limits to the
+/// PAT-management API (they are managed only via `/login` and `/logout`). A
+/// non-owner — or a session row — gets the same 404 as a missing id, so the
+/// endpoint never confirms another user's token nor a session exists. The `Err`
+/// is a ready-to-return response (404 / 500) so callers can `?` it.
 ///
-/// Centralising this means the IDOR guard (`token.user_id == user_id`) lives in
-/// exactly one place — relaxing or fixing it can't be done in one handler and
-/// forgotten in the others.
+/// Centralising this means the IDOR guard (`token.user_id == user_id`) and the
+/// session boundary live in exactly one place — relaxing or fixing either can't
+/// be done in one handler and forgotten in the others.
 #[allow(clippy::result_large_err)]
 pub(crate) async fn find_owned(pool: &Db, id: &str, user_id: &str) -> Result<Token, Response> {
     match token::find(pool, id).await {
-        Ok(Some(t)) if t.user_id == user_id => Ok(t),
+        Ok(Some(t)) if t.user_id == user_id && !t.is_session() => Ok(t),
         Ok(_) => Err(problem_response(
             StatusCode::NOT_FOUND,
             "Not Found",

--- a/src/api/action/webhook/create.rs
+++ b/src/api/action/webhook/create.rs
@@ -119,9 +119,17 @@ mod tests {
     /// Mint a PAT with the given scopes and return its clear `ring_pat_…` value.
     async fn pat(pool: &sqlx::SqlitePool, scopes: &[&str]) -> String {
         let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        let (clear, _) = token::create(pool, ADMIN_ID, "test", &scopes, &[], None)
-            .await
-            .expect("create token");
+        let (clear, _) = token::create(
+            pool,
+            ADMIN_ID,
+            "test",
+            token::TokenKind::Pat,
+            &scopes,
+            &[],
+            None,
+        )
+        .await
+        .expect("create token");
         clear
     }
 

--- a/src/api/action/webhook/delete.rs
+++ b/src/api/action/webhook/delete.rs
@@ -60,9 +60,17 @@ mod tests {
 
     async fn pat(pool: &sqlx::SqlitePool, scopes: &[&str]) -> String {
         let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        let (clear, _) = token::create(pool, ADMIN_ID, "test", &scopes, &[], None)
-            .await
-            .expect("create token");
+        let (clear, _) = token::create(
+            pool,
+            ADMIN_ID,
+            "test",
+            token::TokenKind::Pat,
+            &scopes,
+            &[],
+            None,
+        )
+        .await
+        .expect("create token");
         clear
     }
 

--- a/src/api/action/webhook/events.rs
+++ b/src/api/action/webhook/events.rs
@@ -75,9 +75,17 @@ mod tests {
 
     async fn pat(pool: &sqlx::SqlitePool, scopes: &[&str]) -> String {
         let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        let (clear, _) = token::create(pool, ADMIN_ID, "test", &scopes, &[], None)
-            .await
-            .expect("create token");
+        let (clear, _) = token::create(
+            pool,
+            ADMIN_ID,
+            "test",
+            token::TokenKind::Pat,
+            &scopes,
+            &[],
+            None,
+        )
+        .await
+        .expect("create token");
         clear
     }
 

--- a/src/api/action/webhook/list.rs
+++ b/src/api/action/webhook/list.rs
@@ -38,9 +38,17 @@ mod tests {
 
     async fn pat(pool: &sqlx::SqlitePool, scopes: &[&str]) -> String {
         let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        let (clear, _) = token::create(pool, ADMIN_ID, "test", &scopes, &[], None)
-            .await
-            .expect("create token");
+        let (clear, _) = token::create(
+            pool,
+            ADMIN_ID,
+            "test",
+            token::TokenKind::Pat,
+            &scopes,
+            &[],
+            None,
+        )
+        .await
+        .expect("create token");
         clear
     }
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -35,11 +35,11 @@ use crate::models::users::User;
 /// the scopes and namespaces it was minted with.
 #[derive(Clone, Debug)]
 pub(crate) enum AuthSource {
-    /// Authenticated with a user session Bearer token: full access.
-    Bearer,
-    /// Authenticated with a scoped API token (PAT, `ring_pat_…`). Carries the
-    /// token's scopes and namespace boundary so handlers can enforce them via
-    /// [`require_scope`]. An empty `namespaces` means all namespaces.
+    /// Authenticated with a Bearer token from the `token` table — either a PAT
+    /// (`ring token create`) or a login session (`/login`, named "session",
+    /// scoped `admin`). Carries the token's scopes and namespace boundary so
+    /// handlers can enforce them via [`require_scope`]. An empty `namespaces`
+    /// means all namespaces; a session is `scopes = ["admin"]`, `namespaces = []`.
     Token {
         scopes: Vec<String>,
         namespaces: Vec<String>,
@@ -185,6 +185,16 @@ pub(crate) async fn auth_middleware(
         return next.run(req).await;
     }
 
+    // Logout is a self-action: any authenticated caller may revoke the exact
+    // token they are presenting (the handler resolves it from the bearer). It
+    // therefore needs no scope — gating it would wrongly block a narrowly-scoped
+    // PAT from logging itself out. A ticket never reaches here (returned above).
+    if req.method() == Method::POST
+        && req.extensions().get::<MatchedPath>().map(|m| m.as_str()) == Some("/logout")
+    {
+        return next.run(req).await;
+    }
+
     // Authorise: derive the scope this route requires and enforce it centrally.
     // The matched-path template (`/deployments/{id}`) is stable across ids, so
     // the table in `scope_for_route` stays small and reads like the router.
@@ -198,10 +208,12 @@ pub(crate) async fn auth_middleware(
                 return resp;
             }
         } else {
-            // Deny by default: a protected route with no scope mapping must
-            // not be reachable by a PAT. A session Bearer still passes (it has
-            // no scopes and is full-access), so this only locks down PATs.
-            if matches!(source, AuthSource::Token { .. }) {
+            // Deny by default: a protected route with no scope mapping is only
+            // reachable by a full-access (`admin`) token — i.e. a login session
+            // or an admin PAT. A narrower PAT is locked out, so a new handler
+            // can never ship silently reachable by every scoped token.
+            let is_admin = matches!(&source, AuthSource::Token { scopes, .. } if scopes.iter().any(|s| s == "admin"));
+            if !is_admin {
                 return forbidden("this route is not reachable with a scoped token");
             }
         }
@@ -214,24 +226,14 @@ pub(crate) async fn auth_middleware(
 /// extensions. Returns `Some(())` on success, `None` on any auth failure.
 /// Authorisation (scope/ticket-binding) is handled by the caller.
 async fn authenticate(state: &AppState, req: &mut Request) -> Option<()> {
-    // Bearer wins when present. Two kinds of Bearer token share this path:
-    // a scoped API token (PAT, recognised by its `ring_pat_` prefix) and the
-    // legacy full-access session token. PATs are tried first so a session
-    // token lookup never sees a PAT-shaped value.
+    // Bearer wins when present. PATs and login sessions are both rows in the
+    // `token` table, so a single resolver handles both.
     if let Some(token) = bearer_token(req) {
-        if token.starts_with(token_model::TOKEN_PREFIX) {
-            return resolve_api_token(state, req, &token).await;
-        }
-        return match users_model::find_by_token(&state.connection, &token).await {
-            Ok(user) => {
-                req.extensions_mut().insert(AuthContext {
-                    user,
-                    source: AuthSource::Bearer,
-                });
-                Some(())
-            }
-            Err(_) => None,
-        };
+        // Every Bearer credential — whether a PAT minted by `ring token create`
+        // or a login session minted by `/login` — is a `ring_pat_`-prefixed row
+        // in the `token` table. There is a single resolution path; a session is
+        // just a token named "session" scoped `admin`.
+        return resolve_api_token(state, req, &token).await;
     }
 
     // Fall back to a stream ticket. A ticket is only ever valid for the exact
@@ -301,17 +303,15 @@ async fn resolve_api_token(state: &AppState, req: &mut Request, clear: &str) -> 
 /// centrally, by [`auth_middleware`] using the route's mapped scope — handlers
 /// never call this directly.
 ///
-/// - A session `Bearer` identity (a logged-in human) passes unconditionally —
-///   PATs are the only credential that carries scopes, so this is fully
-///   backward compatible with existing dashboard/CLI usage.
-/// - A `Token` (PAT) identity must hold `required_scope` (or `admin`). The
-///   namespace boundary is enforced separately by [`require_namespace`], since
-///   a resource's namespace is only known after it is loaded.
+/// - A `Token` identity must hold `required_scope` (or `admin`). A login
+///   session is a `Token` scoped `admin`, so it passes unconditionally — fully
+///   backward compatible with existing dashboard/CLI usage. The namespace
+///   boundary is enforced separately by [`require_namespace`], since a
+///   resource's namespace is only known after it is loaded.
 /// - A `Ticket` identity never reaches scoped resources (logs-only) → 403.
 #[allow(clippy::result_large_err)]
 pub(crate) fn require_scope(source: &AuthSource, required_scope: &str) -> Result<(), Response> {
     match source {
-        AuthSource::Bearer => Ok(()),
         AuthSource::Token { scopes, .. } => {
             if scopes.iter().any(|s| s == "admin" || s == required_scope) {
                 Ok(())
@@ -334,9 +334,9 @@ pub(crate) fn require_scope(source: &AuthSource, required_scope: &str) -> Result
 /// namespaced resource fetched by id — the scope is already enforced centrally,
 /// but the namespace cannot be (it isn't known until the row is read).
 ///
-/// - `Bearer` (full-access human session) passes unconditionally.
-/// - `Token` (PAT) with an empty namespace list passes (all namespaces);
-///   otherwise the resource's namespace must be in the token's list, else 403.
+/// - `Token` with an empty namespace list passes (all namespaces) — this
+///   includes login sessions, which carry no namespace restriction; otherwise
+///   the resource's namespace must be in the token's list, else 403.
 /// - `Ticket` never reaches namespaced resources → 403.
 ///
 /// This is the per-handler half of the boundary that `scope_for_route` cannot
@@ -345,7 +345,6 @@ pub(crate) fn require_scope(source: &AuthSource, required_scope: &str) -> Result
 #[allow(clippy::result_large_err)]
 pub(crate) fn require_namespace(source: &AuthSource, namespace: &str) -> Result<(), Response> {
     match source {
-        AuthSource::Bearer => Ok(()),
         AuthSource::Token { namespaces, .. } => {
             if namespaces.is_empty() || namespaces.iter().any(|n| n == namespace) {
                 Ok(())
@@ -363,8 +362,8 @@ pub(crate) fn require_namespace(source: &AuthSource, namespace: &str) -> Result<
 /// Keep only the items whose namespace the caller is allowed to see. List
 /// endpoints can't use [`require_namespace`] (they return many resources across
 /// namespaces), so they filter their result set through this instead: a
-/// namespace-scoped PAT only ever sees its own namespaces, while a full-access
-/// session (Bearer) and an all-namespaces PAT see everything.
+/// namespace-scoped PAT only ever sees its own namespaces, while a login
+/// session and an all-namespaces PAT (both `namespaces = []`) see everything.
 ///
 /// `namespace_of` extracts the namespace from each item so this works for any
 /// resource type (secrets, configs, deployments).
@@ -374,8 +373,7 @@ pub(crate) fn filter_by_namespace<T>(
     namespace_of: impl Fn(&T) -> &str,
 ) -> Vec<T> {
     match source {
-        // Full access, or a PAT with no namespace restriction: see everything.
-        AuthSource::Bearer => items,
+        // A session or a PAT with no namespace restriction: see everything.
         AuthSource::Token { namespaces, .. } if namespaces.is_empty() => items,
         AuthSource::Token { namespaces, .. } => items
             .into_iter()
@@ -479,12 +477,13 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         match parts.extensions.get::<AuthContext>() {
-            Some(ctx) => match ctx.source {
-                AuthSource::Bearer => Ok(RequireFullAccess(ctx.user.clone())),
-                // A scoped API token is not a full-access session: routes that
-                // demand full access (and can't express a scope check) reject
-                // it. Handlers that want to admit an `admin`-scoped PAT should
-                // use `Auth` + `require_scope("admin", …)` instead.
+            Some(ctx) => match &ctx.source {
+                // Full access = an `admin`-scoped token. That covers both login
+                // sessions (always `admin`) and an explicitly admin-scoped PAT.
+                // A narrower PAT or a (logs-only) ticket is rejected.
+                AuthSource::Token { scopes, .. } if scopes.iter().any(|s| s == "admin") => {
+                    Ok(RequireFullAccess(ctx.user.clone()))
+                }
                 AuthSource::Token { .. } => Err(unauthorized()),
                 AuthSource::Ticket { .. } => Err(unauthorized()),
             },
@@ -515,11 +514,12 @@ mod tests {
     }
 
     #[test]
-    fn session_bearer_bypasses_scope_checks() {
-        // A logged-in human carries no scopes; require_scope must let them
-        // through unconditionally (backward compatible).
-        assert!(require_scope(&AuthSource::Bearer, "deployments:write").is_ok());
-        assert!(require_namespace(&AuthSource::Bearer, "prod").is_ok());
+    fn session_token_bypasses_scope_checks() {
+        // A login session is a `Token` scoped `admin` with no namespace
+        // restriction. require_scope/require_namespace must let it through
+        // unconditionally (backward compatible with the old `Bearer` session).
+        assert!(require_scope(&pat(&["admin"], &[]), "deployments:write").is_ok());
+        assert!(require_namespace(&pat(&["admin"], &[]), "prod").is_ok());
     }
 
     #[test]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -13,6 +13,7 @@ use tower::{BoxError, ServiceBuilder};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use crate::api::action::login::login;
+use crate::api::action::logout::logout;
 use crate::api::action::stream_ticket::stream_ticket;
 use crate::config::config::Config;
 
@@ -109,6 +110,7 @@ pub(crate) fn router(state: AppState) -> Router {
 
     // All other routes: protected + 10s timeout.
     let api_routes = Router::new()
+        .route("/logout", post(logout))
         .route("/auth/stream-ticket", post(stream_ticket))
         .route("/deployments", get(deployment_list).post(deployment_create))
         .route(

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -39,7 +39,6 @@ pub(crate) fn error(msg: &str) -> String {
 }
 
 /// Yellow — a warning; the command continued.
-#[allow(dead_code)] // Completes the semantic palette (error/warn/success); used as the CLI grows.
 pub(crate) fn warn(msg: &str) -> String {
     paint(colour_enabled(), || msg.yellow().to_string(), msg)
 }
@@ -55,6 +54,13 @@ pub(crate) fn success(msg: &str) -> String {
 /// plain text) and callers don't each repeat the colouring.
 pub(crate) fn print_error(msg: &str) {
     eprintln!("{}", error(msg));
+}
+
+/// Print a warning line to stderr, coloured yellow when colour is on. For a
+/// problem the command recovered from (e.g. a best-effort step that failed but
+/// did not block the operation).
+pub(crate) fn print_warning(msg: &str) {
+    eprintln!("{}", warn(msg));
 }
 
 /// Print a success line to stdout, coloured green when colour is on.

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,0 +1,80 @@
+use crate::cli::problem_json::transport_error;
+use crate::cli::style;
+use crate::config::auth::{AuthToken, load_auth_config};
+use crate::config::config::Config;
+use crate::config::config::get_config_dir;
+use crate::exit_code;
+use clap::ArgMatches;
+use clap::Command;
+use std::collections::HashMap;
+use std::fs;
+
+pub(crate) fn command_config() -> Command {
+    Command::new("logout").about("Revoke the current session and forget the stored token")
+}
+
+pub(crate) async fn execute(
+    _args: &ArgMatches,
+    mut configuration: Config,
+    client: &reqwest::Client,
+) {
+    let context = configuration.name.clone();
+    let auth = load_auth_config(context.clone());
+
+    // Revoke server-side first so the token can't be replayed. Best-effort: if
+    // the server is unreachable or the token is already invalid we still drop
+    // the local credential — the user asked to log out.
+    if !auth.token.is_empty() {
+        let base_url = configuration.get_api_url();
+        let api_url = format!("{}/logout", base_url);
+        match client
+            .post(&api_url)
+            .header("Authorization", format!("Bearer {}", auth.token))
+            .send()
+            .await
+        {
+            // The server reached us but refused the revoke (e.g. 500). Warn so a
+            // failed server-side revoke isn't silently indistinguishable from a
+            // clean 204 — but don't abort: the local token is still removed. A
+            // 401 means the token was already invalid, which is a no-op success.
+            Ok(response) => {
+                let status = response.status();
+                if !status.is_success() && status != reqwest::StatusCode::UNAUTHORIZED {
+                    style::print_warning(&format!(
+                        "server did not confirm revocation (HTTP {}); removing the local token anyway",
+                        status.as_u16()
+                    ));
+                }
+            }
+            Err(err) => {
+                // Surface the transport problem but don't abort: the local
+                // token is still removed below.
+                style::print_error(&transport_error(&err, &base_url));
+            }
+        }
+    }
+
+    // Remove just this context's entry from auth.json, leaving other contexts
+    // intact. If the file or entry is already gone, that's a successful no-op.
+    let config_file = format!("{}/auth.json", get_config_dir());
+    if let Ok(content) = fs::read_to_string(&config_file) {
+        let mut context_auth: HashMap<String, AuthToken> =
+            serde_json::from_str(&content).unwrap_or_default();
+        if context_auth.remove(&context).is_some() {
+            match serde_json::to_string(&context_auth) {
+                Ok(serialized) => {
+                    if let Err(e) = fs::write(&config_file, serialized) {
+                        eprintln!("Failed to update auth file: {}", e);
+                        exit_code::ExitCode::General.exit();
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to serialize auth data: {}", e);
+                    exit_code::ExitCode::General.exit();
+                }
+            }
+        }
+    }
+
+    style::print_success(&format!("Logged out of context '{}'", context));
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod server;
 
 pub(crate) mod config;
 pub(crate) mod login;
+pub(crate) mod logout;
 pub(crate) mod namespace;
 pub(crate) mod node;
 pub(crate) mod secret;

--- a/src/fixtures/users.rs
+++ b/src/fixtures/users.rs
@@ -21,7 +21,7 @@ pub async fn load(pool: &SqlitePool) {
     // A deletable target account for the delete() test. Plain 'user', distinct
     // username so it never collides with the admin login lookup.
     sqlx::query(
-        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO user (id, created_at, status, role, username, password) VALUES (?, ?, ?, ?, ?, ?)"
     )
         .bind("5b5c370a-cdbf-4fa4-826e-1eea4d8f7d47")
         .bind(chrono::Utc::now().to_rfc3339())
@@ -29,7 +29,6 @@ pub async fn load(pool: &SqlitePool) {
         .bind("user")
         .bind("deletable.user")
         .bind(CHANGEME_HASH)
-        .bind("deletabletoken")
         .execute(pool)
         .await
         .unwrap();
@@ -37,7 +36,7 @@ pub async fn load(pool: &SqlitePool) {
     // A second plain 'user' used to assert a non-admin cannot touch other
     // accounts (IDOR regression tests).
     sqlx::query(
-        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO user (id, created_at, status, role, username, password) VALUES (?, ?, ?, ?, ?, ?)"
     )
         .bind("6c6d481b-debf-5gb5-937f-2ffa5e9f8e58")
         .bind(chrono::Utc::now().to_rfc3339())
@@ -45,7 +44,6 @@ pub async fn load(pool: &SqlitePool) {
         .bind("user")
         .bind("john.doe")
         .bind(CHANGEME_HASH)
-        .bind("john_token")
         .execute(pool)
         .await
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() {
         .subcommand(commands::dashboard::command_config())
         .subcommand(commands::doctor::command_config())
         .subcommand(commands::login::command_config())
+        .subcommand(commands::logout::command_config())
         .subcommand(
             Command::new("deployment")
                 .args_conflicts_with_subcommands(true)
@@ -255,6 +256,9 @@ async fn main() {
         }
         Some(("login", sub_matches)) => {
             commands::login::execute(sub_matches, config, &client).await;
+        }
+        Some(("logout", sub_matches)) => {
+            commands::logout::execute(sub_matches, config, &client).await;
         }
         Some(("user", sub_matches)) => {
             let user_command = sub_matches.subcommand().unwrap_or(("list", sub_matches));

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -11,6 +11,41 @@ use uuid::Uuid;
 /// to the session-token path, and lets the CLI recognise its own output.
 pub(crate) const TOKEN_PREFIX: &str = "ring_pat_";
 
+/// What a token row is, stored in the `kind` column. A login session and a
+/// PAT live in the same table but are different things: a session is minted by
+/// `/login`, carries full access, and is managed only through `/logout`; a PAT
+/// is created and managed by the user via `ring token`. Branching on `kind`
+/// (rather than a magic `name`) keeps `name` a free-text label — a user may
+/// name a PAT "session" without it colliding with the session machinery.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TokenKind {
+    /// A login session minted by `/login` (full access, ended by `/logout`).
+    Session,
+    /// A Personal Access Token created via `ring token create`.
+    Pat,
+}
+
+impl TokenKind {
+    /// On-disk value in the `kind` column. Must match the migration's
+    /// `DEFAULT 'pat'` and backfill (`20220101000022_drop_user_token.sql`).
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            TokenKind::Session => "session",
+            TokenKind::Pat => "pat",
+        }
+    }
+
+    /// Parse the stored value back, defaulting to `Pat` for anything
+    /// unexpected — a token we can't classify is treated as a managed PAT
+    /// (visible, addressable), never silently hidden as a session.
+    fn from_str(s: &str) -> Self {
+        match s {
+            "session" => TokenKind::Session,
+            _ => TokenKind::Pat,
+        }
+    }
+}
+
 /// Number of leading characters of the clear token kept in `token_prefix` for
 /// display in listings (e.g. "ring_pat_a1b2c3"). Enough to disambiguate, not
 /// enough to be a secret.
@@ -41,6 +76,7 @@ pub(crate) struct Token {
     pub(crate) id: String,
     pub(crate) user_id: String,
     pub(crate) name: String,
+    pub(crate) kind: TokenKind,
     pub(crate) token_prefix: String,
     pub(crate) scopes: Vec<String>,
     /// Empty = all namespaces.
@@ -56,6 +92,7 @@ struct TokenRow {
     id: String,
     user_id: String,
     name: String,
+    kind: String,
     /// Selected by `SELECT_COLUMNS` for symmetry with the table but not mapped
     /// onto `Token`: auth looks tokens up *by* this hash in SQL, nothing reads
     /// the value back off a loaded token.
@@ -71,7 +108,7 @@ struct TokenRow {
     revoked_at: Option<String>,
 }
 
-const SELECT_COLUMNS: &str = "id, user_id, name, token_hash, token_prefix, scopes, namespaces, created_at, expire_at, last_used_at, revoked_at";
+const SELECT_COLUMNS: &str = "id, user_id, name, kind, token_hash, token_prefix, scopes, namespaces, created_at, expire_at, last_used_at, revoked_at";
 
 impl From<TokenRow> for Token {
     fn from(row: TokenRow) -> Self {
@@ -95,6 +132,7 @@ impl From<TokenRow> for Token {
             id: row.id,
             user_id: row.user_id,
             name: row.name,
+            kind: TokenKind::from_str(&row.kind),
             token_prefix: row.token_prefix,
             scopes,
             namespaces,
@@ -129,6 +167,13 @@ impl Token {
     pub(crate) fn is_active(&self) -> bool {
         !self.is_revoked() && !self.is_expired()
     }
+
+    /// True when this row is a login session (not a user-managed PAT). Sessions
+    /// are hidden from `ring token list` and not addressable by id — they are
+    /// managed only through `/login` and `/logout`.
+    pub(crate) fn is_session(&self) -> bool {
+        self.kind == TokenKind::Session
+    }
 }
 
 /// SHA-256 of the clear token, hex-encoded. Tokens are high-entropy secrets
@@ -162,6 +207,7 @@ pub(crate) async fn create(
     pool: &SqlitePool,
     user_id: &str,
     name: &str,
+    kind: TokenKind,
     scopes: &[String],
     namespaces: &[String],
     expire_at: Option<&str>,
@@ -173,12 +219,13 @@ pub(crate) async fn create(
     let namespaces_json = serde_json::to_string(namespaces).unwrap_or_else(|_| "[]".to_string());
 
     sqlx::query(
-        "INSERT INTO token (id, user_id, name, token_hash, token_prefix, scopes, namespaces, created_at, expire_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO token (id, user_id, name, kind, token_hash, token_prefix, scopes, namespaces, created_at, expire_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(user_id)
     .bind(name)
+    .bind(kind.as_str())
     .bind(&hash)
     .bind(&prefix)
     .bind(&scopes_json)
@@ -192,6 +239,7 @@ pub(crate) async fn create(
         id,
         user_id: user_id.to_string(),
         name: name.to_string(),
+        kind,
         token_prefix: prefix,
         scopes: scopes.to_vec(),
         namespaces: namespaces.to_vec(),
@@ -234,12 +282,15 @@ pub(crate) async fn find_all_for_user(
     pool: &SqlitePool,
     user_id: &str,
 ) -> Result<Vec<Token>, sqlx::Error> {
+    // Exclude login sessions: they live in this table but are not PATs the user
+    // created or manages, so they must not appear in `ring token list`.
     let sql = format!(
-        "SELECT {} FROM token WHERE user_id = ? ORDER BY created_at DESC",
+        "SELECT {} FROM token WHERE user_id = ? AND kind = ? ORDER BY created_at DESC",
         SELECT_COLUMNS
     );
     let rows = sqlx::query_as::<_, TokenRow>(&sql)
         .bind(user_id)
+        .bind(TokenKind::Pat.as_str())
         .fetch_all(pool)
         .await?;
 
@@ -269,6 +320,7 @@ pub(crate) async fn rotate(
         pool,
         &existing.user_id,
         &existing.name,
+        existing.kind,
         &existing.scopes,
         &existing.namespaces,
         existing.expire_at.as_deref(),
@@ -320,6 +372,7 @@ mod tests {
             id: "t".into(),
             user_id: "u".into(),
             name: "n".into(),
+            kind: TokenKind::Pat,
             token_prefix: "ring_pat_x".into(),
             scopes: scopes.iter().map(|s| s.to_string()).collect(),
             namespaces: namespaces.iter().map(|s| s.to_string()).collect(),

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -21,8 +21,6 @@ pub(crate) struct User {
     pub(crate) username: String,
     #[serde(skip_serializing)]
     pub(crate) password: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub(crate) token: String,
     #[serde(skip_serializing)]
     pub(crate) login_at: Option<String>,
 }
@@ -36,12 +34,11 @@ struct UserRow {
     role: String,
     username: String,
     password: String,
-    token: Option<String>,
     login_at: Option<String>,
 }
 
 const SELECT_COLUMNS: &str =
-    "id, created_at, updated_at, status, role, username, password, token, login_at";
+    "id, created_at, updated_at, status, role, username, password, login_at";
 
 fn default_role() -> String {
     "user".to_string()
@@ -64,7 +61,6 @@ impl From<UserRow> for User {
             role: row.role,
             username: row.username,
             password: row.password,
-            token: row.token.unwrap_or_default(),
             login_at: row.login_at,
         }
     }
@@ -93,16 +89,6 @@ pub(crate) async fn find_by_username(
     Ok(row.map(User::from))
 }
 
-pub(crate) async fn find_by_token(pool: &SqlitePool, token: &str) -> Result<User, sqlx::Error> {
-    let sql = format!("SELECT {} FROM user WHERE token = ?", SELECT_COLUMNS);
-    let row = sqlx::query_as::<_, UserRow>(&sql)
-        .bind(token)
-        .fetch_one(pool)
-        .await?;
-
-    Ok(User::from(row))
-}
-
 pub(crate) async fn find_all(pool: &SqlitePool) -> Result<Vec<User>, sqlx::Error> {
     let sql = format!("SELECT {} FROM user", SELECT_COLUMNS);
     let rows = sqlx::query_as::<_, UserRow>(&sql).fetch_all(pool).await?;
@@ -110,9 +96,11 @@ pub(crate) async fn find_all(pool: &SqlitePool) -> Result<Vec<User>, sqlx::Error
     Ok(rows.into_iter().map(User::from).collect())
 }
 
-pub(crate) async fn login(pool: &SqlitePool, user: User) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE user SET token = ?, login_at = datetime() WHERE id = ?")
-        .bind(&user.token)
+/// Record a successful login by stamping `login_at`. The session credential
+/// itself is no longer stored on the user row — it lives in the `token` table
+/// (minted by the login handler); this only touches the last-login timestamp.
+pub(crate) async fn login(pool: &SqlitePool, user: &User) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE user SET login_at = datetime() WHERE id = ?")
         .bind(&user.id)
         .execute(pool)
         .await?;
@@ -128,14 +116,13 @@ pub(crate) async fn create(
     // role is hard-coded to 'user': there is no API path to create an admin
     // (that would be a privilege-escalation vector). Admin is set out of band.
     sqlx::query(
-        "INSERT INTO user (id, created_at, status, role, username, password, token) VALUES (?, datetime(), ?, ?, ?, ?, ?)"
+        "INSERT INTO user (id, created_at, status, role, username, password) VALUES (?, datetime(), ?, ?, ?, ?)"
     )
     .bind(Uuid::new_v4().to_string())
     .bind("active")
     .bind("user")
     .bind(username)
     .bind(password)
-    .bind(Uuid::new_v4().to_string())
     .execute(pool)
     .await?;
 

--- a/tests/e2e/server/t11_logout.sh
+++ b/tests/e2e/server/t11_logout.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# T11-server: login sessions are revocable via POST /logout, end to end against
+# the real binary.
+#
+# Background: the login session is no longer a plaintext `user.token`; it is a
+# row in the `token` table (kind `session`, scoped `admin`), hashed at rest and
+# revocable. This proves the wire behaviour unit tests can't:
+#
+# Invariants:
+#   1. A fresh login token opens a protected route (200).
+#   2. POST /logout with that token returns 204 and revokes it: the SAME token
+#      is then rejected (401).
+#   3. Replaying the revoked token on /logout is rejected by auth (401) — a dead
+#      token never reaches the handler.
+#   4. A fresh login after logout mints a new, working session (200).
+#   5. `ring login` / `ring logout` CLI round-trip: after `ring logout`, the
+#      stored credential no longer authenticates (`ring deployment list` fails).
+#   6. The session never appears in `ring token list` (it is not a PAT).
+#   (run 3× to confirm stability — see t1..t9 convention.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t11-server-salt"
+scheduler.interval = 1
+
+# A runtime must be enabled or the server refuses to start (opt-in guard, #138).
+# This test never deploys anything; Docker is just the cheapest runtime to
+# satisfy the guard.
+[server.runtime.docker]
+enabled = true
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="$KEY"
+
+log "== T11-server: logout / session revocation =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+# HTTP status helper for a Bearer credential hitting an endpoint.
+code() { # METHOD PATH TOKEN
+  curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+    -X "$1" "$URL$2" -H "Authorization: Bearer $3"
+}
+
+login() {
+  curl -fsS -X POST "$URL/login" \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"admin","password":"changeme"}' \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
+}
+
+# --- Invariant 1: a fresh session opens a protected route ---
+SESSION=$(login)
+[ -n "$SESSION" ] || fail "1: could not obtain a session token"
+[ "$(code GET /deployments "$SESSION")" = "200" ] \
+  || fail "1: fresh session must reach /deployments (200)"
+log "1 (fresh session works): 200"
+
+# --- Invariant 2: logout returns 204 and revokes the token ---
+LOGOUT_CODE=$(code POST /logout "$SESSION")
+[ "$LOGOUT_CODE" = "204" ] || fail "2: POST /logout must be 204, got $LOGOUT_CODE"
+[ "$(code GET /deployments "$SESSION")" = "401" ] \
+  || fail "2: revoked session must be rejected (401)"
+log "2 (logout revokes the session): 204 then 401"
+
+# --- Invariant 3: replaying the dead token on /logout → 401 (auth rejects) ---
+[ "$(code POST /logout "$SESSION")" = "401" ] \
+  || fail "3: replayed revoked token on /logout must be 401"
+log "3 (revoked token replay): 401"
+
+# --- Invariant 4: a fresh login after logout works ---
+SESSION2=$(login)
+[ -n "$SESSION2" ] || fail "4: could not obtain a second session token"
+[ "$SESSION2" != "$SESSION" ] || fail "4: new login must mint a distinct token"
+[ "$(code GET /deployments "$SESSION2")" = "200" ] \
+  || fail "4: fresh post-logout session must work (200)"
+log "4 (fresh login after logout): distinct token, 200"
+
+# --- Invariant 6: the session is not listed as a PAT ---
+LIST=$(curl -fsS "$URL/tokens" -H "Authorization: Bearer $SESSION2")
+echo "$LIST" | grep -q '"name":"session"' \
+  && { echo "$LIST" >&2; fail "6: session must not appear in /tokens"; }
+log "6 (session hidden from token list): ok"
+
+# --- Invariant 5: CLI login → logout round-trip ---
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "5: ring login failed"
+"$RING_BIN" deployment list --output json > /dev/null \
+  || fail "5: ring deployment list failed after login"
+"$RING_BIN" logout > /dev/null \
+  || fail "5: ring logout failed"
+# After logout the stored credential is gone, so the next list must fail
+# (non-zero exit) rather than silently succeeding.
+if "$RING_BIN" deployment list --output json > /dev/null 2>&1; then
+  fail "5: ring deployment list must fail after ring logout"
+fi
+log "5 (CLI login/logout round-trip): list refused after logout"
+
+log "== T11-server: all invariants passed =="

--- a/tests/e2e/server/t2_auth_middleware.sh
+++ b/tests/e2e/server/t2_auth_middleware.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# T2-server: end-to-end validation of the single auth middleware (PR #96).
+#
+# PR #96 replaced the per-handler `User` extractor with one middleware applied
+# at the router via `route_layer`, identity passed through a request extension.
+# The Rust suite covers this in-process with axum_test::TestServer. This test
+# proves the SAME invariants hold for the *real compiled binary* served over a
+# TCP socket and driven by a real HTTP client + the real `ring` CLI — the layer
+# an in-process test cannot exercise (socket, CLI auth.json round-trip, live SSE
+# stream through the middleware without the timeout layer killing it).
+#
+# Invariants exercised, mapped to the refactor's security claims:
+#   1. /healthz is public               → 200, no token
+#   2. /login is public                 → 200 + token (the CLI auth path)
+#   3. protected route, no token        → 401
+#   4. protected route, garbage token   → 401
+#   5. protected route, valid Bearer    → 200 (full-access path; CLI daily use)
+#   6. unknown route, no token          → 404 NOT 401  (the route_layer pitfall)
+#   7. stream ticket scoping:
+#        a. mint via Bearer             → 200 + ticket
+#        b. ticket on its own logs route→ 200 (SSE reached through middleware)
+#        c. ticket on a different id    → 401 (scope is per-deployment)
+#        d. ticket on a non-logs route  → 401 (tickets are logs-only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t2-server-salt"
+scheduler.interval = 1
+
+# A runtime must be enabled or the server refuses to start (opt-in guard, #138).
+[server.runtime.docker]
+enabled = true
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+# All CLI invocations share this config dir, so `ring login` writes auth.json
+# here and later `ring` commands read the token back — the real CLI round-trip.
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="$KEY"
+
+log "== T2-server: single auth middleware (PR #96) =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+# Returns the HTTP status code only.
+code() { curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$@"; }
+
+# --- Invariant 1: /healthz is public ---
+c=$(code "$URL/healthz")
+[ "$c" = "200" ] || fail "1: /healthz must be 200 without a token, got $c"
+log "1 (/healthz public): 200"
+
+# --- Invariant 2: /login is public, returns a token ---
+login_body=$(curl -s --max-time 5 -X POST "$URL/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"changeme"}')
+TOKEN=$(echo "$login_body" | jq -r '.token // empty')
+[ -n "$TOKEN" ] || { echo "$login_body" >&2; fail "2: /login must return a token"; }
+log "2 (/login public): got token"
+
+# --- Invariant 3: protected route without token → 401 ---
+c=$(code "$URL/deployments")
+[ "$c" = "401" ] || fail "3: /deployments without token must be 401, got $c"
+log "3 (no token): 401"
+
+# --- Invariant 4: garbage token → 401 ---
+c=$(code -H "Authorization: Bearer not-a-real-token" "$URL/deployments")
+[ "$c" = "401" ] || fail "4: garbage Bearer must be 401, got $c"
+log "4 (garbage token): 401"
+
+# --- Invariant 5: valid Bearer → 200 (raw HTTP) ---
+c=$(code -H "Authorization: Bearer $TOKEN" "$URL/deployments")
+[ "$c" = "200" ] || fail "5: valid Bearer on /deployments must be 200, got $c"
+log "5 (valid Bearer, raw HTTP): 200"
+
+# --- Invariant 5b: the real CLI auth round-trip (login → auth.json → list) ---
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "5b: ring login failed against the real server"
+"$RING_BIN" deployment list --output json > /dev/null \
+  || fail "5b: ring deployment list failed after CLI login (auth.json round-trip broken)"
+log "5b (CLI login + deployment list): ok"
+
+# --- Invariant 6: unknown route without token → 404, NOT 401 ---
+# This is the route_layer pitfall the refactor explicitly guards against:
+# auth must not turn a missing route into a 401.
+c=$(code "$URL/does-not-exist")
+[ "$c" = "404" ] || fail "6: unknown route must be 404 (not $c) — route_layer leaking auth onto unmatched routes"
+log "6 (unknown route, no token): 404 not 401"
+
+# --- Invariant 7a: mint a stream ticket via Bearer ---
+mint() {
+  curl -s --max-time 5 -X POST "$URL/auth/stream-ticket" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "{\"scope\":\"deployment:logs:$1\"}"
+}
+ticket_body=$(mint dep1)
+TICKET=$(echo "$ticket_body" | jq -r '.ticket // empty')
+[ -n "$TICKET" ] || { echo "$ticket_body" >&2; fail "7a: stream-ticket mint must return a ticket"; }
+log "7a (mint via Bearer): got ticket"
+
+# --- Invariant 7b: ticket opens its own scoped logs route (live SSE) ---
+# The logs route has no timeout layer; the middleware only wraps the head, so
+# the stream must start. We treat "connection established + first bytes / clean
+# timeout" as success and assert the status line is 200, not 401.
+c=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 \
+  "$URL/deployments/dep1/logs?ticket=$TICKET" || true)
+# curl exits 28 on --max-time for a never-ending SSE stream; in that case it
+# still captured the 200 status line. Empty means it was cut before headers.
+if [ "$c" != "200" ] && [ -n "$c" ] && [ "$c" != "000" ]; then
+  fail "7b: ticket on its own logs route must be 200, got $c"
+fi
+log "7b (ticket on own logs route): reached handler (status ${c:-stream})"
+
+# --- Invariant 7c: ticket is per-deployment — wrong id → 401 ---
+# Mint a fresh ticket: tickets are single-use, 7b consumed the first one.
+TICKET2=$(mint dep1 | jq -r '.ticket')
+c=$(code "$URL/deployments/dep2/logs?ticket=$TICKET2")
+[ "$c" = "401" ] || fail "7c: dep1 ticket on dep2 logs must be 401, got $c"
+log "7c (ticket on different deployment): 401"
+
+# --- Invariant 7d: a ticket is logs-only — non-logs route → 401 ---
+TICKET3=$(mint dep1 | jq -r '.ticket')
+c=$(code "$URL/deployments?ticket=$TICKET3")
+[ "$c" = "401" ] || fail "7d: ticket on non-logs route must be 401, got $c"
+log "7d (ticket on non-logs route): 401"
+
+log "== T2-server: PASS =="

--- a/tests/e2e/server/t9_api_tokens.sh
+++ b/tests/e2e/server/t9_api_tokens.sh
@@ -47,6 +47,10 @@ api.scheme = "http"
 api.port = $PORT
 user.salt = "t9-server-salt"
 scheduler.interval = 1
+
+# A runtime must be enabled or the server refuses to start (opt-in guard, #138).
+[server.runtime.docker]
+enabled = true
 EOF
 
 SRV_PID=""
@@ -124,7 +128,29 @@ echo "$LIST" | grep -q "$PAT" \
   && { echo "$LIST" >&2; fail "1: GET /tokens leaked the clear secret"; }
 echo "$LIST" | grep -q '"token_prefix"' \
   || { echo "$LIST" >&2; fail "1: GET /tokens should expose token_prefix"; }
-log "1: clear token shown once, never returned by list"
+# The login session is a row in the same `token` table, but it must NOT appear
+# in the user-facing token list (it is not a PAT the user manages).
+echo "$LIST" | grep -q '"name":"session"' \
+  && { echo "$LIST" >&2; fail "1: GET /tokens must not list the login session"; }
+log "1: clear token shown once, never returned by list, session hidden"
+
+# --- Invariant 1b: a PAT may be named "session" without being hidden ---
+# Sessions are distinguished by their `kind` column, not their name, so a
+# user-created PAT literally named "session" must stay listed and addressable
+# (the magic-name model used to swallow it from the list). Create one, confirm
+# it appears, then revoke it so it doesn't pollute later assertions.
+PAT_SESSION=$("$RING_BIN" token create session --scope deployments:read 2>/dev/null)
+echo "$PAT_SESSION" | grep -q '^ring_pat_' \
+  || { echo "$PAT_SESSION" >&2; fail "1b: could not create a PAT named 'session'"; }
+LIST_S=$(curl -fsS "$URL/tokens" -H "Authorization: Bearer $SESSION")
+echo "$LIST_S" | grep -q '"name":"session"' \
+  || { echo "$LIST_S" >&2; fail "1b: a PAT named 'session' must be listed"; }
+SESSION_PAT_ID=$(echo "$LIST_S" | jq -r '.[] | select(.name=="session") | .id' | head -n1)
+[ -n "$SESSION_PAT_ID" ] && [ "$SESSION_PAT_ID" != "null" ] \
+  || { echo "$LIST_S" >&2; fail "1b: PAT named 'session' must be addressable by id"; }
+"$RING_BIN" token revoke "$SESSION_PAT_ID" --yes >/dev/null 2>&1 \
+  || fail "1b: a PAT named 'session' must be revocable by id"
+log "1b: a PAT named 'session' is listed and manageable (kind, not name)"
 
 # --- Invariant 2: PAT with deployments:read reaches the read endpoint ---
 [ "$(code GET /deployments "$PAT")" = "200" ] \


### PR DESCRIPTION
## What

The login session token (`user.token`) was the security debt flagged in the roadmap: stored **plaintext**, **one per user and never regenerated** (a 2nd login returned the same secret), **never revocable** (no logout), seeded as a UUID at user creation, and generated with a thread-local PRNG instead of a CSPRNG.

This drops `user.token` entirely and makes the login session a row in the existing `token` table (the PAT system): hashed at rest (SHA-256), minted fresh on every login, scoped `admin` (full access — same semantics as before), and revocable via a new `POST /logout`. The two divergent "auth token" implementations are now one.

## Behaviour

- **One auth path**: every Bearer credential — PAT or session — is a `ring_pat_…` row resolved by `resolve_api_token`. The legacy `AuthSource::Bearer` branch and `users_model::find_by_token` are gone.
- **Multi-session, no expiry**: each login mints its own token (no more shared secret); the session lives until `POST /logout`. Machine-to-machine callers are unaffected — they use long-lived PATs they control.
- **Sessions are hidden** from `ring token list` / `GET /tokens` (reserved name `session`), and never revocable as if they were PATs.
- **`POST /logout`** revokes the exact token presented in the `Authorization` header; idempotent and non-revealing (always 204). Reachable by any authenticated caller (self-action, no scope gate).
- **`admin` keeps full access**: `require_scope`/`require_namespace`/`RequireFullAccess`/deny-by-default all treat an `admin`-scoped token as full access, so dashboard and CLI behaviour is unchanged.

## Surfaces

- New `ring logout` CLI: revokes server-side, then clears the context entry from `auth.json` (best-effort — local token removed even if the server is down).
- Dashboard "Sign out" now calls `POST /logout` before clearing localStorage.
- Migration `20220101000022_drop_user_token.sql`.

## Tests & docs

- Unit: session token is `ring_pat_`-prefixed, authenticates a protected route, two logins differ, session hidden from `/tokens`; logout revokes + idempotency + fresh-login-after-logout.
- e2e: new `t11_logout.sh` (6 invariants, 3× stable). `t2`/`t9` updated — they were silently broken on `main` since the opt-in runtime guard (#138) landed (no runtime enabled → server refuses to boot); added a `[server.runtime.docker]` block so the server e2e boot again.
- Docs: `reference/api.md` (unified model + `POST /logout`), `reference/cli.md` (`ring logout`, multi-session).

584 cargo tests pass, clippy clean, dashboard type-check clean.