### PR TITLE
Fix user list rendering an empty table when a user has null timestamps

### DIFF
--- a/documentation/how-to/manage-users.md
+++ b/documentation/how-to/manage-users.md
@@ -34,6 +34,8 @@ ring user list -o json
 
 Output: username, ID, timestamps. Password hashes never appear.
 
+A freshly created user has no **Updated at** or **Login at** until it is edited or logs in for the first time; those cells render empty rather than dropping the row.
+
 ## Update your own password
 
 ```bash

--- a/src/commands/user/list.rs
+++ b/src/commands/user/list.rs
@@ -57,16 +57,22 @@ pub(crate) async fn execute(
                 exit_code::from_http_status(status.as_u16()).exit();
             }
 
-            let users_list: Vec<UserDto> = response.json().await.unwrap_or(vec![]);
+            let users_list: Vec<UserDto> = match response.json().await {
+                Ok(list) => list,
+                Err(e) => {
+                    eprintln!("Failed to parse user list: {}", e);
+                    exit_code::ExitCode::General.exit();
+                }
+            };
 
             for user in users_list {
                 users.push(UserTableItem {
                     id: user.id,
                     created_at: style::format_date(&user.created_at),
-                    updated_at: style::format_date(&user.updated_at),
+                    updated_at: style::format_date(user.updated_at.as_deref().unwrap_or_default()),
                     status: user.status,
                     username: user.username,
-                    login_at: style::format_date(&user.login_at),
+                    login_at: style::format_date(user.login_at.as_deref().unwrap_or_default()),
                 })
             }
 
@@ -83,8 +89,8 @@ pub(crate) async fn execute(
 struct UserDto {
     id: String,
     created_at: String,
-    updated_at: String,
+    updated_at: Option<String>,
     status: String,
     username: String,
-    login_at: String,
+    login_at: Option<String>,
 }

--- a/tests/e2e/server/t12_user_list_null_timestamps.sh
+++ b/tests/e2e/server/t12_user_list_null_timestamps.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# T12-server: `user list` renders users whose updated_at/login_at are NULL.
+#
+# A freshly created user has no `updated_at` and no `login_at` until it is
+# edited or logs in for the first time — the server emits JSON `null` for both
+# (the server DTO declares them `Option<String>`). The CLI's `UserDto` used to
+# declare them as plain `String`, so a single null-bearing user made
+# `response.json::<Vec<UserDto>>()` fail for the WHOLE list. The old code then
+# swallowed that error with `unwrap_or(vec![])` and printed an empty table with
+# a zero exit code — the list silently looked empty even though the API
+# returned 200 with several users.
+#
+# This proves the fix against the *real compiled binary* over a TCP socket:
+# the Rust unit tests on the DTO cannot show that the rows actually reach the
+# user's terminal through the command's render path.
+#
+# Invariants:
+#   1. After creating a brand-new user (NULL updated_at + NULL login_at),
+#      `user list` exits zero AND lists BOTH the seeded admin and the new user.
+#   2. The raw API confirms the new user carries null timestamps — i.e. we are
+#      genuinely exercising the null path, not a server that backfilled them.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T12-server: user list with NULL timestamps =="
+
+# No runtime is needed for this test, but Ring refuses to boot with zero
+# runtimes enabled, so keep Docker on (default) — we never deploy anything.
+start_ring
+ring_login admin changeme
+
+NEWUSER="null-ts-user-$RANDOM"
+
+# A brand-new user: never edited, never logged in → updated_at/login_at NULL.
+"$RING_BIN" user create --username "$NEWUSER" --password changeme > /dev/null \
+  || fail "user create failed for $NEWUSER"
+log "created user $NEWUSER (expected NULL updated_at/login_at)"
+
+# --- Invariant 2: confirm the API really returns null timestamps ---
+# We read the admin token straight from the isolated auth.json so we can hit
+# the API without depending on the CLI's own rendering.
+TOKEN=$(grep -o '"token":"[^"]*"' "$RING_TEST_DIR/auth.json" | head -1 | cut -d'"' -f4)
+[ -n "$TOKEN" ] || fail "could not read admin token from $RING_TEST_DIR/auth.json"
+
+RAW=$(curl -fsS -H "Authorization: Bearer $TOKEN" "$RING_URL/users") \
+  || fail "raw GET /users failed"
+
+# The new user line must show null for both updated_at and login_at. We don't
+# depend on field ordering: assert the username is present AND that a null
+# updated_at/login_at appears in the payload at all.
+echo "$RAW" | grep -qF "\"$NEWUSER\"" \
+  || { echo "$RAW" >&2; fail "raw /users did not include $NEWUSER"; }
+echo "$RAW" | grep -qE '"updated_at":null' \
+  || { echo "$RAW" >&2; fail "expected a null updated_at in /users payload"; }
+echo "$RAW" | grep -qE '"login_at":null' \
+  || { echo "$RAW" >&2; fail "expected a null login_at in /users payload"; }
+log "raw API confirms NULL updated_at/login_at for the new user"
+
+# --- Invariant 1: the CLI lists BOTH users, exits zero ---
+set +e
+OUT=$("$RING_BIN" user list 2>&1)
+RC=$?
+set -e
+
+[ "$RC" -eq 0 ] || { echo "$OUT" >&2; fail "user list exited non-zero (rc=$RC)"; }
+
+# The seeded admin must be present (it always has non-null timestamps)...
+echo "$OUT" | grep -qw "admin" \
+  || { echo "$OUT" >&2; fail "user list did not show the seeded admin"; }
+# ...and so must the null-bearing user. Before the fix, the whole table was
+# empty because deserialization failed on this very row.
+echo "$OUT" | grep -qw "$NEWUSER" \
+  || { echo "$OUT" >&2; fail "user list did not show $NEWUSER (null-timestamp row dropped the table)"; }
+
+log "user list shows both admin and $NEWUSER, rc=0"
+log "== T12-server: all invariants passed =="


### PR DESCRIPTION
## Problem

`ring user list` printed an **empty table** (headers only, exit code 0) even when the API returned `200` with several users.

Root cause: the CLI's `UserDto` declared `updated_at` and `login_at` as plain `String`, but the server DTO (`UserOutput`) declares them `Option<String>` and emits JSON `null` for a user that has never been edited or logged in. A single null-bearing user made `response.json::<Vec<UserDto>>()` fail for the **whole** list. That error was then swallowed by `unwrap_or(vec![])`, so the command silently rendered an empty table and exited `0` — a "successful" command hiding a real failure.

## Fix

- Align the CLI DTO with the server contract: `updated_at: Option<String>`, `login_at: Option<String>`. Absent timestamps render as empty cells (via `format_date("")`) instead of dropping every row.
- Replace the silent `unwrap_or(vec![])` with explicit error handling (print the parse error, exit non-zero), matching the pattern already used in `token/list` and `secret/list`. This stops future schema drift from being masked.

## Test

Added `tests/e2e/server/t12_user_list_null_timestamps.sh`, which boots a real server, creates a brand-new user (null `updated_at`/`login_at`), confirms via the raw API that the timestamps are null, then asserts `user list` exits zero and lists **both** the seeded admin and the new user.

Verified the test **fails on the pre-fix binary** ("user list did not show the seeded admin" — empty table) and **passes** with the fix. `cargo test --bin ring`: 594 passed.

## Docs

`documentation/how-to/manage-users.md` now notes that a freshly created user shows empty **Updated at**/**Login at** cells until edited or logged in.