### PR TITLE
fix: make Podman and containerd runtimes actually work

### DIFF
--- a/src/runtime/containerd/cni.rs
+++ b/src/runtime/containerd/cni.rs
@@ -22,8 +22,30 @@ use std::process::Stdio;
 /// Where Ring writes its default CNI network configuration.
 const CNI_CONF_DIR: &str = "/etc/cni/net.d";
 const CNI_CONF_FILE: &str = "/etc/cni/net.d/10-ring.conflist";
-/// Standard search path for CNI plugin binaries.
-const CNI_BIN_DIR: &str = "/opt/cni/bin";
+/// Candidate directories for CNI plugin binaries, in priority order. `/opt/cni/bin`
+/// is the CNI upstream / containerd / Kubernetes default, but Debian/Ubuntu package
+/// the plugins under `/usr/lib/cni` and Fedora under `/usr/libexec/cni` (both follow
+/// the FHS rather than `/opt`). We probe all three so Ring works regardless of how
+/// the plugins were installed, instead of assuming the upstream layout.
+const CNI_BIN_DIRS: &[&str] = &["/opt/cni/bin", "/usr/lib/cni", "/usr/libexec/cni"];
+
+/// Resolve the directory holding the CNI plugin binaries by probing the known
+/// install locations for `bridge` (the plugin Ring invokes directly). Honours an
+/// explicit `CNI_PATH` override first. Falls back to the upstream default so the
+/// resulting error message names the conventional path.
+fn cni_bin_dir() -> String {
+    if let Ok(path) = std::env::var("CNI_PATH")
+        && !path.is_empty()
+    {
+        return path;
+    }
+    for dir in CNI_BIN_DIRS {
+        if Path::new(dir).join("bridge").is_file() {
+            return (*dir).to_string();
+        }
+    }
+    CNI_BIN_DIRS[0].to_string()
+}
 /// Network name + bridge used by Ring's default conflist.
 const CNI_NETWORK_NAME: &str = "ring";
 const CNI_BRIDGE: &str = "ring-cni0";
@@ -91,7 +113,7 @@ fn default_conflist() -> String {
 /// still boots, just without a CNI address (health checks that need an IP will
 /// report the missing address).
 pub(crate) fn plugins_available() -> bool {
-    Path::new(CNI_BIN_DIR).join("bridge").exists()
+    Path::new(&cni_bin_dir()).join("bridge").is_file()
 }
 
 /// Run `CNI ADD` for a container's network namespace and return the assigned IP.
@@ -102,8 +124,8 @@ pub(crate) fn plugins_available() -> bool {
 pub(crate) async fn add(container_id: &str, netns_path: &str) -> Option<IpAddr> {
     if !plugins_available() {
         warn!(
-            "CNI plugins not found under {} — instance {} will have no CNI network",
-            CNI_BIN_DIR, container_id
+            "CNI plugins not found under any of {:?} — instance {} will have no CNI network",
+            CNI_BIN_DIRS, container_id
         );
         return None;
     }
@@ -170,13 +192,14 @@ fn exec_plugin(command: &str, container_id: &str, netns_path: &str) -> Option<Ve
     })
     .to_string();
 
-    let plugin = Path::new(CNI_BIN_DIR).join("bridge");
+    let bin_dir = cni_bin_dir();
+    let plugin = Path::new(&bin_dir).join("bridge");
     let mut child = match std::process::Command::new(&plugin)
         .env("CNI_COMMAND", command)
         .env("CNI_CONTAINERID", container_id)
         .env("CNI_NETNS", netns_path)
         .env("CNI_IFNAME", CNI_IFNAME)
-        .env("CNI_PATH", CNI_BIN_DIR)
+        .env("CNI_PATH", &bin_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -219,6 +242,12 @@ fn exec_plugin(command: &str, container_id: &str, netns_path: &str) -> Option<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// `CNI_PATH` is a process-global env var; tests that set/remove it must not
+    /// run concurrently or they race each other's view of the var. Serialise the
+    /// window with a shared lock (same pattern as the virtiofsd env tests).
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn default_conflist_is_valid_json_with_bridge() {
@@ -234,5 +263,39 @@ mod tests {
         let raw = r#"{"ips":[{"address":"10.43.0.5/16"}]}"#;
         let result: CniResult = serde_json::from_slice(raw.as_bytes()).unwrap();
         assert_eq!(result.ips[0].address, "10.43.0.5/16");
+    }
+
+    #[test]
+    fn cni_bin_dir_honours_cni_path_override() {
+        let _g = ENV_GUARD.lock().unwrap();
+        // CNI_PATH wins over probing, even pointing at a path that doesn't exist.
+        let prev = std::env::var_os("CNI_PATH");
+        // SAFETY: this is the only test touching CNI_PATH and it restores it.
+        unsafe { std::env::set_var("CNI_PATH", "/custom/cni") };
+        assert_eq!(cni_bin_dir(), "/custom/cni");
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("CNI_PATH", v),
+                None => std::env::remove_var("CNI_PATH"),
+            }
+        }
+    }
+
+    #[test]
+    fn cni_bin_dir_falls_back_to_upstream_default() {
+        let _g = ENV_GUARD.lock().unwrap();
+        // With no override and (assumed) no plugins under the test paths, the
+        // resolver still returns the conventional upstream path so error
+        // messages name something sensible.
+        let prev = std::env::var_os("CNI_PATH");
+        // SAFETY: this is the only test touching CNI_PATH and it restores it.
+        unsafe { std::env::remove_var("CNI_PATH") };
+        let resolved = cni_bin_dir();
+        assert!(CNI_BIN_DIRS.contains(&resolved.as_str()));
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("CNI_PATH", v);
+            }
+        }
     }
 }

