### PR TITLE
fix(podman): converge crash loops to CrashLoopBackOff + quiet event-channel log

### DIFF
--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -25,7 +25,7 @@ Enable just the runtimes a host actually runs — Docker-only, Podman-only, cont
 | Memory overhead per workload | ~10 MB | ~10 MB | ~10 MB | ~80–150 MB (kernel + guest userland) | ~5–50 MB (minimal device model) |
 | Image format | Docker image (`nginx:1.25`) | Docker/OCI image | OCI image (`nginx:1.25`) | Raw disk image on the host filesystem | Kernel (`vmlinux`) + ext4 rootfs on the host filesystem |
 | Networking | Per-namespace bridge, DNS aliases | Per-namespace bridge, DNS aliases | CNI (bridge + host-local IPAM) | Per-VM /30 subnet, host-port forwarding via `socat` | Per-VM /30 subnet, host-port forwarding via `socat` (Ring-owned host TAP) |
-| Live event stream | Yes (sub-second crash detection) | Only while `podman system service` runs (not yet consumed) | No (tick-bound) | No (tick-bound) | No (tick-bound) |
+| Crash detection | ✓ event-driven (sub-second) | ✓ reconcile-based (per scheduler tick) | ✓ reconcile-based (per scheduler tick) | ✓ reconcile-based (per scheduler tick) | ✓ reconcile-based (per scheduler tick) |
 | `command` health checks | `docker exec` | `podman exec` (same API) | `Tasks.Exec` (gRPC) | In-guest `ring-agent` over AF_VSOCK | Not yet |
 | `kind: job` | Exit code visible | Exit code visible | Exit code visible | Clean shutdown = success (no exit code from host) | Not yet (runs as worker) |
 | Labels (`labels:`) | Forwarded to container | Forwarded to container | Forwarded to container | Silently ignored | Silently ignored |
