### PR TITLE
fix(config): allow a server-only config.toml (no [contexts])

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -8,6 +8,12 @@ use std::fs;
 
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct Contexts {
+    /// Client contexts. Optional: a server-only `config.toml` (just a
+    /// `[server]` table, no `[contexts.<name>]`) is valid, because the daemon
+    /// never reads client contexts — it only needs `[server]`. When this map is
+    /// empty, `pick_context` synthesises a default client context and attaches
+    /// the shared `[server]` table to it (see `pick_context`).
+    #[serde(default)]
     pub(crate) contexts: HashMap<String, Config>,
     /// The single, top-level `[server]` table. It is shared by the whole file
     /// (a host runs one daemon, whatever client contexts point at it), so it is
@@ -153,6 +159,18 @@ fn pick_context(contexts: Contexts, context_current: &str) -> Option<Config> {
     // to whichever context we return so `configuration.server.*` is populated
     // regardless of which client context was picked.
     let server = contexts.server;
+
+    // A server-only config (a `[server]` table with no `[contexts.<name>]`) is
+    // valid: the daemon needs `[server]`, not client contexts. Synthesise a
+    // default context so the shared `[server]` table is still applied instead
+    // of being dropped to `ServerConfig::default()` by the caller's fallback.
+    if contexts.contexts.is_empty() {
+        return Some(Config {
+            server,
+            ..Config::default()
+        });
+    }
+
     let mut current_fallback: Option<Config> = None;
     for (context_name, mut config) in contexts.contexts {
         config.name = context_name.clone();
@@ -267,6 +285,24 @@ api.port = 3030
         let picked = pick_context(contexts, "dev").expect("dev should match");
         assert!(picked.server.runtime.docker.enabled);
         assert!(picked.server.runtime.cloud_hypervisor.enabled);
+    }
+
+    #[test]
+    fn server_only_config_parses_and_keeps_runtime() {
+        // A daemon config needs only `[server]`; client contexts are optional.
+        // The shared [server] table must survive onto the synthesised context
+        // instead of being lost to ServerConfig::default().
+        let toml_str = r#"
+[server.runtime.docker]
+enabled = true
+"#;
+        let contexts = make_contexts(toml_str);
+        let picked = pick_context(contexts, "default")
+            .expect("a server-only config must yield a usable context");
+        assert!(
+            picked.server.runtime.docker.enabled,
+            "the [server] table must be preserved when no contexts are declared"
+        );
     }
 
     #[test]

--- a/tests/e2e/server/t1_secret_key_validation.sh
+++ b/tests/e2e/server/t1_secret_key_validation.sh
@@ -84,6 +84,11 @@ host = "127.0.0.1"
 api.scheme = "http"
 api.port = $port
 user.salt = "t1-server-salt"
+
+# Ring refuses to start with no runtime enabled; this case asserts a healthy
+# start, so it must enable one.
+[server.runtime.docker]
+enabled = true
 EOF
 RING_CONFIG_DIR="$cfg" RING_DATABASE_PATH="$cfg/ring.db" RING_SECRET_KEY="$key" \
   "$RING_BIN" server start > "$cfg/out.log" 2>&1 &

--- a/tests/e2e/server/t3_cli_error_messages.sh
+++ b/tests/e2e/server/t3_cli_error_messages.sh
@@ -41,6 +41,10 @@ api.scheme = "http"
 api.port = $PORT
 user.salt = "t3-server-salt"
 scheduler.interval = 1
+
+# Ring refuses to start with no runtime enabled.
+[server.runtime.docker]
+enabled = true
 EOF
 
 SRV_PID=""

--- a/tests/e2e/server/t5_no_color_in_pipes.sh
+++ b/tests/e2e/server/t5_no_color_in_pipes.sh
@@ -36,6 +36,10 @@ api.scheme = "http"
 api.port = $PORT
 user.salt = "t5-server-salt"
 scheduler.interval = 1
+
+# Ring refuses to start with no runtime enabled.
+[server.runtime.docker]
+enabled = true
 EOF
 
 SRV_PID=""

--- a/tests/e2e/server/t6_apply_configs_block.sh
+++ b/tests/e2e/server/t6_apply_configs_block.sh
@@ -48,6 +48,10 @@ api.scheme = "http"
 api.port = $PORT
 user.salt = "t6-server-salt"
 scheduler.interval = 1
+
+# Ring refuses to start with no runtime enabled.
+[server.runtime.docker]
+enabled = true
 EOF
 
 NS="t6cfg"


### PR DESCRIPTION
## Problem

A `config.toml` containing only a `[server]` table (no `[contexts.<name>]`) fails to parse with `missing field 'contexts'`, even though the daemon never reads client contexts on its start path — it only needs `[server]`.

This makes a runtime-only server config impossible: the operator has to add a dummy client context just to satisfy the parser.

## Fix

- `contexts` is now `#[serde(default)]`, so it may be omitted.
- When no contexts are declared, `pick_context` synthesises a default context and attaches the shared `[server]` table to it — otherwise the caller's fallback would drop to `ServerConfig::default()` and silently discard the configured runtime.

## Tests

- New unit test `server_only_config_parses_and_keeps_runtime` locks in that a `[server]`-only config parses and preserves the runtime.
- Four `server/` e2e tests that assert a healthy start wrote a `config.toml` with no runtime; they now enable one (Ring refuses to start with zero runtimes). `tests/e2e/lib.sh` already did this — these inline configs were out of sync.

`cargo test config::` green (34/34); e2e `server` 11/11, `docker` 37/37, `podman` 1/1.