### PR TITLE
fix(firecracker): re-adopt instance networking across ring-server restarts

### DIFF
--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -124,8 +124,9 @@ Ring copies the rootfs per instance (so replicas and reboots don't share guest s
 - **No volumes** — `volumes:` are not mounted yet (virtio-fs reuse is planned)
 - **No `command` health checks** — needs an in-guest agent over vsock, like Cloud Hypervisor
 - **No metrics** and **no `kind: job`** — a `job` deployment is treated as a worker
-- **No reconciliation across `ring-server` restarts** — instances tracked in-process are not re-adopted after a restart
 - Crash detection is tick-bound (no event stream), and `labels` are silently ignored
+
+A `ring-server` restart is transparent: running microVMs (and their persistent host taps) survive it, and the reconciler re-adopts them — re-deriving each instance's network from its id and re-spawning the host port-forwarders the old process took down — so a deployment keeps its guest state and its published ports across a restart.
 
 ## Choosing
 

--- a/src/hypervisor/port_forwarder.rs
+++ b/src/hypervisor/port_forwarder.rs
@@ -64,6 +64,69 @@ impl Drop for PortForwarder {
     }
 }
 
+/// The `socat` listen address for a forwarder — the exact argv token used both
+/// to spawn it and to recognise it in `/proc` later. Keeping one source of
+/// truth means an orphan left by a previous `ring-server` is matched by the
+/// same string that created it.
+fn listen_arg(host_ip: &str, published_port: u16, protocol: PortProtocol) -> String {
+    let proto = match protocol {
+        PortProtocol::Tcp => "TCP4",
+        PortProtocol::Udp => "UDP4",
+    };
+    if host_ip == DEFAULT_HOST_IP {
+        format!("{}-LISTEN:{},reuseaddr,fork", proto, published_port)
+    } else {
+        format!(
+            "{}-LISTEN:{},reuseaddr,fork,bind={}",
+            proto, published_port, host_ip
+        )
+    }
+}
+
+/// SIGKILL any `socat` whose command line carries this exact listen address.
+/// Used before re-spawning a forwarder when re-adopting an instance after a
+/// `ring-server` restart: a forwarder SIGKILLed along with the old server is
+/// gone, but one orphaned by an unclean exit is reparented to init and still
+/// holds the port — left alone, the re-spawn would hit `Address already in use`.
+/// Matching the full listen token (not just the port number) avoids killing an
+/// unrelated socat that merely mentions the same port elsewhere on its line.
+pub(crate) fn kill_orphan_forwarder(
+    host_ip: Option<&str>,
+    published_port: u16,
+    protocol: PortProtocol,
+) {
+    let needle = listen_arg(host_ip.unwrap_or(DEFAULT_HOST_IP), published_port, protocol);
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|s| s.parse::<i32>().ok()) else {
+            continue;
+        };
+        let Ok(cmdline) = std::fs::read(format!("/proc/{}/cmdline", pid)) else {
+            continue;
+        };
+        // argv is NUL-separated; argv[0] must be socat and some arg must equal
+        // the listen token exactly.
+        let mut args = cmdline.split(|&b| b == 0);
+        let is_socat = args
+            .next()
+            .map(|a0| a0.ends_with(b"socat"))
+            .unwrap_or(false);
+        if !is_socat {
+            continue;
+        }
+        if args.any(|arg| arg == needle.as_bytes()) {
+            // SAFETY: kill(2) with a pid we just read from /proc; ESRCH if it
+            // already exited is harmless.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
 /// Spawn a `socat` that forwards `<host_ip>:<published>` to
 /// `<guest_ip>:<target>`. `host_ip` is `None` for the default (all
 /// interfaces). Returns once the child has been spawned (we do not wait for
@@ -99,14 +162,7 @@ pub(crate) async fn spawn_forwarder(
         PortProtocol::Tcp => "TCP4",
         PortProtocol::Udp => "UDP4",
     };
-    let listen = if host_ip == DEFAULT_HOST_IP {
-        format!("{}-LISTEN:{},reuseaddr,fork", proto, published_port)
-    } else {
-        format!(
-            "{}-LISTEN:{},reuseaddr,fork,bind={}",
-            proto, published_port, host_ip
-        )
-    };
+    let listen = listen_arg(host_ip, published_port, protocol);
     let connect = format!("{}:{}:{}", proto, guest_ip, target_port);
 
     let child = Command::new("socat")
@@ -152,6 +208,33 @@ mod tests {
             return true;
         }
         false
+    }
+
+    #[test]
+    fn listen_arg_default_host_omits_bind() {
+        // Default host_ip → no `bind=`, byte-for-byte the historical command.
+        assert_eq!(
+            listen_arg(DEFAULT_HOST_IP, 8080, PortProtocol::Tcp),
+            "TCP4-LISTEN:8080,reuseaddr,fork"
+        );
+    }
+
+    #[test]
+    fn listen_arg_scoped_host_and_udp() {
+        // Non-default host_ip appends `bind=`; UDP switches the proto token.
+        assert_eq!(
+            listen_arg("127.0.0.1", 53, PortProtocol::Udp),
+            "UDP4-LISTEN:53,reuseaddr,fork,bind=127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn kill_orphan_forwarder_no_match_is_noop() {
+        // A port no socat listens on must not error or kill anything. We can't
+        // assert "nothing died" cheaply, but the call must return cleanly on a
+        // host with no matching forwarder (the re-adoption fast path).
+        let port = pick_free_port();
+        kill_orphan_forwarder(None, port, PortProtocol::Tcp);
     }
 
     /// Bind a random ephemeral port and immediately release it so we can

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -486,7 +486,99 @@ impl FirecrackerLifecycle {
         instances
     }
 
+    /// Instances of a deployment that are alive on disk (socket present) but
+    /// absent from our PID map — i.e. inherited from a previous `ring-server`.
+    /// These are the ones whose in-process networking state was lost on restart.
+    fn orphan_instances(&self, deployment_id: &str) -> Vec<String> {
+        let pids = self.pids.lock().unwrap();
+        self.scan_instances(deployment_id)
+            .into_iter()
+            .filter(|id| !pids.contains_key(id))
+            .collect()
+    }
+
+    /// Re-adopt the host networking of instances inherited from a previous
+    /// `ring-server` (socket on disk, but no PID in our map). The VM and its
+    /// persistent tap survive a restart, but the socat forwarders — children of
+    /// the old process — died with it, so a deployment with `ports` loses its
+    /// host port-forwarding. Re-derive the network from the instance id (the IP
+    /// and tap name are pure functions of it), re-adopt the tap, re-spawn one
+    /// socat per published port, and re-register the PID so the instance is
+    /// fully owned again. Nothing is persisted: every input is either
+    /// deterministic or already in the deployment. No-op for portless
+    /// deployments (no network to lose) and for instances we already track.
+    async fn readopt_networking(&self, deployment: &Deployment) {
+        if deployment.ports.is_empty() {
+            return;
+        }
+        for instance_id in self.orphan_instances(&deployment.id) {
+            // Skip if we already re-adopted its forwarders on an earlier tick.
+            if self
+                .port_forwarders
+                .lock()
+                .unwrap()
+                .contains_key(&instance_id)
+            {
+                continue;
+            }
+            let net = InstanceNet::for_instance(&instance_id);
+            // The tap is persistent, so it's still on the host — adopt by name
+            // and bring it back under our ownership. ensure_outbound_nat is
+            // idempotent and global, so re-running it after a restart is a no-op.
+            let tap = TapDevice::adopt(&net.tap_name);
+            crate::hypervisor::host_nat::ensure_outbound_nat();
+
+            let mut forwarders = Vec::with_capacity(deployment.ports.len());
+            let mut ok = true;
+            for p in &deployment.ports {
+                match port_forwarder::spawn_forwarder(
+                    &net.guest_ip,
+                    p.published,
+                    p.target,
+                    p.host_ip.as_deref(),
+                    p.protocol,
+                )
+                .await
+                {
+                    Ok(fw) => forwarders.push(fw),
+                    Err(e) => {
+                        warn!(
+                            "Firecracker: failed to re-adopt port {} for {} after restart: {}",
+                            p.published, instance_id, e
+                        );
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if !ok {
+                // Drop partial forwarders; leave the instance for the next tick
+                // to retry rather than tearing down a live VM over a bind race.
+                continue;
+            }
+
+            self.taps.lock().unwrap().insert(instance_id.clone(), tap);
+            if !forwarders.is_empty() {
+                self.port_forwarders
+                    .lock()
+                    .unwrap()
+                    .insert(instance_id.clone(), forwarders);
+            }
+            if let Some(pid) = find_pid_by_socket(&self.socket_path(&instance_id)) {
+                self.pids.lock().unwrap().insert(instance_id.clone(), pid);
+            }
+            info!(
+                "Firecracker: re-adopted networking for {} after restart",
+                instance_id
+            );
+        }
+    }
+
     async fn handle_worker_deployment(&self, mut deployment: Deployment) -> Deployment {
+        // Before scaling, re-adopt any instance inherited from a previous
+        // ring-server so its network is restored without recreating the VM.
+        self.readopt_networking(&deployment).await;
+
         let current = self.scan_instances(&deployment.id);
         let desired = deployment.replicas as usize;
 
@@ -684,6 +776,48 @@ mod tests {
             found,
             vec!["dep-1-aaa".to_string(), "dep-1-bbb".to_string()]
         );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn orphan_instances_are_on_disk_but_not_in_pid_map() {
+        // After a restart the pid map is empty, so every on-disk instance is an
+        // orphan whose networking must be re-adopted. An instance we still track
+        // in `pids` (booted by this process) is not an orphan.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("ring-fc-orphan-{}-{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let cfg = FirecrackerRuntimeConfig {
+            socket_dir: dir.to_string_lossy().to_string(),
+            ..FirecrackerRuntimeConfig::default()
+        };
+        let lc = FirecrackerLifecycle::new(cfg);
+
+        for f in ["dep-1-aaa.sock", "dep-1-bbb.sock"] {
+            std::fs::write(dir.join(f), b"").unwrap();
+        }
+
+        // Empty pid map (post-restart): both instances are orphans.
+        let mut orphans = lc.orphan_instances("dep-1");
+        orphans.sort();
+        assert_eq!(
+            orphans,
+            vec!["dep-1-aaa".to_string(), "dep-1-bbb".to_string()]
+        );
+
+        // One instance is tracked again (re-adopted or freshly booted): no
+        // longer an orphan.
+        lc.pids
+            .lock()
+            .unwrap()
+            .insert("dep-1-aaa".to_string(), 4242);
+        assert_eq!(lc.orphan_instances("dep-1"), vec!["dep-1-bbb".to_string()]);
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -531,6 +531,16 @@ impl FirecrackerLifecycle {
             let mut forwarders = Vec::with_capacity(deployment.ports.len());
             let mut ok = true;
             for p in &deployment.ports {
+                // A forwarder orphaned by an unclean exit of the previous
+                // ring-server is reparented to init and still holds the port;
+                // kill it first so the re-spawn below doesn't hit "address
+                // already in use". No-op when the old server SIGKILLed it or
+                // exited cleanly (Drop killed it).
+                port_forwarder::kill_orphan_forwarder(
+                    p.host_ip.as_deref(),
+                    p.published,
+                    p.protocol,
+                );
                 match port_forwarder::spawn_forwarder(
                     &net.guest_ip,
                     p.published,
@@ -687,6 +697,12 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
         _resolved_mounts: Vec<ResolvedMount>,
     ) -> Deployment {
         if deployment.status == DeploymentStatus::Deleted {
+            // Re-adopt first so an instance inherited from a previous
+            // ring-server (its forwarders orphaned, not in our maps) is brought
+            // back under ownership — then stop_vm's Drop kills its socat. Without
+            // this, deleting right after a restart could leak an orphan forwarder
+            // still holding the port.
+            self.readopt_networking(&deployment).await;
             for instance_id in self.scan_instances(&deployment.id) {
                 if !self.stop_vm(&instance_id).await {
                     warn!(

--- a/tests/e2e/firecracker/setup.sh
+++ b/tests/e2e/firecracker/setup.sh
@@ -44,7 +44,9 @@ setup_fc() {
   # Snapshot pre-existing ring-* taps so cleanup only reaps taps THIS run leaked
   # (e.g. t4 SIGKILLs ring-server mid-run, leaving a tap with no graceful
   # teardown) — never orphans from unrelated runs on a shared host.
-  RING_E2E_FC_TAPS_BEFORE=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u)
+  # `|| true`: grep exits 1 when there are no ring-* taps (a clean host), which
+  # would abort the suite under `set -e` before config is exported.
+  RING_E2E_FC_TAPS_BEFORE=$( (ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' || true) | sort -u)
   export RING_E2E_FC_TAPS_BEFORE
 
   RING_EXTRA_CONFIG=$(cat <<EOF
@@ -78,7 +80,7 @@ cleanup_fc() {
   # CAP_NET_ADMIN/root; `ip link delete` direct, then `sudo -n` for CI.
   if [ -n "${RING_E2E_FC_TAPS_BEFORE+x}" ]; then
     local now leaked
-    now=$(ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u)
+    now=$( (ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' || true) | sort -u)
     leaked=$(comm -13 <(printf '%s\n' "$RING_E2E_FC_TAPS_BEFORE") <(printf '%s\n' "$now"))
     for tap in $leaked; do
       ip link delete "$tap" 2>/dev/null \

--- a/tests/e2e/firecracker/t4_restart.sh
+++ b/tests/e2e/firecracker/t4_restart.sh
@@ -70,7 +70,7 @@ EOF
 
 # Record pre-existing ring-* taps so we attribute the NEW one to this VM, not an
 # orphan left by an earlier run on a shared host.
-taps_now() { ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' | sort -u; }
+taps_now() { (ip -o link show 2>/dev/null | grep -oE 'ring-[0-9a-f]+' || true) | sort -u; }
 TAPS_BEFORE=$(taps_now)
 
 "$RING_BIN" apply --file "$FIXTURE"
@@ -99,6 +99,18 @@ for _ in $(seq 1 20); do
 done
 [ -n "$TAP" ] || fail "no new ring-* tap before restart"
 log "firecracker pid=$FC_PID, tap=$TAP"
+
+# Record the socat forwarder backing the published port. It's a child of this
+# ring-server, so the SIGKILL below takes it down — re-adoption must re-spawn it.
+socat_pid() { pgrep -f "socat.*TCP4-LISTEN:$PORT_A" | head -n1 || true; }
+SOCAT_PID=""
+for _ in $(seq 1 30); do
+  SOCAT_PID=$(socat_pid)
+  [ -n "$SOCAT_PID" ] && break
+  sleep 0.5
+done
+[ -n "$SOCAT_PID" ] || fail "no socat forwarder for port $PORT_A before restart"
+log "socat forwarder pid=$SOCAT_PID for port $PORT_A"
 
 # === 2. SIGKILL ring-server, leaving the VM alive ===
 log "killing ring-server (pid=$RING_PID), VM should keep running"
@@ -144,6 +156,27 @@ fi
 # And it must be the same firecracker process (proves no reboot-over).
 kill -0 "$FC_PID" 2>/dev/null || fail "original VM pid $FC_PID gone — a duplicate was booted over it"
 log "re-adopted same instance $INSTANCE_ID (pid $FC_PID still the one running)"
+
+# Re-adoption must leave the published port served by exactly one socat that is
+# a CHILD of the restarted ring-server (ppid == new RING_PID) — not the orphan
+# reparented to init when the old server was killed. This is the real proof the
+# networking was re-adopted: owned again, and idempotent (no double-bind).
+socat_pids_for_port() { pgrep -f "socat.*TCP4-LISTEN:$PORT_A" || true; }
+OWNED=""
+for _ in $(seq 1 30); do
+  mapfile -t sp < <(socat_pids_for_port)
+  if [ "${#sp[@]}" -eq 1 ]; then
+    ppid=$(ps -o ppid= -p "${sp[0]}" 2>/dev/null | tr -d ' ')
+    if [ "$ppid" = "$RING_PID" ]; then OWNED="${sp[0]}"; break; fi
+  fi
+  sleep 1
+done
+if [ -z "$OWNED" ]; then
+  echo "socat for port $PORT_A: $(socat_pids_for_port | tr '\n' ' ') (want exactly 1, child of $RING_PID)" >&2
+  for p in $(socat_pids_for_port); do ps -o pid,ppid,cmd -p "$p" --no-headers >&2 || true; done
+  fail "port $PORT_A not re-adopted: expected exactly one socat owned by the restarted ring-server"
+fi
+log "port $PORT_A re-adopted: single socat pid=$OWNED owned by ring-server $RING_PID"
 
 # === 5. Delete reaps the VM, socket, rootfs and tap — via the disk fallbacks ===
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "restart-vm")


### PR DESCRIPTION
On the experimental Firecracker runtime, restarting `ring-server` left a deployment with published `ports` unreachable: the microVM and its persistent host tap survive the restart, but the host port-forwarders did not, and the reconciler never restored them.

The reconciler now re-adopts inherited instances before scaling: it re-derives each instance's network from its id, re-adopts the persistent tap, and re-spawns one forwarder per published port, then re-registers the process. The pass is idempotent and stateless — every input is deterministic or already in the deployment — so guest state and published ports are preserved across a restart with no VM recreation.

Updates the runtimes doc, which previously stated instances were not re-adopted.

Unit test covers orphan selection (on-disk instance absent from the PID map).