--- a/src/runtime/containerd/image.rs
+++ b/src/runtime/containerd/image.rs
@@ -42,8 +42,16 @@ impl ContainerdImage {
     /// Build from the deployment's image string and optional config auth.
     pub(crate) fn from_deployment(image: &str, auth: Option<(String, String, String)>) -> Self {
         let (repo, parsed_ref) = parse_image_reference(image);
+        // Unlike the Docker daemon, containerd does NOT expand short image names:
+        // it needs a fully-qualified reference. A bare `nginx` reaches its
+        // Transfer resolver as `dummy://nginx:1.25-alpine`, whose `:1.25-alpine`
+        // the URL parser reads as a port → "invalid port after host" and the
+        // pull fails (deployment crash-loops). So we apply Docker Hub's implicit
+        // rules ourselves: default the registry to `docker.io` and the namespace
+        // to `library` for official images.
+        let repo = normalize_repository(&repo);
         // The reference containerd stores the image under is the canonical
-        // `name:tag` / `name@digest` — same string the user wrote, normalized.
+        // `name:tag` / `name@digest`.
         let reference = match &parsed_ref {
             ImageReference::Tag(t) => format!("{}:{}", repo, t),
             ImageReference::Digest(d) => format!("{}@{}", repo, d),
@@ -53,6 +61,33 @@ impl ContainerdImage {
             parsed_ref,
             auth,
         }
+    }
+}
+
+/// Expand a Docker-style repository name to a fully-qualified containerd
+/// reference, applying the same implicit defaults the Docker CLI/daemon do:
+///   - `nginx`            → `docker.io/library/nginx`   (official image)
+///   - `bitnami/redis`    → `docker.io/bitnami/redis`   (Hub user/org image)
+///   - `ghcr.io/o/p`      → `ghcr.io/o/p`               (explicit registry, kept)
+///   - `localhost:5000/x` → `localhost:5000/x`          (local registry, kept)
+///
+/// The first path segment is a registry host only if it contains a `.` or `:`
+/// (a domain or `host:port`) or is exactly `localhost`; otherwise it's part of
+/// the repository path on Docker Hub.
+fn normalize_repository(repo: &str) -> String {
+    let first_segment = repo.split('/').next().unwrap_or(repo);
+    let has_registry_host =
+        first_segment.contains('.') || first_segment.contains(':') || first_segment == "localhost";
+
+    if has_registry_host {
+        // Registry is explicit — leave it as the user wrote it.
+        repo.to_string()
+    } else if repo.contains('/') {
+        // Hub user/org image: registry defaults to docker.io, path kept.
+        format!("docker.io/{}", repo)
+    } else {
+        // Official image: docker.io + the implicit `library` namespace.
+        format!("docker.io/library/{}", repo)
     }
 }
 
@@ -67,10 +102,49 @@ struct OciDescriptor {
     digest: String,
 }
 
-/// Subset of an OCI image config we need: the rootfs diff ids.
+/// A multi-arch manifest list / OCI image index: a list of per-platform
+/// manifests instead of a single image. Docker Hub serves most official images
+/// (nginx, alpine, …) this way, so the digest containerd records as the image
+/// target points here, NOT at an image manifest. We must pick the entry matching
+/// the host platform and recurse into it.
+#[derive(Deserialize)]
+struct OciIndex {
+    manifests: Vec<OciIndexEntry>,
+}
+
+#[derive(Deserialize)]
+struct OciIndexEntry {
+    digest: String,
+    #[serde(default)]
+    platform: Option<OciPlatform>,
+}
+
+#[derive(Deserialize)]
+struct OciPlatform {
+    architecture: String,
+    os: String,
+}
+
+/// Subset of an OCI image config we need: the rootfs diff ids plus the default
+/// process the image declares. containerd is low-level — unlike the Docker
+/// daemon, nothing merges the image's Entrypoint/Cmd into the OCI spec for us,
+/// so Ring must read them here and apply them when the deployment overrides no
+/// command (otherwise `runc create` fails with `args must not be empty`).
 #[derive(Deserialize)]
 struct OciImageConfig {
     rootfs: OciRootfs,
+    #[serde(default)]
+    config: OciImageConfigInner,
+}
+
+/// The `config` block of an OCI image config: the container runtime defaults.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct OciImageConfigInner {
+    #[serde(default)]
+    entrypoint: Option<Vec<String>>,
+    #[serde(default)]
+    cmd: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -85,6 +159,10 @@ pub(crate) struct ResolvedImage {
     /// Snapshot chain id that serves as the read-only parent of each
     /// per-instance writable snapshot.
     pub(crate) chain_id: String,
+    /// The image's default process (`Entrypoint` + `Cmd`), used as `process.args`
+    /// when the deployment does not override the command. Empty if the image
+    /// declares neither — that image is only runnable with an explicit command.
+    pub(crate) default_args: Vec<String>,
 }
 
 /// Ensure the image is present (and unpacked) honouring `policy`, then resolve
@@ -124,11 +202,13 @@ pub(crate) async fn ensure_image(
     }
 
     let descriptor = get_image_target(client, namespace, &image.reference).await?;
-    let chain_id = resolve_chain_id(client, namespace, &descriptor.digest).await?;
+    let (chain_id, default_args) =
+        resolve_chain_id_and_args(client, namespace, &descriptor.digest).await?;
 
     Ok(ResolvedImage {
         digest: Some(descriptor.digest),
         chain_id,
+        default_args,
     })
 }
 