@@ -66,7 +66,7 @@ The socket must be running — start it once with `systemctl --user start podman
 - You want Docker semantics without the Docker daemon
 
 **Caveats:**
-- **Event stream**: Podman only emits events while `podman system service` is up. Ring does not yet consume Podman events (the orphan-volume reaper stays Docker-only), so crash detection is tick-bound for now.
+- **Crash detection is tick-bound.** Ring does not consume Podman's event stream, so a crashed container is noticed on the next scheduler reconcile pass (which still bumps `restart_count` and converges a crash loop to `CrashLoopBackOff`, bounded), not sub-second like Docker. The orphan-volume reaper, which *does* rely on live events, stays Docker-only.
 - **Host networking** (`network.mode: host`) is not yet allowed on Podman — Docker only.
 - Rootless remaps UID/GID; bind-mount and named-volume ownership behave differently than Docker-root — mind file permissions on mounts.
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -79,11 +79,17 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // isn't enabled is never touched, even if its socket/binary happens to
     // exist. This is what lets Ring run Docker-only, CH-only, or any mix.
     //
-    // Fail-fast: a runtime the operator explicitly enabled but that's
-    // unreachable at startup is a configuration error, not a silent skip — we
-    // refuse to start so the misconfiguration surfaces immediately rather than
-    // as a 500 on the first deployment.
+    // Best-effort startup: a runtime the operator enabled but that's unreachable
+    // at boot is logged and skipped — it does NOT take the node down. A broken
+    // (or freshly-added-but-misconfigured) runtime must never knock out the
+    // others that are working. We verify ALL enabled runtimes (no short-circuit
+    // on the first failure), collect every failure, and report them together.
+    // The two hard floors below still hold: zero usable runtime aborts, and an
+    // apply targeting an enabled-but-unregistered runtime gets an actionable
+    // error (see api::action::create) instead of a confusing "unknown runtime".
     let mut runtimes_map: HashMap<String, Arc<dyn RuntimeLifecycle>> = HashMap::new();
+    // (runtime name, reason) for every enabled runtime that failed to come up.
+    let mut runtime_failures: Vec<(String, String)> = Vec::new();
 
     // Docker: enabled in config → verify the daemon answers a `ping()` (client
     // construction alone is lazy and always succeeds, so it can't gate this).
@@ -100,11 +106,9 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
                 docker::connect_with_host(&host).ok()
             }
             Err(e) => {
-                error!(
-                    "Refusing to start: Docker runtime is enabled in config but unreachable: {}",
-                    e
-                );
-                std::process::exit(1);
+                warn!("Docker runtime enabled but unreachable, skipping: {}", e);
+                runtime_failures.push(("docker".to_string(), e.to_string()));
+                None
             }
         }
     } else {
@@ -115,9 +119,9 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // Podman: enabled in config → verify the daemon answers a `ping()` over its
     // Docker-compatible API. Podman speaks the same wire protocol, so we reuse
     // `DockerLifecycle` (no PodmanLifecycle) and register it under the "podman"
-    // key. Same fail-fast contract as Docker. No event listener yet: Podman's
-    // event stream only flows while `podman system service` is up (see
-    // runtime::podman docs) — the orphan reaper stays Docker-only for now.
+    // key. No event listener yet: Podman's event stream only flows while
+    // `podman system service` is up (see runtime::podman docs) — the orphan
+    // reaper stays Docker-only for now.
     if configuration.server.runtime.podman.enabled {
         let host = configuration.server.runtime.podman.host.clone();
         match docker::connect_and_verify(&host).await {
@@ -125,15 +129,18 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
                 info!("Connected to Podman at {}", host);
                 runtimes_map.insert(
                     "podman".to_string(),
-                    Arc::new(DockerLifecycle::new(podman, intentional_shutdowns.clone())),
+                    // Podman has no event listener (see below) — use the
+                    // reconcile-based crash detector so crash loops still
+                    // converge to CrashLoopBackOff.
+                    Arc::new(DockerLifecycle::new_podman(
+                        podman,
+                        intentional_shutdowns.clone(),
+                    )),
                 );
             }
             Err(e) => {
-                error!(
-                    "Refusing to start: Podman runtime is enabled in config but unreachable: {}",
-                    e
-                );
-                std::process::exit(1);
+                warn!("Podman runtime enabled but unreachable, skipping: {}", e);
+                runtime_failures.push(("podman".to_string(), e.to_string()));
             }
         }
     } else {
@@ -141,9 +148,9 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     }
 
     // containerd: enabled in config → verify the gRPC socket answers a Version
-    // round-trip, else fail fast. Unlike Podman, containerd speaks its own native
-    // API (no Docker daemon in between), so it has its own ContainerdLifecycle
-    // registered under the "containerd" key.
+    // round-trip. Unlike Podman, containerd speaks its own native API (no Docker
+    // daemon in between), so it has its own ContainerdLifecycle registered under
+    // the "containerd" key.
     if configuration.server.runtime.containerd.enabled {
         let containerd_config =
             ContainerdRuntimeConfig::from_user_config(&configuration.server.runtime.containerd);
@@ -152,81 +159,110 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
                 runtimes_map.insert("containerd".to_string(), Arc::new(containerd));
             }
             Err(e) => {
-                error!(
-                    "Refusing to start: containerd runtime is enabled in config but unreachable: {}",
+                warn!(
+                    "containerd runtime enabled but unreachable, skipping: {}",
                     e
                 );
-                std::process::exit(1);
+                runtime_failures.push(("containerd".to_string(), e.to_string()));
             }
         }
     } else {
         info!("containerd runtime disabled in config, skipping");
     }
 
-    // Cloud Hypervisor: enabled in config → its binary must resolve, else fail
-    // fast. The config/log-rotator are only built when we'll use it.
+    // Cloud Hypervisor: enabled in config → its binary must resolve. The
+    // config/log-rotator are only built when we'll use it.
     let mut _ch_log_rotator = None;
     if configuration.server.runtime.cloud_hypervisor.enabled {
         let ch_runtime_config =
             crate::runtime::cloud_hypervisor::CloudHypervisorRuntimeConfig::from_user_config(
                 &configuration.server.runtime.cloud_hypervisor,
             );
-        if !ch_runtime_config.is_available() {
-            error!(
-                "Refusing to start: Cloud Hypervisor runtime is enabled in config but its binary \
-                 '{}' could not be found",
+        if ch_runtime_config.is_available() {
+            info!(
+                "Cloud Hypervisor runtime: binary={}, firmware={}, socket_dir={}, seccomp={:?}",
+                ch_runtime_config.binary_path,
+                ch_runtime_config.firmware_path,
+                ch_runtime_config.socket_dir,
+                ch_runtime_config.seccomp,
+            );
+            let ch_lifecycle = CloudHypervisorLifecycle::new(ch_runtime_config);
+            _ch_log_rotator = Some(ch_lifecycle.spawn_console_log_rotator());
+            runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
+        } else {
+            let reason = format!(
+                "binary '{}' could not be found",
                 ch_runtime_config.binary_path
             );
-            std::process::exit(1);
+            warn!(
+                "Cloud Hypervisor runtime enabled but unavailable, skipping: {}",
+                reason
+            );
+            runtime_failures.push(("cloud-hypervisor".to_string(), reason));
         }
-        info!(
-            "Cloud Hypervisor runtime: binary={}, firmware={}, socket_dir={}, seccomp={:?}",
-            ch_runtime_config.binary_path,
-            ch_runtime_config.firmware_path,
-            ch_runtime_config.socket_dir,
-            ch_runtime_config.seccomp,
-        );
-        let ch_lifecycle = CloudHypervisorLifecycle::new(ch_runtime_config);
-        _ch_log_rotator = Some(ch_lifecycle.spawn_console_log_rotator());
-        runtimes_map.insert("cloud-hypervisor".to_string(), Arc::new(ch_lifecycle));
     } else {
         info!("Cloud Hypervisor runtime disabled in config, skipping");
     }
 
-    // Firecracker: same opt-in + fail-fast contract. Its binary must resolve
-    // when enabled, else Ring refuses to start.
+    // Firecracker: same opt-in contract. Its binary must resolve when enabled,
+    // else the runtime is skipped (best-effort, like the others).
     if configuration.server.runtime.firecracker.enabled {
         let fc_runtime_config =
             FirecrackerRuntimeConfig::from_user_config(&configuration.server.runtime.firecracker);
-        if !fc_runtime_config.is_available() {
-            error!(
-                "Refusing to start: Firecracker runtime is enabled in config but its binary \
-                 '{}' could not be found",
+        if fc_runtime_config.is_available() {
+            info!(
+                "Firecracker runtime: binary={}, kernel={}, socket_dir={}",
+                fc_runtime_config.binary_path,
+                fc_runtime_config.kernel_path,
+                fc_runtime_config.socket_dir,
+            );
+            runtimes_map.insert(
+                "firecracker".to_string(),
+                Arc::new(FirecrackerLifecycle::new(fc_runtime_config)),
+            );
+        } else {
+            let reason = format!(
+                "binary '{}' could not be found",
                 fc_runtime_config.binary_path
             );
-            std::process::exit(1);
+            warn!(
+                "Firecracker runtime enabled but unavailable, skipping: {}",
+                reason
+            );
+            runtime_failures.push(("firecracker".to_string(), reason));
         }
-        info!(
-            "Firecracker runtime: binary={}, kernel={}, socket_dir={}",
-            fc_runtime_config.binary_path,
-            fc_runtime_config.kernel_path,
-            fc_runtime_config.socket_dir,
-        );
-        runtimes_map.insert(
-            "firecracker".to_string(),
-            Arc::new(FirecrackerLifecycle::new(fc_runtime_config)),
-        );
     } else {
         info!("Firecracker runtime disabled in config, skipping");
     }
 
-    // Hard floor: no runtime enabled means Ring can't deploy anything — fail
-    // loudly with an actionable message instead of starting a useless server.
-    if runtimes_map.is_empty() {
-        error!(
-            "Refusing to start: no container runtime is enabled. Enable at least one in \
-             config.toml, e.g. `[server.runtime.docker]` with `enabled = true`."
+    // Aggregate report: surface every enabled-but-skipped runtime in one place so
+    // the operator sees the full picture (not just the first failure).
+    if !runtime_failures.is_empty() {
+        let summary = runtime_failures
+            .iter()
+            .map(|(name, reason)| format!("{} ({})", name, reason))
+            .collect::<Vec<_>>()
+            .join(", ");
+        warn!(
+            "Enabled runtimes that failed to start and were skipped: {}",
+            summary
         );
+    }
+
+    // Hard floor: if every enabled runtime failed (or none was enabled), Ring
+    // can't deploy anything — fail loudly instead of starting a useless server.
+    if runtimes_map.is_empty() {
+        if runtime_failures.is_empty() {
+            error!(
+                "Refusing to start: no container runtime is enabled. Enable at least one in \
+                 config.toml, e.g. `[server.runtime.docker]` with `enabled = true`."
+            );
+        } else {
+            error!(
+                "Refusing to start: every enabled runtime is unreachable. Fix at least one of \
+                 the runtimes above, or enable a reachable one in config.toml."
+            );
+        }
         std::process::exit(1);
     }
 

--- a/src/runtime/docker/docker_lifecycle.rs
+++ b/src/runtime/docker/docker_lifecycle.rs
@@ -27,13 +27,31 @@ fn filter_instances(
 pub struct DockerLifecycle {
     docker: Docker,
     intentional_shutdowns: IntentionalShutdowns,
+    /// Whether crash detection comes from a Docker event listener (`die`/`oom`/
+    /// `kill` → `restart_count`). Docker runs one; Podman does not (its event
+    /// stream only flows while `podman system service` is up), so for Podman the
+    /// reconcile pass must detect exited containers itself — otherwise a
+    /// crash-looping container is silently recreated forever and never reaches
+    /// `CrashLoopBackOff`. `true` for Docker, `false` for Podman.
+    events_driven: bool,
 }
 
 impl DockerLifecycle {
+    /// Docker: an event listener drives crash counting.
     pub fn new(docker: Docker, intentional_shutdowns: IntentionalShutdowns) -> Self {
         Self {
             docker,
             intentional_shutdowns,
+            events_driven: true,
+        }
+    }
+
+    /// Podman: no event listener — the reconcile pass detects crashes instead.
+    pub fn new_podman(docker: Docker, intentional_shutdowns: IntentionalShutdowns) -> Self {
+        Self {
+            docker,
+            intentional_shutdowns,
+            events_driven: false,
         }
     }
 }
@@ -50,6 +68,7 @@ impl RuntimeLifecycle for DockerLifecycle {
             self.docker.clone(),
             resolved_mounts,
             self.intentional_shutdowns.clone(),
+            self.events_driven,
         )
         .await
     }

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -15,6 +15,7 @@ pub(crate) async fn apply(
     docker: Docker,
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
+    events_driven: bool,
 ) -> Deployment {
     let status_filter = if deployment.status == DeploymentStatus::Deleted {
         "all"
@@ -26,7 +27,55 @@ pub(crate) async fn apply(
     if deployment.kind == "job" {
         handle_job_deployment(deployment, docker, resolved_mounts, intentional_shutdowns).await
     } else {
-        handle_worker_deployment(deployment, docker, resolved_mounts, intentional_shutdowns).await
+        handle_worker_deployment(
+            deployment,
+            docker,
+            resolved_mounts,
+            intentional_shutdowns,
+            events_driven,
+        )
+        .await
+    }
+}
+
+/// Detect containers that started then exited unexpectedly since the last
+/// reconcile, and bump `restart_count` for each so a crash loop eventually
+/// reaches `CrashLoopBackOff`.
+///
+/// Only used when the runtime has NO event listener (Podman). On Docker the
+/// `die`/`oom`/`kill` events already drive `restart_count`, so running this
+/// there too would double-count and contend over `IntentionalShutdowns`.
+///
+/// Operator-initiated stops (scale-down, delete, rolling update, health-check
+/// eviction) pre-mark the container in `IntentionalShutdowns`; those are
+/// consumed and skipped here so a scale-down is never mistaken for a crash. Each
+/// real crash is reaped (removed) so its `exited` state isn't re-counted on the
+/// next tick.
+async fn detect_and_count_crashes(
+    deployment: &mut Deployment,
+    docker: &Docker,
+    intentional_shutdowns: &IntentionalShutdowns,
+) {
+    let exited = list_instances(docker, deployment.id.to_string(), "exited").await;
+    for container_id in exited {
+        if intentional_shutdowns.take(&container_id).await {
+            // Operator-initiated stop — not a crash. Reap it quietly.
+            remove_container(docker.clone(), container_id).await;
+            continue;
+        }
+        deployment.restart_count += 1;
+        deployment.emit_event(
+            "error",
+            format!(
+                "Container {} exited unexpectedly (restart {})",
+                &container_id[..container_id.len().min(12)],
+                deployment.restart_count
+            ),
+            "docker",
+            Some("container_crashed"),
+        );
+        // Reap the dead container so it is not counted again next tick.
+        remove_container(docker.clone(), container_id).await;
     }
 }
 
@@ -250,6 +299,7 @@ async fn handle_worker_deployment(
     docker: Docker,
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
+    events_driven: bool,
 ) -> Deployment {
     if deployment.status == DeploymentStatus::Deleted {
         debug!("{} marked as deleted. Remove all instances", deployment.id);
@@ -260,6 +310,20 @@ async fn handle_worker_deployment(
     } else if deployment.status == DeploymentStatus::CrashLoopBackOff {
         return deployment;
     } else {
+        // Runtimes without an event listener (Podman) can't learn of a
+        // started-then-exited container from a `die` event, so detect it here:
+        // count each unexpected exit toward restart_count before deciding how
+        // many to (re)create. Without this the deployment recreates a crashing
+        // container forever and never reaches CrashLoopBackOff. Re-check the
+        // restart bound right after, so we converge in the same tick.
+        if !events_driven {
+            detect_and_count_crashes(&mut deployment, &docker, &intentional_shutdowns).await;
+            if deployment.restart_count >= MAX_RESTART_COUNT {
+                deployment.status = DeploymentStatus::CrashLoopBackOff;
+                return deployment;
+            }
+        }
+
         let current_count: usize = deployment.instances.len();
         let target_count: usize = match deployment.replicas.try_into() {
             Ok(count) => count,

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -912,13 +912,32 @@ async fn drain_docker_events(
     pool: &SqlitePool,
     event_rx: &mut mpsc::Receiver<DockerEvent>,
     intentional_shutdowns: &IntentionalShutdowns,
+    disconnect_logged: &mut bool,
 ) {
     loop {
         match event_rx.try_recv() {
-            Ok(event) => apply_docker_event(pool, event, intentional_shutdowns).await,
+            Ok(event) => {
+                // A live event means the channel is healthy; re-arm the
+                // one-shot log so a *later* disconnect is reported again.
+                *disconnect_logged = false;
+                apply_docker_event(pool, event, intentional_shutdowns).await
+            }
             Err(mpsc::error::TryRecvError::Empty) => return,
             Err(mpsc::error::TryRecvError::Disconnected) => {
-                error!("Docker event channel disconnected — listener task likely died");
+                // The channel is disconnected for the whole process lifetime
+                // when no Docker event listener was started — the normal case
+                // for a Podman- or containerd-only node (crash detection there
+                // is reconcile-based, not event-based). Log it ONCE at debug so
+                // we don't spam an ERROR every scheduler tick. A genuinely
+                // crashed listener on a Docker node also lands here; the single
+                // line is enough to notice it.
+                if !*disconnect_logged {
+                    debug!(
+                        "Docker event channel disconnected — no event listener \
+                         (Podman/containerd use reconcile-based crash detection)"
+                    );
+                    *disconnect_logged = true;
+                }
                 return;
             }
         }
@@ -1083,6 +1102,10 @@ pub(crate) async fn schedule(
     let cleanup_interval = Duration::from_secs(300);
     let mut last_cleanup = Instant::now();
 
+    // One-shot guard so a permanently disconnected event channel (a node with
+    // no Docker event listener) is logged once, not every tick.
+    let mut event_disconnect_logged = false;
+
     // Per-deployment retry backoff. Shared across runtimes so any new runtime
     // (Docker, Cloud Hypervisor, future Firecracker, ...) automatically gets
     // exponential backoff on transient failures without duplicating the logic.
@@ -1098,7 +1121,13 @@ pub(crate) async fn schedule(
         // Doing this before `find_all` ensures that the deployments we load
         // already reflect the latest restart_count, so the worker scaler can
         // hit CrashLoopBackOff in the same cycle as the crash that caused it.
-        drain_docker_events(&pool, &mut event_rx, &intentional_shutdowns).await;
+        drain_docker_events(
+            &pool,
+            &mut event_rx,
+            &intentional_shutdowns,
+            &mut event_disconnect_logged,
+        )
+        .await;
 
         // The scheduler picks up every status that can still progress on the
         // next tick. Pending/Creating need their first apply, Running needs

--- a/tests/e2e/podman/t3_podman_crashloop.sh
+++ b/tests/e2e/podman/t3_podman_crashloop.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# T3-podman: prove a crash-looping container converges to CrashLoopBackOff on
+# Podman — bounded, not an infinite recreate.
+#
+# Regression guard: Podman has no Docker event listener, so a container that
+# STARTS then EXITS was never counted as a crash. restart_count stayed 0, status
+# stayed running, and the scheduler recreated a fresh container every tick
+# forever (70+ containers observed), never reaching CrashLoopBackOff. The fix
+# detects exited (non-intentional) containers during reconciliation and bumps
+# restart_count, reaping each dead container so it isn't re-counted.
+#
+# This deploys a container that exits 1 immediately and asserts:
+#   1. it reaches crash_loop_back_off, and
+#   2. the live Podman container count stays bounded (no runaway recreation).
+#
+# Skips cleanly (exit 0) if Podman or its rootless socket isn't available.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T3-podman: crash loop converges to CrashLoopBackOff =="
+
+if ! command -v podman > /dev/null 2>&1; then
+  log "podman not installed — SKIP"
+  exit 0
+fi
+
+PODMAN_SOCK="${RING_PODMAN_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+SOCK_PATH="${PODMAN_SOCK#unix://}"
+if [ ! -S "$SOCK_PATH" ]; then
+  systemctl --user start podman.socket 2>/dev/null || true
+  if [ ! -S "$SOCK_PATH" ]; then
+    log "podman socket $SOCK_PATH not available — SKIP"
+    exit 0
+  fi
+fi
+log "podman socket: $SOCK_PATH"
+
+cleanup_podman() {
+  podman ps -aq --filter "label=ring_deployment" 2>/dev/null \
+    | xargs -r podman rm -f > /dev/null 2>&1 || true
+}
+trap 'cleanup_podman; cleanup_ring' EXIT
+
+export RING_E2E_ENABLE_DOCKER=false
+export RING_EXTRA_CONFIG="[server.runtime.podman]
+enabled = true
+host = \"$PODMAN_SOCK\""
+
+start_ring
+ring_login
+
+# A container that exits 1 the moment it starts — a textbook crash loop.
+FIXTURE="$RING_TEST_DIR/crasher.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  crasher:
+    name: crasher
+    namespace: ring-e2e
+    runtime: podman
+    image: docker.io/library/alpine:latest
+    replicas: 1
+    command: ["sh", "-c", "exit 1"]
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+DID=$(get_deployment_id "ring-e2e" "crasher")
+[ -n "$DID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DID"
+
+# Must reach crash_loop_back_off within MAX_RESTART_COUNT cycles, AND the live
+# container count must never blow up (the bug created one per tick, unbounded).
+reached=0
+max_seen=0
+for _ in $(seq 1 40); do
+  status=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg id "$DID" '.[] | select(.id==$id) | .status' | head -n1)
+  live=$(podman ps -aq --filter "label=ring_deployment=$DID" | wc -l | tr -d ' ')
+  [ "$live" -gt "$max_seen" ] && max_seen=$live
+  if [ "$status" = "crash_loop_back_off" ]; then
+    reached=1
+    break
+  fi
+  sleep 1
+done
+
+[ "$reached" -eq 1 ] || fail "crasher never reached crash_loop_back_off (bug: infinite recreate)"
+log "reached crash_loop_back_off"
+
+# Bounded recreation: a single replica crash loop must not accumulate many
+# containers. Allow generous slack for in-flight reaping but catch a runaway
+# (the bug reached 70+ within 40s).
+[ "$max_seen" -le 5 ] || fail "container count blew up to $max_seen (expected bounded ≤5) — runaway recreation"
+log "container count stayed bounded (max seen: $max_seen)"
+
+log "== T3-podman: PASS =="


### PR DESCRIPTION
## Summary

Two event-related fixes that bring Podman (and containerd) in line with Docker.

## 1. Podman crash loops never reached CrashLoopBackOff

A Podman container that **starts then exits** (a crash, e.g. `command: ["sh","-c","exit 1"]`) was never counted as a crash. Podman has no Docker event listener — its event stream only flows while `podman system service` runs — so the `die`/`oom`/`kill` path that bumps `restart_count` never fired. Container *creation* succeeds, so `handle_create_error` didn't fire either. Result: `restart_count` stayed 0, status stayed `running`, and the scheduler recreated a fresh container every tick **forever** (70+ observed), never reaching `CrashLoopBackOff`.

Fix: an `events_driven` flag on `DockerLifecycle` (`true` for Docker, `false` for Podman via `new_podman`). When `false`, the worker reconcile pass lists **exited** containers, skips operator-initiated stops (consumed from `IntentionalShutdowns`, same as the event path, so a scale-down is never mistaken for a crash), bumps `restart_count` for real crashes, emits a crash event, and reaps each dead container so it isn't re-counted. Docker keeps its event-driven counting untouched — no double-count.

containerd already inspects task exit status during reconciliation, so it was never affected.

## 2. `event channel disconnected` log spam

On a Podman- or containerd-only node there is no event listener, so the event channel is disconnected for the whole process lifetime. `drain_docker_events` logged this at **ERROR every scheduler tick** — a misleading error-level line per second on a perfectly healthy node. Now logged **once at debug** (re-armed if a real event later arrives), reworded to note crash detection is reconcile-based there.

## Testing

- **Live Podman**: a crasher reaches `crash_loop_back_off` at `rc=5` with a **bounded** container count (was 70+). Verified the log spam is gone (0 lines over 12s, was ~12).
- New e2e `tests/e2e/podman/t3_podman_crashloop.sh` asserting convergence + bounded recreation.
- **Docker regression**: `t6_crashloop`, `t7_scaledown_no_falsepositive`, `t5_replicas`, `t23_create_container_error_loop` all pass — the event-driven path is unchanged.
- 630 unit tests green.

Docs updated (`concepts/runtimes.md`): Podman crash detection is reconcile-based and reaches CrashLoopBackOff.