### PR TITLE
feat(login): interactive prompts when credentials are omitted

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -8,6 +8,7 @@ use clap::Command;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
+use std::io::IsTerminal;
 
 use crate::config::auth::AuthToken;
 use crate::config::config::get_config_dir;
@@ -20,16 +21,72 @@ pub(crate) fn command_config() -> Command {
             Arg::new("username")
                 .short('u')
                 .long("username")
-                .help("Your username")
-                .required(true),
+                .help("Your username (prompted if omitted)"),
         )
         .arg(
             Arg::new("password")
                 .short('p')
                 .long("password")
-                .help("Your password")
-                .required(true),
+                .help("Your password (prompted if omitted)"),
         )
+}
+
+/// What to do with a credential given the flag value and whether stdin is a tty.
+#[derive(Debug, PartialEq)]
+enum CredentialAction {
+    /// The flag was supplied; use it as-is.
+    Use(String),
+    /// The flag was missing but we have a terminal; prompt the user.
+    Prompt,
+    /// The flag was missing and there is no terminal; refuse.
+    Fail,
+}
+
+/// Pure decision: flag present wins; otherwise prompt on a tty, fail without one.
+fn decide_credential(flag: Option<String>, is_tty: bool) -> CredentialAction {
+    match flag {
+        Some(value) => CredentialAction::Use(value),
+        None if is_tty => CredentialAction::Prompt,
+        None => CredentialAction::Fail,
+    }
+}
+
+/// Returns the username from the flag, or prompts for it on an interactive
+/// terminal. Exits with a clear error when neither is available (pipe/CI).
+fn resolve_username(flag: Option<String>) -> String {
+    match decide_credential(flag, std::io::stdin().is_terminal()) {
+        CredentialAction::Use(value) => value,
+        CredentialAction::Fail => {
+            style::print_error("error: username required; pass --username or run in a terminal");
+            exit_code::ExitCode::General.exit();
+        }
+        CredentialAction::Prompt => inquire::Text::new("Username:")
+            .prompt()
+            .unwrap_or_else(|_| {
+                eprintln!("Aborted.");
+                exit_code::ExitCode::General.exit();
+            }),
+    }
+}
+
+/// Returns the password from the flag, or prompts for it (masked) on an
+/// interactive terminal. Exits with a clear error when neither is available.
+fn resolve_password(flag: Option<String>) -> String {
+    match decide_credential(flag, std::io::stdin().is_terminal()) {
+        CredentialAction::Use(value) => value,
+        CredentialAction::Fail => {
+            style::print_error("error: password required; pass --password or run in a terminal");
+            exit_code::ExitCode::General.exit();
+        }
+        CredentialAction::Prompt => inquire::Password::new("Password:")
+            .with_display_mode(inquire::PasswordDisplayMode::Masked)
+            .without_confirmation()
+            .prompt()
+            .unwrap_or_else(|_| {
+                eprintln!("Aborted.");
+                exit_code::ExitCode::General.exit();
+            }),
+    }
 }
 
 pub(crate) async fn execute(
@@ -37,8 +94,8 @@ pub(crate) async fn execute(
     mut configuration: Config,
     client: &reqwest::Client,
 ) {
-    let username = args.get_one::<String>("username").unwrap();
-    let password = args.get_one::<String>("password").unwrap();
+    let username = resolve_username(args.get_one::<String>("username").cloned());
+    let password = resolve_password(args.get_one::<String>("password").cloned());
 
     let config_directory = get_config_dir();
     let config_file = format!("{}/auth.json", config_directory);
@@ -101,5 +158,32 @@ pub(crate) async fn execute(
             style::print_error(&transport_error(&err, &base_url));
             exit_code::from_reqwest_error(&err).exit();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CredentialAction, decide_credential};
+
+    #[test]
+    fn flag_value_is_used_regardless_of_tty() {
+        assert_eq!(
+            decide_credential(Some("admin".to_string()), true),
+            CredentialAction::Use("admin".to_string())
+        );
+        assert_eq!(
+            decide_credential(Some("admin".to_string()), false),
+            CredentialAction::Use("admin".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_flag_prompts_on_a_terminal() {
+        assert_eq!(decide_credential(None, true), CredentialAction::Prompt);
+    }
+
+    #[test]
+    fn missing_flag_fails_without_a_terminal() {
+        assert_eq!(decide_credential(None, false), CredentialAction::Fail);
     }
 }


### PR DESCRIPTION
`ring login` no longer requires `-u`/`-p` up front.

- On a terminal, missing username/password are prompted (password masked, no confirmation).
- Off a terminal (pipe/CI), missing credentials are refused with a clear message and a non-zero exit, rather than blocking on a prompt — consistent with the TTY guard already used by `token revoke`.
- Passing the flags keeps the existing non-interactive behavior; flags can be mixed (e.g. `-u` only prompts for the password).

The flag-vs-prompt-vs-fail decision is extracted into a pure function and unit-tested.