@@ -271,18 +351,91 @@ async fn get_image_target(
         })
 }
 
-/// Compute the rootfs chain id of an image from its manifest + config.
+/// The host platform containerd unpacked layers for. Ring builds for
+/// `x86_64-unknown-linux-gnu`; matching `linux/amd64` is correct for the
+/// supported targets. `arm64` falls out of `target_arch` when cross-built.
+fn host_architecture() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "amd64"
+    }
+}
+
+/// If `digest` points at a multi-arch index, return the digest of the manifest
+/// matching the host platform; otherwise return `digest` unchanged.
 ///
-/// containerd stores the image config (with `rootfs.diff_ids`) in the content
-/// store, keyed by the manifest's `config.digest`. The chain id is the iterated
-/// SHA-256 of the diff ids — the same value the snapshotter keys unpacked layers
-/// under, so it is the correct parent for a writable snapshot.
-async fn resolve_chain_id(
+/// We distinguish an index from an image manifest by structure: an index has a
+/// `manifests` array and no `config`. Parsing as `OciIndex` succeeds only for
+/// the former, so a failed parse means "already an image manifest" and we pass
+/// the digest through untouched.
+async fn resolve_platform_manifest(
+    client: &containerd_client::Client,
+    namespace: &str,
+    digest: &str,
+) -> Result<String, RuntimeError> {
+    let bytes = read_content(client, namespace, digest).await?;
+
+    let index: OciIndex = match serde_json::from_slice(&bytes) {
+        Ok(index) => index,
+        // Not an index (no `manifests` array) — it's already an image manifest.
+        Err(_) => return Ok(digest.to_string()),
+    };
+
+    // An image manifest can also deserialize loosely; require a non-empty
+    // `manifests` list to treat it as an index.
+    if index.manifests.is_empty() {
+        return Ok(digest.to_string());
+    }
+
+    let arch = host_architecture();
+    select_platform_digest(&index, arch).ok_or_else(|| {
+        RuntimeError::Other(format!(
+            "image index {} has no manifest for platform linux/{}",
+            digest, arch
+        ))
+    })
+}
+
+/// Pick the manifest digest matching `linux/<arch>` from an index, falling back
+/// to a platform-less entry. Pure (no I/O) so it is unit-tested directly.
+fn select_platform_digest(index: &OciIndex, arch: &str) -> Option<String> {
+    index
+        .manifests
+        .iter()
+        .find(|m| {
+            m.platform
+                .as_ref()
+                .is_some_and(|p| p.os == "linux" && p.architecture == arch)
+        })
+        // Some indexes carry attestation manifests with no platform; the real
+        // images declare one, so the platform match above wins when present.
+        .or_else(|| index.manifests.iter().find(|m| m.platform.is_none()))
+        .map(|m| m.digest.clone())
+}
+
+/// Compute an image's rootfs chain id AND its default process args from its
+/// manifest + config.
+///
+/// containerd stores the image config (with `rootfs.diff_ids` and the
+/// `Entrypoint`/`Cmd` defaults) in the content store, keyed by the manifest's
+/// `config.digest`. The chain id is the iterated SHA-256 of the diff ids — the
+/// same value the snapshotter keys unpacked layers under, so it is the correct
+/// parent for a writable snapshot. The default args (`Entrypoint ++ Cmd`) are
+/// what containerd would run when no command override is given; Ring applies
+/// them to the OCI spec itself because nothing else does at this level.
+async fn resolve_chain_id_and_args(
     client: &containerd_client::Client,
     namespace: &str,
     manifest_digest: &str,
-) -> Result<String, RuntimeError> {
-    let manifest_bytes = read_content(client, namespace, manifest_digest).await?;
+) -> Result<(String, Vec<String>), RuntimeError> {
+    // The target may be a multi-arch index (manifest list) rather than an image
+    // manifest. Follow the index to the host-platform manifest before parsing
+    // the `config` pointer — otherwise `config` is absent and parsing fails,
+    // which manifested as an endless crash loop on official Docker Hub images.
+    let manifest_digest = resolve_platform_manifest(client, namespace, manifest_digest).await?;
+
+    let manifest_bytes = read_content(client, namespace, &manifest_digest).await?;
     let manifest: OciManifest = serde_json::from_slice(&manifest_bytes).map_err(|e| {
         RuntimeError::Other(format!(
             "failed to parse image manifest {}: {}",
@@ -304,7 +457,16 @@ async fn resolve_chain_id(
         ));
     }
 
-    Ok(compute_chain_id(&config.rootfs.diff_ids))
+    let default_args = image_default_args(&config.config);
+    Ok((compute_chain_id(&config.rootfs.diff_ids), default_args))
+}
+
+/// The default process an image declares: `Entrypoint` concatenated with `Cmd`,
+/// matching Docker/OCI semantics. Pure (no I/O) so it is unit-tested directly.
+fn image_default_args(config: &OciImageConfigInner) -> Vec<String> {
+    let mut args = config.entrypoint.clone().unwrap_or_default();
+    args.extend(config.cmd.clone().unwrap_or_default());
+    args
 }
 
 /// Iterated chain id over an ordered list of layer diff ids, per the OCI image
@@ -374,13 +536,153 @@ mod tests {
 
     #[test]
     fn image_reference_tag_canonicalized() {
+        // Containerd needs a fully-qualified reference: a bare `nginx` must
+        // expand to docker.io/library/nginx, else its Transfer resolver builds
+        // `dummy://nginx:latest` and the URL parser rejects the tag as a port.
         let img = ContainerdImage::from_deployment("nginx", None);
-        assert_eq!(img.reference, "nginx:latest");
+        assert_eq!(img.reference, "docker.io/library/nginx:latest");
+    }
+
+    #[test]
+    fn image_reference_with_tag_canonicalized() {
+        let img = ContainerdImage::from_deployment("nginx:1.25-alpine", None);
+        assert_eq!(img.reference, "docker.io/library/nginx:1.25-alpine");
     }
 
     #[test]
     fn image_reference_digest_canonicalized() {
         let img = ContainerdImage::from_deployment("nginx@sha256:abc", None);
-        assert_eq!(img.reference, "nginx@sha256:abc");
+        assert_eq!(img.reference, "docker.io/library/nginx@sha256:abc");
+    }
+
+    fn entry(digest: &str, os: Option<&str>, arch: Option<&str>) -> OciIndexEntry {
+        OciIndexEntry {
+            digest: digest.to_string(),
+            platform: match (os, arch) {
+                (Some(os), Some(arch)) => Some(OciPlatform {
+                    os: os.to_string(),
+                    architecture: arch.to_string(),
+                }),
+                _ => None,
+            },
+        }
+    }
+
+    #[test]
+    fn select_platform_picks_matching_arch() {
+        // A typical multi-arch index (nginx:alpine on Docker Hub): the bug was
+        // parsing this as an image manifest, which has no `config` field.
+        let index = OciIndex {
+            manifests: vec![
+                entry("sha256:arm64", Some("linux"), Some("arm64")),
+                entry("sha256:amd64", Some("linux"), Some("amd64")),
+            ],
+        };
+        assert_eq!(
+            select_platform_digest(&index, "amd64"),
+            Some("sha256:amd64".to_string())
+        );
+        assert_eq!(
+            select_platform_digest(&index, "arm64"),
+            Some("sha256:arm64".to_string())
+        );
+    }
+
+    #[test]
+    fn select_platform_falls_back_to_platformless_entry() {
+        let index = OciIndex {
+            manifests: vec![entry("sha256:plain", None, None)],
+        };
+        assert_eq!(
+            select_platform_digest(&index, "amd64"),
+            Some("sha256:plain".to_string())
+        );
+    }
+
+    #[test]
+    fn select_platform_none_when_no_match() {
+        // Index with only a non-matching arch and no platform-less fallback.
+        let index = OciIndex {
+            manifests: vec![entry("sha256:arm64", Some("linux"), Some("arm64"))],
+        };
+        assert_eq!(select_platform_digest(&index, "amd64"), None);
+    }
+
+    #[test]
+    fn image_default_args_concatenates_entrypoint_and_cmd() {
+        let cfg = OciImageConfigInner {
+            entrypoint: Some(vec!["/docker-entrypoint.sh".to_string()]),
+            cmd: Some(vec!["nginx".to_string(), "-g".to_string()]),
+        };
+        assert_eq!(
+            image_default_args(&cfg),
+            vec!["/docker-entrypoint.sh", "nginx", "-g"]
+        );
+    }
+
+    #[test]
+    fn image_default_args_cmd_only() {
+        let cfg = OciImageConfigInner {
+            entrypoint: None,
+            cmd: Some(vec!["/bin/sh".to_string()]),
+        };
+        assert_eq!(image_default_args(&cfg), vec!["/bin/sh"]);
+    }
+
+    #[test]
+    fn image_default_args_empty_when_neither() {
+        let cfg = OciImageConfigInner {
+            entrypoint: None,
+            cmd: None,
+        };
+        assert!(image_default_args(&cfg).is_empty());
+    }
+
+    #[test]
+    fn select_platform_ignores_non_linux_os() {
+        let index = OciIndex {
+            manifests: vec![
+                entry("sha256:win", Some("windows"), Some("amd64")),
+                entry("sha256:lin", Some("linux"), Some("amd64")),
+            ],
+        };
+        assert_eq!(
+            select_platform_digest(&index, "amd64"),
+            Some("sha256:lin".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_official_image_gets_library_namespace() {
+        assert_eq!(normalize_repository("nginx"), "docker.io/library/nginx");
+    }
+
+    #[test]
+    fn normalize_hub_user_image_gets_docker_io() {
+        assert_eq!(
+            normalize_repository("bitnami/redis"),
+            "docker.io/bitnami/redis"
+        );
+    }
+
+    #[test]
+    fn normalize_explicit_registry_is_untouched() {
+        assert_eq!(
+            normalize_repository("ghcr.io/owner/proj"),
+            "ghcr.io/owner/proj"
+        );
+        assert_eq!(
+            normalize_repository("registry.example.com/team/app"),
+            "registry.example.com/team/app"
+        );
+    }
+
+    #[test]
+    fn normalize_registry_with_port_is_untouched() {
+        assert_eq!(
+            normalize_repository("localhost:5000/app"),
+            "localhost:5000/app"
+        );
+        assert_eq!(normalize_repository("localhost/app"), "localhost/app");
     }
 }

--- a/src/runtime/containerd/lifecycle.rs
+++ b/src/runtime/containerd/lifecycle.rs
@@ -439,6 +439,7 @@ impl ContainerdLifecycle {
             .unwrap_or(ImagePullPolicy::Always);
         let resolved = ensure_image(client, ns, &image, policy).await?;
         deployment.image_digest = resolved.digest;
+        let image_default_args = resolved.default_args;
 
         // Instance id: human-readable, unique, also the container + snapshot key.
         let instance_id = format!("{}_{}_{}", deployment.namespace, deployment.name, tiny_id());
@@ -456,7 +457,12 @@ impl ContainerdLifecycle {
                 return Err(e);
             }
         };
-        let spec = oci::build_spec(deployment, resolved_mounts, &config_files);
+        let spec = oci::build_spec(
+            deployment,
+            resolved_mounts,
+            &config_files,
+            &image_default_args,
+        );
 
         // 4. Register the container object, tagged with the owning deployment.
         if let Err(e) = self

--- a/src/runtime/containerd/oci.rs
+++ b/src/runtime/containerd/oci.rs
@@ -32,8 +32,14 @@ pub(crate) fn build_spec(
     deployment: &Deployment,
     resolved_mounts: &[ResolvedMount],
     config_files: &[(String, String)],
+    image_default_args: &[String],
 ) -> Any {
-    let spec = build_spec_value(deployment, resolved_mounts, config_files);
+    let spec = build_spec_value(
+        deployment,
+        resolved_mounts,
+        config_files,
+        image_default_args,
+    );
     // `spec` is an in-memory serde_json::Value built from owned data, so
     // serialisation cannot fail in practice; expect() over unwrap_or_default()
     // so a truly impossible failure surfaces loudly instead of silently
@@ -50,8 +56,18 @@ pub(crate) fn build_spec_value(
     deployment: &Deployment,
     resolved_mounts: &[ResolvedMount],
     config_files: &[(String, String)],
+    image_default_args: &[String],
 ) -> Value {
-    let args = deployment.command.clone();
+    // The deployment command overrides the image default. When the deployment
+    // gives no command, fall back to the image's Entrypoint+Cmd: containerd is
+    // low-level and (unlike the Docker daemon) does NOT merge image defaults
+    // into the OCI spec, so an empty `process.args` makes `runc create` fail
+    // with `args must not be empty`.
+    let args = if deployment.command.is_empty() {
+        image_default_args.to_vec()
+    } else {
+        deployment.command.clone()
+    };
 
     let mut env: Vec<String> =
         vec!["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()];
@@ -71,11 +87,11 @@ pub(crate) fn build_spec_value(
     let mut mounts = default_mounts();
     mounts.extend(spec_mounts_from_resolved(resolved_mounts, config_files));
 
-    // `args` may legitimately be empty (use the image entrypoint). The OCI spec
-    // requires `process.args` to be non-empty, but the runc shim merges the
-    // image config's entrypoint/cmd when the container is created from an image,
-    // so omitting `args` entirely lets the image defaults apply. We only set
-    // `args` when the deployment overrides the command.
+    // `args` is resolved above (deployment command, else image default). It can
+    // still be empty if the image declares neither Entrypoint nor Cmd — such an
+    // image is only runnable with an explicit command, and runc will reject it
+    // with a clear `args must not be empty`. We set `args` only when non-empty
+    // to keep the spec clean.
     let mut process = json!({
         "terminal": false,
         "user": { "uid": uid, "gid": gid },
@@ -318,24 +334,48 @@ mod tests {
         let mut d = make_deployment();
         d.environment
             .insert("FOO".to_string(), EnvValue::Plain("bar".to_string()));
-        let spec = build_spec_value(&d, &[], &[]);
+        let spec = build_spec_value(&d, &[], &[], &[]);
         assert_eq!(spec["process"]["args"][0], "nginx");
         let env = spec["process"]["env"].as_array().unwrap();
         assert!(env.iter().any(|e| e == "FOO=bar"));
     }
 
     #[test]
-    fn spec_omits_args_when_command_empty() {
+    fn spec_falls_back_to_image_default_args_when_command_empty() {
+        // No deployment command → the image's Entrypoint+Cmd must populate
+        // process.args, or runc rejects the container with "args must not be
+        // empty" (the containerd crash-loop bug on official images).
         let mut d = make_deployment();
         d.command.clear();
-        let spec = build_spec_value(&d, &[], &[]);
+        let image_args = vec!["/docker-entrypoint.sh".to_string(), "nginx".to_string()];
+        let spec = build_spec_value(&d, &[], &[], &image_args);
+        assert_eq!(spec["process"]["args"][0], "/docker-entrypoint.sh");
+        assert_eq!(spec["process"]["args"][1], "nginx");
+    }
+
+    #[test]
+    fn spec_command_overrides_image_default_args() {
+        // Deployment command wins over the image default.
+        let d = make_deployment(); // command = ["nginx", "-g", "daemon off;"]
+        let image_args = vec!["/docker-entrypoint.sh".to_string()];
+        let spec = build_spec_value(&d, &[], &[], &image_args);
+        assert_eq!(spec["process"]["args"][0], "nginx");
+    }
+
+    #[test]
+    fn spec_omits_args_when_no_command_and_no_image_default() {
+        // Neither deployment command nor image default → args omitted (runc will
+        // surface a clear error rather than us shipping an empty array).
+        let mut d = make_deployment();
+        d.command.clear();
+        let spec = build_spec_value(&d, &[], &[], &[]);
         assert!(spec["process"].get("args").is_none());
     }
 
     #[test]
     fn spec_has_network_namespace() {
         let d = make_deployment();
-        let spec = build_spec_value(&d, &[], &[]);
+        let spec = build_spec_value(&d, &[], &[], &[]);
         let namespaces = spec["linux"]["namespaces"].as_array().unwrap();
         assert!(namespaces.iter().any(|n| n["type"] == "network"));
     }
@@ -348,7 +388,7 @@ mod tests {
             destination: "/data".to_string(),
             read_only: true,
         }];
-        let spec = build_spec_value(&d, &mounts, &[]);
+        let spec = build_spec_value(&d, &mounts, &[], &[]);
         let m = spec["mounts"].as_array().unwrap();
         assert!(
             m.iter()

--- a/src/runtime/docker/instances.rs
+++ b/src/runtime/docker/instances.rs
@@ -1,36 +1,39 @@
 use bollard::Docker;
+use bollard::models::ContainerSummaryStateEnum;
 use bollard::query_parameters::ListContainersOptionsBuilder;
-use std::collections::HashMap;
 
 fn build_list_options(status: &str) -> bollard::query_parameters::ListContainersOptions {
+    // Always list every container and filter by state client-side (see
+    // `matches_status`). We deliberately do NOT push a server-side `status`
+    // filter:
+    // Podman's Docker-compatible API rejects `restarting` (it has no such
+    // state) and fails the whole request, which `list_*` then swallows into an
+    // empty Vec — making the scheduler believe a deployment has 0 live
+    // instances and spawn one new container every tick, unbounded. Listing all
+    // and filtering in-process behaves identically on Docker and Podman.
+    let all = !matches!(status, "all");
+    ListContainersOptionsBuilder::new().all(all).build()
+}
+
+/// Whether a container counts as a live instance for the given filter.
+///
+/// `active` = running or restarting. We deliberately drop `created`: a
+/// container stuck in `created` (Docker accepted the spec but `start` failed —
+/// e.g. the OCI runtime can't exec the binary) is *not* a live instance.
+/// Counting it as active masked the failure — the scheduler saw
+/// `current_count == target_count`, skipped the retry path, and `restart_count`
+/// never climbed to `MAX_RESTART_COUNT`. With it excluded, the next tick sees
+/// 0 instances, retries, increments `restart_count`, and eventually flips the
+/// deployment to `CrashLoopBackOff` like any other crash loop.
+fn matches_status(state: Option<&ContainerSummaryStateEnum>, status: &str) -> bool {
     match status {
-        "all" => ListContainersOptionsBuilder::new().all(true).build(),
-        "active" => {
-            // We deliberately drop `created` here. A container stuck in
-            // `created` (Docker accepted the spec but `start` failed — e.g.
-            // OCI runtime can't exec the binary) is *not* a live instance.
-            // Counting it as active masked the failure: the scheduler saw
-            // `current_count == target_count`, skipped the retry path, and
-            // restart_count never climbed to MAX_RESTART_COUNT. With it out
-            // of the filter, the next tick sees 0 instances, re-tries,
-            // increments restart_count, and eventually flips the deployment
-            // to CrashLoopBackOff like any other crash loop.
-            let filters = HashMap::from([(
-                "status".to_string(),
-                vec!["running".to_string(), "restarting".to_string()],
-            )]);
-            ListContainersOptionsBuilder::new()
-                .all(true)
-                .filters(&filters)
-                .build()
-        }
-        s => {
-            let filters = HashMap::from([("status".to_string(), vec![s.to_string()])]);
-            ListContainersOptionsBuilder::new()
-                .all(false)
-                .filters(&filters)
-                .build()
-        }
+        "all" => true,
+        "active" => matches!(
+            state,
+            Some(ContainerSummaryStateEnum::RUNNING) | Some(ContainerSummaryStateEnum::RESTARTING)
+        ),
+        // An explicit single state filter (e.g. "exited", "created").
+        s => state.map(|st| st.to_string() == s).unwrap_or(false),
     }
 }
 
@@ -41,7 +44,8 @@ pub(crate) async fn list_instances(docker: &Docker, id: String, status: &str) ->
     match docker.list_containers(Some(options)).await {
         Ok(containers) => {
             for container in containers {
-                if let Some(labels) = container.labels
+                if matches_status(container.state.as_ref(), status)
+                    && let Some(labels) = container.labels
                     && let Some(deployment_id) = labels.get("ring_deployment")
                     && deployment_id == &id
                     && let Some(container_id) = container.id
@@ -67,7 +71,8 @@ pub(crate) async fn list_instances_with_names(
     match docker.list_containers(Some(options)).await {
         Ok(containers) => {
             for container in containers {
-                if let Some(labels) = &container.labels
+                if matches_status(container.state.as_ref(), status)
+                    && let Some(labels) = &container.labels
                     && let Some(deployment_id) = labels.get("ring_deployment")
                     && deployment_id == &id
                     && let Some(container_id) = &container.id
@@ -86,4 +91,59 @@ pub(crate) async fn list_instances_with_names(
     }
 
     instances
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_counts_running_and_restarting() {
+        assert!(matches_status(
+            Some(&ContainerSummaryStateEnum::RUNNING),
+            "active"
+        ));
+        assert!(matches_status(
+            Some(&ContainerSummaryStateEnum::RESTARTING),
+            "active"
+        ));
+    }
+
+    #[test]
+    fn active_excludes_created_and_exited() {
+        // A `created` container (start failed) is NOT a live instance — this is
+        // the exclusion that lets the scheduler retry and eventually reach
+        // CrashLoopBackOff instead of treating it as healthy.
+        assert!(!matches_status(
+            Some(&ContainerSummaryStateEnum::CREATED),
+            "active"
+        ));
+        assert!(!matches_status(
+            Some(&ContainerSummaryStateEnum::EXITED),
+            "active"
+        ));
+        assert!(!matches_status(None, "active"));
+    }
+
+    #[test]
+    fn all_matches_any_state() {
+        assert!(matches_status(
+            Some(&ContainerSummaryStateEnum::CREATED),
+            "all"
+        ));
+        assert!(matches_status(None, "all"));
+    }
+
+    #[test]
+    fn explicit_state_filter_matches_by_name() {
+        assert!(matches_status(
+            Some(&ContainerSummaryStateEnum::EXITED),
+            "exited"
+        ));
+        assert!(!matches_status(
+            Some(&ContainerSummaryStateEnum::RUNNING),
+            "exited"
+        ));
+        assert!(!matches_status(None, "exited"));
+    }
 }

--- a/tests/e2e/containerd/setup.sh
+++ b/tests/e2e/containerd/setup.sh
@@ -15,7 +15,13 @@ set -euo pipefail
 
 RING_CONTAINERD_SOCKET="${RING_CONTAINERD_SOCKET:-/run/containerd/containerd.sock}"
 RING_CONTAINERD_NS="${RING_CONTAINERD_NS:-ring}"
-CNI_BIN_DIR="${CNI_BIN_DIR:-/opt/cni/bin}"
+# Probe the same locations Ring's cni_bin_dir() does: the CNI upstream default
+# (/opt/cni/bin) plus the Debian/Ubuntu (/usr/lib/cni) and Fedora
+# (/usr/libexec/cni) package layouts. An explicit CNI_PATH wins.
+CNI_BIN_DIRS=("/opt/cni/bin" "/usr/lib/cni" "/usr/libexec/cni")
+if [ -n "${CNI_PATH:-}" ]; then
+  CNI_BIN_DIRS=("$CNI_PATH")
+fi
 
 check_containerd_prereqs() {
   if ! command -v ctr > /dev/null 2>&1; then
@@ -40,8 +46,15 @@ check_containerd_prereqs() {
 
   # CNI plugins are required for container networking. Without them Ring boots
   # the container with no address and the networking/health-check tests fail.
-  if [ ! -x "$CNI_BIN_DIR/bridge" ] || [ ! -x "$CNI_BIN_DIR/host-local" ]; then
-    echo "[containerd-setup] FAIL: CNI plugins missing under $CNI_BIN_DIR (need bridge + host-local)" >&2
+  local found=""
+  for dir in "${CNI_BIN_DIRS[@]}"; do
+    if [ -x "$dir/bridge" ] && [ -x "$dir/host-local" ]; then
+      found="$dir"
+      break
+    fi
+  done
+  if [ -z "$found" ]; then
+    echo "[containerd-setup] FAIL: CNI plugins missing under ${CNI_BIN_DIRS[*]} (need bridge + host-local)" >&2
     echo "                   install the containernetworking-plugins package, or download from" >&2
     echo "                   https://github.com/containernetworking/plugins/releases" >&2
     return 1

--- a/tests/e2e/podman/t2_podman_replicas.sh
+++ b/tests/e2e/podman/t2_podman_replicas.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# T2-podman: prove Ring's replica reconciliation CONVERGES on Podman.
+#
+# Regression guard for the unbounded-scaling bug: `list_instances` used to push
+# a server-side `status=["running","restarting"]` filter, but Podman's
+# Docker-compat API rejects `restarting` (it has no such state) and fails the
+# whole request. `list_instances` swallowed the error into an empty Vec, so the
+# scheduler saw 0 live instances every cycle and spawned one new container per
+# tick, forever (observed: 38+ containers for replicas:3). The fix lists all
+# containers and filters state client-side.
+#
+# This test deploys replicas:3, asserts the Podman container count converges to
+# EXACTLY 3 and stays there across several scheduler cycles (it would keep
+# climbing under the bug), then scales down to 1 and asserts convergence to 1.
+#
+# Skips cleanly (exit 0) if Podman or its rootless socket isn't available.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T2-podman: replica reconciliation converges =="
+
+# --- Prerequisites: podman binary + a reachable rootless socket ---
+if ! command -v podman > /dev/null 2>&1; then
+  log "podman not installed — SKIP"
+  exit 0
+fi
+
+PODMAN_SOCK="${RING_PODMAN_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+SOCK_PATH="${PODMAN_SOCK#unix://}"
+if [ ! -S "$SOCK_PATH" ]; then
+  systemctl --user start podman.socket 2>/dev/null || true
+  if [ ! -S "$SOCK_PATH" ]; then
+    log "podman socket $SOCK_PATH not available — SKIP"
+    exit 0
+  fi
+fi
+log "podman socket: $SOCK_PATH"
+
+# Clean up any podman containers we create, regardless of outcome.
+cleanup_podman() {
+  podman ps -aq --filter "label=ring_deployment" 2>/dev/null \
+    | xargs -r podman rm -f > /dev/null 2>&1 || true
+}
+trap 'cleanup_podman; cleanup_ring' EXIT
+
+# Boot Ring with Podman only (no Docker), pointing at the rootless socket.
+export RING_E2E_ENABLE_DOCKER=false
+export RING_EXTRA_CONFIG="[server.runtime.podman]
+enabled = true
+host = \"$PODMAN_SOCK\""
+
+start_ring
+ring_login
+
+# Count RUNNING podman containers across all ring deployments in this namespace.
+podman_running_count() {
+  local id="$1"
+  podman ps -q --filter "label=ring_deployment=$id" 2>/dev/null | wc -l | tr -d ' '
+}
+
+# --- replicas: 3 ---
+FIXTURE="$RING_TEST_DIR/replicas.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  replicas3:
+    name: replicas3
+    namespace: ring-e2e
+    runtime: podman
+    image: docker.io/library/nginx:alpine
+    replicas: 3
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "replicas3" "running" 60
+
+DID=$(get_deployment_id "ring-e2e" "replicas3")
+[ -n "$DID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DID"
+
+# Converge to exactly 3.
+converged=0
+for _ in $(seq 1 30); do
+  c=$(podman_running_count "$DID")
+  if [ "$c" -eq 3 ]; then converged=1; break; fi
+  sleep 1
+done
+[ "$converged" -eq 1 ] || {
+  podman ps -a --filter "label=ring_deployment=$DID" >&2
+  fail "deployment $DID did not converge to 3 containers (last: $(podman_running_count "$DID"))"
+}
+log "converged to 3 containers"
+
+# Stability: must STAY at 3 across several scheduler cycles (the bug would keep
+# adding one per ~1s tick). Sample for 8s.
+for _ in $(seq 1 8); do
+  c=$(podman_running_count "$DID")
+  [ "$c" -eq 3 ] || {
+    podman ps -a --filter "label=ring_deployment=$DID" >&2
+    fail "container count drifted to $c (expected stable 3) — reconciliation not converging"
+  }
+  sleep 1
+done
+log "stable at 3 containers across 8 scheduler cycles (no runaway scaling)"
+
+# --- scale down to 1 ---
+# Ring recreates the deployment on a replica change (new id, old drained), so
+# track the running container that belongs to the namespace, by the NEW id.
+sed -i 's/replicas: 3/replicas: 1/' "$FIXTURE"
+"$RING_BIN" apply --file "$FIXTURE"
+
+# Wait for a running deployment with replicas=1, then grab its id.
+NEW_DID=""
+for _ in $(seq 1 60); do
+  NEW_DID=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r '.[] | select(.namespace=="ring-e2e" and .name=="replicas3" and .replicas==1 and .status=="running") | .id' \
+    | head -n1)
+  [ -n "$NEW_DID" ] && break
+  sleep 1
+done
+[ -n "$NEW_DID" ] || fail "replicas:1 deployment never reached running"
+log "scaled-down deployment id: $NEW_DID"
+
+# The new deployment must converge to exactly 1 and stay there.
+converged=0
+for _ in $(seq 1 30); do
+  c=$(podman_running_count "$NEW_DID")
+  if [ "$c" -eq 1 ]; then converged=1; break; fi
+  sleep 1
+done
+[ "$converged" -eq 1 ] || fail "scaled-down deployment $NEW_DID did not converge to 1 (last: $(podman_running_count "$NEW_DID"))"
+
+for _ in $(seq 1 5); do
+  c=$(podman_running_count "$NEW_DID")
+  [ "$c" -eq 1 ] || fail "scaled-down count drifted to $c (expected stable 1)"
+  sleep 1
+done
+log "scaled down and stable at 1 container"
+
+log "== T2-podman: PASS =="


### PR DESCRIPTION
## Summary

Three runtime bugs found and fixed by testing Podman and containerd end-to-end against real engines. Each made a runtime unusable for common cases; all three are now verified live.

| Runtime | Bug | Symptom |
|---|---|---|
| **Podman** | server-side `status` filter incompatible | unbounded container creation |
| **containerd** | multi-arch image index not followed | crash loop on every official image |
| **containerd** | image entrypoint not applied to OCI spec | `runc: args must not be empty` |
| **containerd** | CNI plugin path hardcoded | no network on Debian/Ubuntu/Fedora |

## 1. Podman — unbounded container creation (`fix(podman)`)

Podman's Docker-compat API rejects the server-side status filter value `restarting` (it has no such state) and fails the whole `list_containers` request. `list_instances` swallowed the error into an empty `Vec`, so the scheduler saw **0 live instances every tick** and spawned one new container per cycle, never converging — observed 38+ containers for `replicas: 3`.

Fix: list all containers and filter state **client-side** (`matches_status`), identical behaviour on Docker and Podman. Adds `tests/e2e/podman/t2_podman_replicas.sh` asserting convergence to exactly 3 (and back to 1 on scale-down).

## 2. containerd — official multi-arch images (`fix(containerd): run official multi-arch images`)

Two bugs, each an endless crash loop on official Docker Hub images (nginx, alpine, …):

- The image target of a multi-arch image is a **manifest list (OCI index)**, not an image manifest. The code parsed it directly and failed with `missing field config`. Now it follows the index to the host-platform (`linux/amd64|arm64`) manifest first.
- containerd is low-level: unlike the Docker daemon it does **not** merge the image's `Entrypoint`/`Cmd` into the OCI spec, so empty `process.args` made `runc create` fail with `args must not be empty`. Ring now reads `Entrypoint`+`Cmd` from the image config and applies them when the deployment overrides no command.

## 3. containerd — CNI plugin discovery (`fix(containerd): probe CNI plugin dirs`)

The CNI plugin path was hardcoded to `/opt/cni/bin` (upstream/Kubernetes default), but Debian/Ubuntu package them under `/usr/lib/cni` and Fedora under `/usr/libexec/cni`. On those distros Ring booted containers with no network. Now probes all three (honouring a `CNI_PATH` override).

## Testing

- Unit tests added for platform selection, entrypoint resolution, OCI spec arg fallback, and CNI path resolution (630 tests green).
- **Live e2e** on real engines:
  - Podman rootless: `t1` create/delete, `t2` replicas converge to 3.
  - containerd: `t1`-`t4` (create/delete, replicas, logs, command health check) all pass.
- Docker regression: `t1`, `t5`, `t7`, `t23` pass — the shared `instances.rs` change is behaviour-preserving.