### PR TITLE
ci: use Swatinem/rust-cache for robust cargo caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
       - uses: oven-sh/setup-bun@v2
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
       - run: rustup component add clippy
+      # Rust-specific cache (tokio/axum/clap all use it): prunes stale target/
+      # artifacts, keys on toolchain + Cargo.lock, and adds restore-keys so a
+      # Cargo.lock change reuses the closest cache instead of starting cold.
+      # save-if keeps PR runs from filling the 10 GB repo quota — only main saves.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-targets -- -D warnings
 
   dashboard-lint:
@@ -58,18 +58,14 @@ jobs:
       RING_SECRET_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
       - uses: oven-sh/setup-bun@v2
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: docker pull nginx:alpine
       - run: cargo test
 
@@ -78,5 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Caches ~/.cargo/bin (cache-bin defaults to true) so the compiled
+      # cargo-audit binary is reused instead of recompiled from scratch each run.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo install cargo-audit
       - run: cargo audit --ignore RUSTSEC-2023-0071

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-gnu-${{ hashFiles('**/Cargo.lock') }}
+      # Per-job cache key (rust-cache appends the job id automatically), so the
+      # gnu and musl release builds keep separate caches.
+      - uses: Swatinem/rust-cache@v2
 
       # The dashboard's static build is baked into the Rust binary via
       # rust-embed, so it must exist before `cargo build` runs. Skipping
@@ -80,13 +76,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-musl-${{ hashFiles('**/Cargo.lock') }}
+      # Distinct per-job cache (rust-cache appends the job id), keeping the musl
+      # target/ artifacts separate from the gnu build above.
+      - uses: Swatinem/rust-cache@v2
 
       # ring-agent must be a static binary so users can drop it into any
       # guest image regardless of its libc — musl is the standard choice.


### PR DESCRIPTION
## Why

The CI cached cargo with a manual `actions/cache` keyed solely on `hashFiles('Cargo.lock')` and **no `restore-keys`** — so any change to `Cargo.lock` invalidated the whole cache and forced a cold rebuild of every dependency. The `clippy` and `test` jobs also used different keys, duplicating the dependency compilation, and the `audit` job recompiled `cargo-audit` from scratch on every run.

## Change

Switch to `Swatinem/rust-cache@v2`, the Rust-specific cache action used by tokio, axum and clap. It:
- prunes stale `target/` artifacts (avoids the unbounded growth that triggers GitHub's 10 GB cache eviction),
- keys on the toolchain + Cargo files and adds restore-keys, so a `Cargo.lock` change reuses the closest cache instead of starting cold,
- caches `~/.cargo/bin`, so the `audit` job reuses the compiled `cargo-audit` binary.

`save-if: ${{ github.ref == 'refs/heads/main' }}` on the CI jobs means PR runs restore the cache but only `main` writes it, keeping PR branches from filling the per-repo quota. Release jobs (gnu/musl) keep distinct per-job caches via rust-cache's automatic job-id key.

## Sources

- README Swatinem/rust-cache (target pruning, restore-keys, 10 GB limit, save-if guidance)
- GitHub Actions cache docs (10 GB/repo limit, LRU + 7-day eviction, restore-keys fallback)
- tokio / axum / clap CI all use `Swatinem/rust-cache@v2`