### PR TITLE
feat: add public Prometheus /metrics endpoint

### DIFF
--- a/documentation/help/observe-and-debug.md
+++ b/documentation/help/observe-and-debug.md
@@ -152,7 +152,49 @@ Returns CPU% (one core = 100), memory (`usage_bytes`, `limit_bytes`, `usage_perc
 - **Docker** — all five categories populated, sourced from the Docker stats endpoint
 - **Cloud Hypervisor** — CPU% and memory from `/proc/<pid>/*` of the VMM process; `network`, `disk_io`, `pids` reported as zero pending host-side wiring
 
-**Snapshot, not history.** Ring does not retain a time-series. Scrape the endpoint periodically into Prometheus / InfluxDB / a flat file if you want trends. A first-class Prometheus exporter is on the roadmap.
+**Snapshot, not history.** `ring deployment metrics` returns the current sample only — Ring does not retain a time-series. For trends, scrape the Prometheus endpoint below into your monitoring stack.
+
+## Prometheus
+
+`GET /metrics` exposes node-wide metrics in Prometheus text exposition format. No authentication (Prometheus scrapers send none); front it with TLS or a network ACL.
+
+```bash
+curl http://localhost:3030/metrics                       # Prometheus text
+curl -H 'Accept: application/json' http://localhost:3030/metrics   # same values as JSON
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: ring
+    static_configs:
+      - targets: ['localhost:3030']
+```
+
+Two families of series:
+
+- **Inventory** — `ring_deployments_by_status{status=…}`, `ring_deployments_by_runtime{runtime=…}`, `ring_events_by_status{status=…}` (`pending` = outbound-queue depth, `dead` = dead-lettered), `ring_health_checks_by_status{status=…}`, plus counts for namespaces, secrets, volumes, users, webhooks, configs.
+- **Per-deployment resource usage** — `ring_deployment_cpu_usage_percent`, `ring_deployment_memory_usage_bytes`, `ring_deployment_network_*_bytes_total`, `ring_deployment_restarts_total`, … labelled `deployment` / `namespace` / `runtime`.
+
+Resource usage is refreshed in the background on the scheduler interval, not per scrape, so scraping is cheap regardless of how many deployments are running. `ring_runtime_last_refresh_seconds` exposes the last refresh time — values are at most one interval stale.
+
+Useful alerts:
+
+```promql
+# A deployment is crash-looping
+ring_deployments_by_status{status="crash_loop_back_off"} > 0
+
+# Outbound event queue is backing up
+ring_events_by_status{status="pending"} > 50
+
+# Events are being dead-lettered (delivery gave up)
+ring_events_by_status{status="dead"} > 0
+
+# The background stats refresh has stalled (no update in 2 minutes)
+time() - ring_runtime_last_refresh_seconds > 120
+```
+
+See [Reference: REST API](/documentation/reference/api) for the full list of series.
 
 ## Node view
 
@@ -207,9 +249,7 @@ An SSE events endpoint similar to `/logs?follow=true` is on the roadmap.
 ## Limits
 
 - **No structured-log ingestion.** JSON logs are passed through unparsed.
-- **No metrics history.** Each call returns the current sample only.
-- **No Prometheus endpoint** out of the box. Scrape per-deployment with an adapter.
-- **No outbound webhook for events.** Poll-and-forward for now.
+- **No metrics history.** `ring deployment metrics` returns the current sample only; for trends, scrape `/metrics` into Prometheus.
 
 ## See also
 

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -105,6 +105,24 @@ Check the server is up. Does not require authentication.
 { "state": "UP" }
 ```
 
+### `GET /metrics`
+
+Prometheus metrics for the whole node. Does not require authentication (Prometheus scrapers send none; front it with TLS / a network ACL).
+
+Content negotiation by `Accept`:
+
+- default (or any non-JSON `Accept`) → Prometheus text exposition `version=0.0.4`
+- `Accept: application/json` → the same values as a JSON object
+
+Two families of series are exposed:
+
+- **Inventory** (read from the database on each scrape): `ring_deployments`, `ring_deployments_by_status{status=…}`, `ring_deployments_by_runtime{runtime=…}`, `ring_events_by_status{status=…}` (`pending` is the outbound-queue depth, `dead` the dead-letter count), `ring_health_checks_by_status{status=…}`, and counts for `ring_namespaces` / `ring_secrets` / `ring_volumes` / `ring_users` / `ring_webhooks` / `ring_configs`. Every known status is emitted even at `0`, so a series never disappears between scrapes (which would break alerts written against it).
+- **Per-deployment resource usage** (labelled `deployment` / `namespace` / `runtime`): gauges `ring_deployment_instances`, `ring_deployment_cpu_usage_percent`, `ring_deployment_memory_usage_bytes`, `ring_deployment_memory_limit_bytes`, `ring_deployment_pids`; counters `ring_deployment_network_rx_bytes_total`, `ring_deployment_network_tx_bytes_total`, `ring_deployment_disk_read_bytes_total`, `ring_deployment_disk_write_bytes_total`, `ring_deployment_restarts_total`.
+
+Resource usage is refreshed in the background on the scheduler interval, not at request time, so a scrape never blocks on the runtimes. `ring_runtime_last_refresh_seconds` carries the Unix time of the last successful refresh — alert on `time() - ring_runtime_last_refresh_seconds` to catch a stalled refresh. Values are therefore at most one interval stale; for a fresh point-in-time read of one deployment use [`GET /deployments/{id}/metrics`](#get-deploymentsidmetrics).
+
+The per-deployment series carry one time series per running deployment (`deployment` / `namespace` labels). Series count grows with the number of deployments, so on nodes that churn through many short-lived deployments keep an eye on your Prometheus cardinality.
+
 ## Deployments
 
 ### `GET /deployments`

--- a/src/api/action/metrics.rs
+++ b/src/api/action/metrics.rs
@@ -1,0 +1,428 @@
+//! `/metrics` endpoint with two output formats negotiated via `Accept`.
+//!
+//! Reads the live inventory from the database and renders it in either:
+//!
+//! - Prometheus text exposition `version=0.0.4` (default — what Prometheus
+//!   scrapers expect when no `Accept` is sent);
+//! - JSON, when the client sends `Accept: application/json`. Same data,
+//!   structured for direct consumption by a dashboard or any other client that
+//!   prefers to skip the text-parsing step.
+//!
+//! No moving parts, no background aggregator — every scrape recomputes from the
+//! database, so values are always consistent with what the rest of the API
+//! would return.
+//!
+//! Endpoint is intentionally unauthenticated: Prometheus scrapers default to no
+//! auth and operators front the API with TLS / network ACLs anyway.
+//!
+//! This is the lightweight inventory snapshot (counts only). Per-deployment
+//! resource usage (CPU/memory/network) lives behind `/deployments/{id}/metrics`
+//! because querying every runtime on each scrape would be expensive; it can be
+//! folded in here later as an additive section without breaking this format.
+
+use crate::api::server::AppState;
+use crate::models::deployments::DeploymentStatus;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use tracing::error;
+
+const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
+
+pub(crate) async fn metrics(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let snap = Snapshot::collect(&state.connection).await;
+
+    let (body, content_type) = if wants_json(&headers) {
+        let body = serde_json::to_string(&snap).unwrap_or_else(|e| {
+            error!("metrics: JSON serialization failed: {}", e);
+            "{}".to_string()
+        });
+        (body, JSON_CONTENT_TYPE)
+    } else {
+        (render_prom(&snap), PROM_CONTENT_TYPE)
+    };
+
+    let mut response = (StatusCode::OK, body).into_response();
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response
+}
+
+/// Returns true when the request's `Accept` header asks for JSON. Anything
+/// else — including no `Accept`, `*/*`, or the Prometheus content-type — falls
+/// back to Prometheus text so existing scrapers are never surprised by a JSON
+/// body.
+fn wants_json(headers: &HeaderMap) -> bool {
+    let Some(accept) = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok()) else {
+        return false;
+    };
+    accept
+        .split(',')
+        .map(|part| part.split(';').next().unwrap_or("").trim())
+        .any(|media| media.eq_ignore_ascii_case("application/json"))
+}
+
+/// Numeric snapshot of every metric we expose, computed once per scrape from
+/// the database. Both renderers (Prometheus text and JSON) read from this
+/// struct so the two formats can never drift on values.
+///
+/// The `deployments_by_*` maps use `BTreeMap` so label order is deterministic
+/// across scrapes.
+#[derive(Debug, Default, Serialize)]
+struct Snapshot {
+    /// Deployments excluding the `deleted` tombstone status — the count an
+    /// operator means by "how many deployments do I have".
+    deployments: u64,
+    deployments_by_status: BTreeMap<String, u64>,
+    deployments_by_runtime: BTreeMap<String, u64>,
+    namespaces: u64,
+    secrets: u64,
+    volumes: u64,
+    users: u64,
+    webhooks: u64,
+    configs: u64,
+    /// Outbound event queue by delivery status. `pending` is the live queue
+    /// depth, `dead` is the dead-letter count — both are alerting signals.
+    events_by_status: BTreeMap<String, u64>,
+    /// Health-check results by status; failing checks surface here.
+    health_checks_by_status: BTreeMap<String, u64>,
+}
+
+/// Delivery statuses of the outbound event queue, always emitted so the series
+/// never vanish between scrapes. Mirrors the `events.status` domain documented
+/// in migration `20220101000019`.
+const EVENT_STATUSES: [&str; 3] = ["pending", "delivered", "dead"];
+
+impl Snapshot {
+    async fn collect(pool: &sqlx::SqlitePool) -> Self {
+        let mut snap = Snapshot::default();
+
+        // Seed every known deployment status at 0, then overlay the DB counts.
+        // A status with no rows still gets a series so alerts never break.
+        let status_keys = DeploymentStatus::all().map(|s| s.to_string());
+        snap.deployments_by_status = with_zero_keys(
+            group_count(pool, "deployment", "status").await,
+            status_keys.iter().map(String::as_str),
+        );
+        snap.deployments_by_runtime = group_count(pool, "deployment", "runtime").await;
+        snap.deployments = snap
+            .deployments_by_status
+            .iter()
+            .filter(|(status, _)| status.as_str() != "deleted")
+            .map(|(_, count)| count)
+            .sum();
+
+        snap.events_by_status = with_zero_keys(
+            group_count(pool, "events", "status").await,
+            EVENT_STATUSES.iter().copied(),
+        );
+        snap.health_checks_by_status = group_count(pool, "health_check", "status").await;
+
+        snap.namespaces = table_count(pool, "namespace").await;
+        snap.secrets = table_count(pool, "secret").await;
+        snap.volumes = table_count(pool, "volumes").await;
+        snap.users = table_count(pool, "user").await;
+        snap.webhooks = table_count(pool, "webhook").await;
+        snap.configs = table_count(pool, "config").await;
+
+        snap
+    }
+}
+
+/// `SELECT COUNT(*)` for a table. A query error logs and yields `0` rather than
+/// failing the whole scrape — a single broken series should never take the
+/// endpoint down for a scraper.
+async fn table_count(pool: &sqlx::SqlitePool, table: &str) -> u64 {
+    // `table` is a hard-coded literal at every call site, never user input, so
+    // the format!-built query carries no injection surface.
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    match sqlx::query_scalar::<_, i64>(&sql).fetch_one(pool).await {
+        Ok(count) => count.max(0) as u64,
+        Err(e) => {
+            error!("metrics: counting {} failed: {}", table, e);
+            0
+        }
+    }
+}
+
+/// `SELECT col, COUNT(*) ... GROUP BY col` as a label→count map. Same
+/// fail-soft contract as [`table_count`].
+async fn group_count(pool: &sqlx::SqlitePool, table: &str, column: &str) -> BTreeMap<String, u64> {
+    // `table`/`column` are hard-coded literals at every call site.
+    let sql = format!("SELECT {column}, COUNT(*) FROM {table} GROUP BY {column}");
+    match sqlx::query_as::<_, (String, i64)>(&sql)
+        .fetch_all(pool)
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(label, count)| (label, count.max(0) as u64))
+            .collect(),
+        Err(e) => {
+            error!("metrics: grouping {}.{} failed: {}", table, column, e);
+            BTreeMap::new()
+        }
+    }
+}
+
+/// Ensure every expected label value is present, defaulting to 0, without
+/// dropping any extra keys the DB returned. Keeps zero-valued series alive
+/// across scrapes (Prometheus alerts break when a series disappears) while
+/// still surfacing unforeseen values.
+fn with_zero_keys<'a>(
+    mut counts: BTreeMap<String, u64>,
+    expected: impl Iterator<Item = &'a str>,
+) -> BTreeMap<String, u64> {
+    for key in expected {
+        counts.entry(key.to_string()).or_insert(0);
+    }
+    counts
+}
+
+fn render_prom(snap: &Snapshot) -> String {
+    let mut out = String::with_capacity(1024);
+
+    write_gauge(
+        &mut out,
+        "ring_deployments",
+        "Number of deployments, excluding deleted ones.",
+        snap.deployments,
+    );
+
+    write_labelled_gauge(
+        &mut out,
+        "ring_deployments_by_status",
+        "Number of deployments per status (includes deleted).",
+        "status",
+        &snap.deployments_by_status,
+    );
+    write_labelled_gauge(
+        &mut out,
+        "ring_deployments_by_runtime",
+        "Number of deployments per runtime (includes deleted).",
+        "runtime",
+        &snap.deployments_by_runtime,
+    );
+
+    write_gauge(
+        &mut out,
+        "ring_namespaces",
+        "Number of namespaces.",
+        snap.namespaces,
+    );
+    write_gauge(&mut out, "ring_secrets", "Number of secrets.", snap.secrets);
+    write_gauge(&mut out, "ring_volumes", "Number of volumes.", snap.volumes);
+    write_gauge(&mut out, "ring_users", "Number of users.", snap.users);
+    write_gauge(
+        &mut out,
+        "ring_webhooks",
+        "Number of webhooks.",
+        snap.webhooks,
+    );
+    write_gauge(&mut out, "ring_configs", "Number of configs.", snap.configs);
+
+    write_labelled_gauge(
+        &mut out,
+        "ring_events_by_status",
+        "Outbound events per delivery status (pending = queue depth, dead = dead-lettered).",
+        "status",
+        &snap.events_by_status,
+    );
+    write_labelled_gauge(
+        &mut out,
+        "ring_health_checks_by_status",
+        "Health-check results per status.",
+        "status",
+        &snap.health_checks_by_status,
+    );
+
+    out
+}
+
+fn write_gauge(out: &mut String, name: &str, help: &str, value: u64) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} gauge");
+    let _ = writeln!(out, "{name} {value}");
+}
+
+/// Render a gauge with one series per label value. Emits the HELP/TYPE pair
+/// once, then a line per entry. Label values are escaped per the Prometheus
+/// exposition rules (`\`, `"`, newline).
+fn write_labelled_gauge(
+    out: &mut String,
+    name: &str,
+    help: &str,
+    label: &str,
+    values: &BTreeMap<String, u64>,
+) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} gauge");
+    for (key, count) in values {
+        let _ = writeln!(
+            out,
+            "{name}{{{label}=\"{}\"}} {count}",
+            escape_label_value(key)
+        );
+    }
+}
+
+/// Escape a Prometheus label value: backslash, double-quote and newline, per
+/// the text exposition format.
+fn escape_label_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::server::tests::{login, new_test_app, new_test_app_with_pool};
+    use axum_test::TestServer;
+    use http::StatusCode;
+    use serde_json::json;
+
+    #[test]
+    fn escape_label_value_escapes_special_chars() {
+        assert_eq!(escape_label_value(r#"a"b\c"#), r#"a\"b\\c"#);
+        assert_eq!(escape_label_value("plain"), "plain");
+    }
+
+    #[test]
+    fn wants_json_recognizes_application_json() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT, "application/json".parse().unwrap());
+        assert!(wants_json(&h));
+    }
+
+    #[test]
+    fn wants_json_handles_multiple_media_types() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            header::ACCEPT,
+            "text/html, application/json;q=0.9, */*;q=0.8"
+                .parse()
+                .unwrap(),
+        );
+        assert!(wants_json(&h));
+    }
+
+    #[test]
+    fn wants_json_defaults_to_false_when_absent() {
+        assert!(!wants_json(&HeaderMap::new()));
+    }
+
+    #[tokio::test]
+    async fn metrics_is_public_and_prometheus_text() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let response = server.get("/metrics").await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert_eq!(
+            response.header(header::CONTENT_TYPE).to_str().unwrap(),
+            "text/plain; version=0.0.4; charset=utf-8"
+        );
+
+        let body = response.text();
+        assert!(body.contains("# HELP ring_deployments"));
+        assert!(body.contains("# TYPE ring_deployments gauge"));
+        assert!(body.contains("ring_namespaces"));
+        // The seeded fixtures include the admin user.
+        assert!(body.contains("ring_users"));
+    }
+
+    #[tokio::test]
+    async fn metrics_accept_json_returns_json() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let response = server
+            .get("/metrics")
+            .add_header(header::ACCEPT, "application/json")
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::OK);
+        assert_eq!(
+            response.header(header::CONTENT_TYPE).to_str().unwrap(),
+            "application/json; charset=utf-8"
+        );
+
+        let json: serde_json::Value = response.json();
+        assert!(json["deployments"].is_number());
+        assert!(json["deployments_by_status"].is_object());
+        assert!(json["users"].is_number());
+    }
+
+    #[test]
+    fn with_zero_keys_seeds_missing_and_keeps_extra() {
+        let mut counts = BTreeMap::new();
+        counts.insert("pending".to_string(), 3);
+        counts.insert("unexpected".to_string(), 1);
+        let out = with_zero_keys(counts, EVENT_STATUSES.iter().copied());
+        assert_eq!(out.get("pending"), Some(&3));
+        assert_eq!(out.get("delivered"), Some(&0));
+        assert_eq!(out.get("dead"), Some(&0));
+        // An unforeseen DB value is preserved, not dropped.
+        assert_eq!(out.get("unexpected"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn metrics_emit_all_statuses_even_at_zero() {
+        let server = TestServer::new(new_test_app().await).unwrap();
+        let body = server.get("/metrics").await.text();
+
+        // Error statuses that have no rows in fixtures must still be present.
+        assert!(body.contains("ring_deployments_by_status{status=\"crash_loop_back_off\"}"));
+        assert!(body.contains("ring_deployments_by_status{status=\"image_pull_back_off\"}"));
+        // Event queue statuses are always emitted.
+        assert!(body.contains("ring_events_by_status{status=\"pending\"}"));
+        assert!(body.contains("ring_events_by_status{status=\"dead\"}"));
+    }
+
+    #[tokio::test]
+    async fn metrics_counts_deployments_and_excludes_deleted_from_total() {
+        let (pool, app) = new_test_app_with_pool().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        // The fixtures already seed some deployments; measure the delta we add
+        // rather than an absolute count.
+        let before = Snapshot::collect(&pool).await;
+        let docker_before = before
+            .deployments_by_runtime
+            .get("docker")
+            .copied()
+            .unwrap_or(0);
+
+        for name in ["one", "two"] {
+            let create = server
+                .post("/deployments")
+                .add_header("Authorization", format!("Bearer {}", token))
+                .json(&json!({
+                    "runtime": "docker",
+                    "name": name,
+                    "namespace": "test",
+                    "image": "nginx:latest",
+                }))
+                .await;
+            assert_eq!(create.status_code(), StatusCode::CREATED);
+        }
+
+        let after = Snapshot::collect(&pool).await;
+        assert_eq!(after.deployments, before.deployments + 2);
+        assert_eq!(
+            after.deployments_by_runtime.get("docker").copied(),
+            Some(docker_before + 2)
+        );
+    }
+}

--- a/src/api/action/metrics.rs
+++ b/src/api/action/metrics.rs
@@ -8,17 +8,19 @@
 //!   structured for direct consumption by a dashboard or any other client that
 //!   prefers to skip the text-parsing step.
 //!
-//! No moving parts, no background aggregator — every scrape recomputes from the
-//! database, so values are always consistent with what the rest of the API
-//! would return.
+//! The inventory series (counts by status/runtime, table totals) are recomputed
+//! from the database on every scrape, so they are always consistent with what
+//! the rest of the API would return.
 //!
 //! Endpoint is intentionally unauthenticated: Prometheus scrapers default to no
 //! auth and operators front the API with TLS / network ACLs anyway.
 //!
-//! This is the lightweight inventory snapshot (counts only). Per-deployment
-//! resource usage (CPU/memory/network) lives behind `/deployments/{id}/metrics`
-//! because querying every runtime on each scrape would be expensive; it can be
-//! folded in here later as an additive section without breaking this format.
+//! Per-deployment resource usage (CPU/memory/network) is NOT read on the scrape
+//! path — querying every runtime on each scrape would be expensive. It comes
+//! from a background-refreshed snapshot (`scheduler::stats_cache`), so those
+//! series are at most one refresh interval stale; `ring_runtime_last_refresh_seconds`
+//! exposes that staleness. For a fresh point-in-time read of one deployment,
+//! use `/deployments/{id}/metrics`.
 
 use crate::api::server::AppState;
 use crate::models::deployments::DeploymentStatus;
@@ -34,7 +36,18 @@ const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
 
 pub(crate) async fn metrics(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    let snap = Snapshot::collect(&state.connection).await;
+    let mut snap = Snapshot::collect(&state.connection).await;
+
+    // Runtime resource usage comes from the background cache, never the request
+    // path, so the scrape stays cheap. A poisoned lock yields no runtime series
+    // (logged) rather than failing the whole scrape.
+    match state.stats_cache.read() {
+        Ok(guard) => {
+            snap.runtime_last_refresh_seconds = guard.last_refresh_unix;
+            snap.deployment_runtime = guard.deployments.iter().map(RuntimeSeries::from).collect();
+        }
+        Err(e) => error!("metrics: stats cache lock poisoned: {}", e),
+    }
 
     let (body, content_type) = if wants_json(&headers) {
         let body = serde_json::to_string(&snap).unwrap_or_else(|e| {
@@ -91,6 +104,53 @@ struct Snapshot {
     events_by_status: BTreeMap<String, u64>,
     /// Health-check results by status; failing checks surface here.
     health_checks_by_status: BTreeMap<String, u64>,
+    /// Unix timestamp of the last successful runtime-stats refresh; `0` if the
+    /// background worker has not completed a cycle yet.
+    runtime_last_refresh_seconds: u64,
+    /// Per-deployment runtime resource usage, sourced from the background
+    /// cache (not the DB). Empty until the first refresh, or when no active
+    /// deployment reports stats.
+    deployment_runtime: Vec<RuntimeSeries>,
+}
+
+/// Serializable, render-ready copy of one deployment's cached runtime stats.
+/// Mirrors `stats_cache::DeploymentRuntimeStats` but lives here so the cache
+/// type need not depend on serde or the metrics format.
+#[derive(Debug, Serialize)]
+struct RuntimeSeries {
+    name: String,
+    namespace: String,
+    runtime: String,
+    instances: u64,
+    cpu_usage_percent: f64,
+    memory_usage_bytes: u64,
+    memory_limit_bytes: u64,
+    network_rx_bytes: u64,
+    network_tx_bytes: u64,
+    disk_read_bytes: u64,
+    disk_write_bytes: u64,
+    pids: u64,
+    restarts: u64,
+}
+
+impl From<&crate::scheduler::stats_cache::DeploymentRuntimeStats> for RuntimeSeries {
+    fn from(s: &crate::scheduler::stats_cache::DeploymentRuntimeStats) -> Self {
+        RuntimeSeries {
+            name: s.name.clone(),
+            namespace: s.namespace.clone(),
+            runtime: s.runtime.clone(),
+            instances: s.instance_count,
+            cpu_usage_percent: s.cpu_usage_percent,
+            memory_usage_bytes: s.memory_usage_bytes,
+            memory_limit_bytes: s.memory_limit_bytes,
+            network_rx_bytes: s.network_rx_bytes,
+            network_tx_bytes: s.network_tx_bytes,
+            disk_read_bytes: s.disk_read_bytes,
+            disk_write_bytes: s.disk_write_bytes,
+            pids: s.pids,
+            restarts: s.restarts,
+        }
+    }
 }
 
 /// Delivery statuses of the outbound event queue, always emitted so the series
@@ -241,7 +301,120 @@ fn render_prom(snap: &Snapshot) -> String {
         &snap.health_checks_by_status,
     );
 
+    render_runtime(&mut out, snap);
+
     out
+}
+
+/// Render the per-deployment runtime resource usage section. Sourced from the
+/// background cache; values are at most one refresh interval stale, surfaced
+/// via `ring_runtime_last_refresh_seconds` so a stale/stalled worker is
+/// detectable (`time() - ring_runtime_last_refresh_seconds`).
+///
+/// CPU, memory, pids and instance counts are gauges (point-in-time). Network
+/// and disk byte totals are counters (monotonic, cumulative since the
+/// instance started) — `rate(...)` them in PromQL.
+fn render_runtime(out: &mut String, snap: &Snapshot) {
+    write_gauge(
+        out,
+        "ring_runtime_last_refresh_seconds",
+        "Unix timestamp of the last successful runtime-stats refresh. 0 means never.",
+        snap.runtime_last_refresh_seconds,
+    );
+
+    if snap.deployment_runtime.is_empty() {
+        return;
+    }
+
+    // (name, HELP, value extractor). One group per metric: a single HELP/TYPE
+    // pair followed by all its series, as the exposition format requires.
+    let gauges: [RuntimeMetric; 5] = [
+        (
+            "ring_deployment_instances",
+            "Number of running instances per deployment.",
+            |s| s.instances.to_string(),
+        ),
+        (
+            "ring_deployment_cpu_usage_percent",
+            "Aggregate CPU usage percent across a deployment's instances.",
+            |s| format!("{:.2}", s.cpu_usage_percent),
+        ),
+        (
+            "ring_deployment_memory_usage_bytes",
+            "Aggregate memory usage in bytes across a deployment's instances.",
+            |s| s.memory_usage_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_memory_limit_bytes",
+            "Aggregate memory limit in bytes across a deployment's instances.",
+            |s| s.memory_limit_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_pids",
+            "Aggregate process/thread count across a deployment's instances.",
+            |s| s.pids.to_string(),
+        ),
+    ];
+    for metric in gauges {
+        write_runtime_metric_group(out, metric, "gauge", &snap.deployment_runtime);
+    }
+
+    let counters: [RuntimeMetric; 5] = [
+        (
+            "ring_deployment_network_rx_bytes_total",
+            "Cumulative bytes received per deployment since instance start.",
+            |s| s.network_rx_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_network_tx_bytes_total",
+            "Cumulative bytes transmitted per deployment since instance start.",
+            |s| s.network_tx_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_disk_read_bytes_total",
+            "Cumulative bytes read from disk per deployment since instance start.",
+            |s| s.disk_read_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_disk_write_bytes_total",
+            "Cumulative bytes written to disk per deployment since instance start.",
+            |s| s.disk_write_bytes.to_string(),
+        ),
+        (
+            "ring_deployment_restarts_total",
+            "Cumulative restart count across a deployment's instances.",
+            |s| s.restarts.to_string(),
+        ),
+    ];
+    for metric in counters {
+        write_runtime_metric_group(out, metric, "counter", &snap.deployment_runtime);
+    }
+}
+
+/// A per-deployment runtime metric: its name, HELP text, and a function
+/// extracting its rendered value from one deployment's stats.
+type RuntimeMetric = (&'static str, &'static str, fn(&RuntimeSeries) -> String);
+
+/// Emit one metric group: the HELP/TYPE header, then one labelled series per
+/// deployment.
+fn write_runtime_metric_group(
+    out: &mut String,
+    (name, help, value): RuntimeMetric,
+    metric_type: &str,
+    deployments: &[RuntimeSeries],
+) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} {metric_type}");
+    for s in deployments {
+        let _ = writeln!(
+            out,
+            "{name}{{deployment=\"{}\",namespace=\"{}\",runtime=\"{}\"}} {}",
+            escape_label_value(&s.name),
+            escape_label_value(&s.namespace),
+            escape_label_value(&s.runtime),
+            value(s),
+        );
+    }
 }
 
 fn write_gauge(out: &mut String, name: &str, help: &str, value: u64) {
@@ -387,6 +560,53 @@ mod tests {
         // Event queue statuses are always emitted.
         assert!(body.contains("ring_events_by_status{status=\"pending\"}"));
         assert!(body.contains("ring_events_by_status{status=\"dead\"}"));
+    }
+
+    #[test]
+    fn render_runtime_emits_labelled_series_and_skips_when_empty() {
+        // Empty cache: only the freshness gauge, no per-deployment series.
+        let body = render_prom(&Snapshot::default());
+        assert!(body.contains("ring_runtime_last_refresh_seconds 0"));
+        assert!(!body.contains("ring_deployment_cpu_usage_percent"));
+
+        // Populated cache: one deployment, fully labelled, gauges + counters.
+        let snap = Snapshot {
+            runtime_last_refresh_seconds: 1717000000,
+            deployment_runtime: vec![RuntimeSeries {
+                name: "web".to_string(),
+                namespace: "prod".to_string(),
+                runtime: "docker".to_string(),
+                instances: 2,
+                cpu_usage_percent: 12.5,
+                memory_usage_bytes: 1000,
+                memory_limit_bytes: 4000,
+                network_rx_bytes: 50,
+                network_tx_bytes: 60,
+                disk_read_bytes: 70,
+                disk_write_bytes: 80,
+                pids: 9,
+                restarts: 3,
+            }],
+            ..Default::default()
+        };
+        let body = render_prom(&snap);
+
+        assert!(body.contains("ring_runtime_last_refresh_seconds 1717000000"));
+        assert!(body.contains("# TYPE ring_deployment_cpu_usage_percent gauge"));
+        assert!(body.contains(
+            "ring_deployment_cpu_usage_percent{deployment=\"web\",namespace=\"prod\",runtime=\"docker\"} 12.50"
+        ));
+        assert!(body.contains(
+            "ring_deployment_instances{deployment=\"web\",namespace=\"prod\",runtime=\"docker\"} 2"
+        ));
+        // Cumulative metrics are counters with the `_total` suffix.
+        assert!(body.contains("# TYPE ring_deployment_network_rx_bytes_total counter"));
+        assert!(body.contains(
+            "ring_deployment_network_rx_bytes_total{deployment=\"web\",namespace=\"prod\",runtime=\"docker\"} 50"
+        ));
+        assert!(body.contains(
+            "ring_deployment_restarts_total{deployment=\"web\",namespace=\"prod\",runtime=\"docker\"} 3"
+        ));
     }
 
     #[tokio::test]

--- a/src/api/action/mod.rs
+++ b/src/api/action/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod deployment;
 pub(crate) mod healthz;
 pub(crate) mod login;
 pub(crate) mod logout;
+pub(crate) mod metrics;
 pub(crate) mod namespace;
 pub(crate) mod node;
 pub(crate) mod secret;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -67,6 +67,7 @@ use crate::api::action::webhook::events as webhook_events;
 use crate::api::action::webhook::list as webhook_list;
 
 use crate::api::action::healthz::healthz;
+use crate::api::action::metrics::metrics;
 
 use crate::api::auth::auth_middleware;
 
@@ -99,7 +100,8 @@ pub(crate) fn router(state: AppState) -> Router {
     // axum does not document) makes the public surface unambiguous.
     let public_routes = Router::new()
         .route("/login", post(login))
-        .route("/healthz", get(healthz));
+        .route("/healthz", get(healthz))
+        .route("/metrics", get(metrics));
 
     // SSE: protected, but NO timeout layer — a tower Timeout would kill the
     // long-lived stream. The auth middleware only wraps the request→response

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -86,12 +86,15 @@ pub(crate) type RuntimeMap = std::sync::Arc<
 
 pub(crate) type TicketStoreState = crate::api::stream_tickets::TicketStore;
 
+pub(crate) type StatsCacheState = crate::scheduler::stats_cache::StatsCache;
+
 #[derive(Clone, FromRef)]
 pub(crate) struct AppState {
     pub(crate) connection: SqlitePool,
     pub(crate) configuration: Config,
     pub(crate) runtimes: RuntimeMap,
     pub(crate) ticket_store: TicketStoreState,
+    pub(crate) stats_cache: StatsCacheState,
 }
 
 pub(crate) fn router(state: AppState) -> Router {
@@ -204,7 +207,12 @@ pub(crate) fn router(state: AppState) -> Router {
     app
 }
 
-pub(crate) async fn start(pool: SqlitePool, mut configuration: Config, runtimes: RuntimeMap) {
+pub(crate) async fn start(
+    pool: SqlitePool,
+    mut configuration: Config,
+    runtimes: RuntimeMap,
+    stats_cache: StatsCacheState,
+) {
     info!("Starting server on {}", configuration.get_api_url());
 
     let bind_addr = format!("{}:{}", configuration.host, configuration.api.port);
@@ -214,6 +222,7 @@ pub(crate) async fn start(pool: SqlitePool, mut configuration: Config, runtimes:
         configuration,
         runtimes,
         ticket_store: TicketStoreState::new(),
+        stats_cache,
     };
 
     let app = router(state);
@@ -283,6 +292,7 @@ pub(crate) mod tests {
             configuration,
             runtimes,
             ticket_store: TicketStoreState::new(),
+            stats_cache: crate::scheduler::stats_cache::new_cache(),
         };
 
         (pool, router(state))

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -280,10 +280,32 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     let event_listener_handler =
         docker_for_events.map(|docker| task::spawn(start_event_listener(event_tx, docker)));
 
+    // Shared cache of per-deployment runtime resource usage, refreshed in the
+    // background and read by `/metrics` so a scrape never blocks on the
+    // runtimes. See `scheduler::stats_cache`.
+    let stats_cache = crate::scheduler::stats_cache::new_cache();
+    {
+        let cache = stats_cache.clone();
+        let cache_pool = pool.clone();
+        let cache_runtimes = runtimes.clone();
+        let cache_interval = configuration.server.scheduler.interval;
+        task::spawn(async move {
+            crate::scheduler::stats_cache::run(
+                cache,
+                cache_pool,
+                cache_runtimes,
+                cache_interval,
+                unix_now,
+            )
+            .await;
+        });
+    }
+
     let api_server_handler = task::spawn(ApiServer::start(
         pool.clone(),
         configuration.clone(),
         runtimes.clone(),
+        stats_cache,
     ));
 
     // Embedded dashboard — only spawned when explicitly enabled in config,
@@ -331,6 +353,16 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     {
         eprintln!("Docker event listener task failed: {}", e);
     }
+}
+
+/// Current Unix time in seconds, or `0` if the clock is before the epoch
+/// (never in practice). Handed to the stats-cache worker as its timestamp
+/// source so the module itself stays free of direct clock access.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// Print a concise, human-readable summary of where the server is reachable

--- a/src/hypervisor/mock.rs
+++ b/src/hypervisor/mock.rs
@@ -10,19 +10,29 @@ use std::pin::Pin;
 
 pub(crate) struct MockRuntime {
     health_check_result: (HealthCheckStatus, Option<String>),
+    instance_stats: Vec<InstanceStatsOutput>,
 }
 
 impl MockRuntime {
     pub(crate) fn healthy() -> Self {
         Self {
             health_check_result: (HealthCheckStatus::Success, None),
+            instance_stats: Vec::new(),
         }
     }
 
     pub(crate) fn unhealthy(message: &str) -> Self {
         Self {
             health_check_result: (HealthCheckStatus::Failed, Some(message.to_string())),
+            instance_stats: Vec::new(),
         }
+    }
+
+    /// Seed the stats this mock returns from `get_instance_stats`, so the
+    /// stats-cache refresh path can be exercised with deterministic numbers.
+    pub(crate) fn with_instance_stats(mut self, stats: Vec<InstanceStatsOutput>) -> Self {
+        self.instance_stats = stats;
+        self
     }
 }
 
@@ -73,6 +83,6 @@ impl RuntimeLifecycle for MockRuntime {
     }
 
     async fn get_instance_stats(&self, _deployment_id: &str) -> Vec<InstanceStatsOutput> {
-        Vec::new()
+        self.instance_stats.clone()
     }
 }

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -81,6 +81,31 @@ impl std::str::FromStr for DeploymentStatus {
     }
 }
 
+impl DeploymentStatus {
+    /// Every variant, in declaration order. Used to emit a metric series per
+    /// status even when its count is zero — a Prometheus series that vanishes
+    /// between scrapes breaks alerts written against it, so all statuses are
+    /// always present.
+    pub(crate) const fn all() -> [DeploymentStatus; 14] {
+        [
+            Self::Pending,
+            Self::Creating,
+            Self::Running,
+            Self::Completed,
+            Self::Failed,
+            Self::Deleted,
+            Self::CrashLoopBackOff,
+            Self::ImagePullBackOff,
+            Self::CreateContainerError,
+            Self::NetworkError,
+            Self::ConfigError,
+            Self::FileSystemError,
+            Self::InsufficientResources,
+            Self::Error,
+        ]
+    }
+}
+
 #[cfg(test)]
 mod status_roundtrip_tests {
     use super::DeploymentStatus;
@@ -92,23 +117,7 @@ mod status_roundtrip_tests {
     /// went undetected for months because there was no such test).
     #[test]
     fn every_variant_round_trips() {
-        let all = [
-            DeploymentStatus::Pending,
-            DeploymentStatus::Creating,
-            DeploymentStatus::Running,
-            DeploymentStatus::Completed,
-            DeploymentStatus::Failed,
-            DeploymentStatus::Deleted,
-            DeploymentStatus::CrashLoopBackOff,
-            DeploymentStatus::ImagePullBackOff,
-            DeploymentStatus::CreateContainerError,
-            DeploymentStatus::NetworkError,
-            DeploymentStatus::ConfigError,
-            DeploymentStatus::FileSystemError,
-            DeploymentStatus::InsufficientResources,
-            DeploymentStatus::Error,
-        ];
-        for s in all {
+        for s in DeploymentStatus::all() {
             let txt = s.to_string();
             // snake_case: lowercase + underscores only.
             assert!(

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod event_worker;
 pub(crate) mod health_checker;
 pub(crate) mod intentional_shutdowns;
 pub(crate) mod scheduler;
+pub(crate) mod stats_cache;

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -1441,6 +1441,51 @@ mod tests {
         }
     }
 
+    // A secret value containing `$` (e.g. a password like "pa$$w0rd") must
+    // survive resolution untouched: Ring stores the decrypted bytes and injects
+    // them verbatim into the container env, with no shell/variable expansion.
+    #[tokio::test]
+    async fn secret_value_with_dollar_is_preserved_through_resolution() {
+        use crate::models::secret::{Secret, create as create_secret, encrypt_value};
+        use base64::Engine as _;
+
+        let pool = new_test_pool().await;
+        // Test key for encrypt/decrypt (same shape as secret.rs tests).
+        unsafe {
+            std::env::set_var(
+                "RING_SECRET_KEY",
+                base64::engine::general_purpose::STANDARD.encode([0u8; 32]),
+            );
+        }
+
+        let raw = "pa$$w0rd$with$dollars";
+        let secret = Secret {
+            id: "sec-1".to_string(),
+            created_at: chrono::Utc::now().to_string(),
+            updated_at: None,
+            namespace: "test".to_string(),
+            name: "DB_PASSWORD".to_string(),
+            value: encrypt_value(raw),
+        };
+        create_secret(&pool, &secret).await.unwrap();
+
+        let mut deployment = child_with_health_checks("d1", vec![]);
+        deployment.namespace = "test".to_string();
+        deployment.environment.insert(
+            "DB_PASSWORD".to_string(),
+            EnvValue::SecretRef {
+                secret_ref: "DB_PASSWORD".to_string(),
+            },
+        );
+
+        resolve_environment(&mut deployment, &pool).await.unwrap();
+
+        match deployment.environment.get("DB_PASSWORD") {
+            Some(EnvValue::Plain(v)) => assert_eq!(v, raw, "the `$` must not be stripped"),
+            other => panic!("expected resolved Plain value, got {other:?}"),
+        }
+    }
+
     #[test]
     fn rollout_deadline_not_exceeded_for_fresh_child() {
         // created_at = now → well within the 600s default deadline.

--- a/src/scheduler/stats_cache.rs
+++ b/src/scheduler/stats_cache.rs
@@ -1,0 +1,308 @@
+//! Background cache of per-deployment runtime resource usage.
+//!
+//! Querying a runtime for instance stats (`get_instance_stats`) hits a socket
+//! per deployment and is comparatively expensive, so we do NOT do it on the
+//! `/metrics` request path: a Prometheus scrape every 15s across N deployments
+//! would mean N runtime round-trips per scrape and could blow the scraper's
+//! timeout. Instead a standalone worker refreshes the numbers on the scheduler
+//! interval into an in-memory store, and `/metrics` reads that store
+//! instantly. The cost of talking to the runtimes is decoupled from the scrape
+//! frequency.
+//!
+//! The trade-off is freshness: values are at most one refresh interval stale.
+//! For capacity/resource dashboards that is fine; for anything needing
+//! per-request freshness, query `/deployments/{id}/metrics` directly.
+//!
+//! Fail-soft: a runtime that is slow or unreachable has its deployments omitted
+//! from the snapshot (logged), never stalling the refresh or the scrape.
+
+use crate::api::dto::stats::InstanceStatsOutput;
+use crate::api::server::RuntimeMap;
+use crate::models::deployments;
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
+
+/// Per-deployment aggregate, ready to render as labelled Prometheus series.
+/// `name`/`namespace`/`runtime` are the label set; the couple
+/// (namespace, name) is unique, so no unstable `id` is needed as a label.
+#[derive(Debug, Clone)]
+pub(crate) struct DeploymentRuntimeStats {
+    pub name: String,
+    pub namespace: String,
+    pub runtime: String,
+    pub instance_count: u64,
+    pub cpu_usage_percent: f64,
+    pub memory_usage_bytes: u64,
+    pub memory_limit_bytes: u64,
+    pub network_rx_bytes: u64,
+    pub network_tx_bytes: u64,
+    pub disk_read_bytes: u64,
+    pub disk_write_bytes: u64,
+    pub pids: u64,
+    pub restarts: u64,
+}
+
+/// In-memory snapshot read by `/metrics`. Replaced wholesale on each refresh so
+/// readers never observe a half-updated set.
+#[derive(Debug, Default)]
+pub(crate) struct StatsSnapshot {
+    /// Unix timestamp (seconds) of the last successful refresh. `0` if never.
+    pub last_refresh_unix: u64,
+    pub deployments: Vec<DeploymentRuntimeStats>,
+}
+
+/// Shared handle to the snapshot. Cheap to clone (an `Arc`); stored in
+/// `AppState` and handed to the refresh worker.
+pub(crate) type StatsCache = Arc<RwLock<StatsSnapshot>>;
+
+pub(crate) fn new_cache() -> StatsCache {
+    Arc::new(RwLock::new(StatsSnapshot::default()))
+}
+
+/// Per-deployment ceiling on the `get_instance_stats` call. A wedged runtime
+/// must not hold the whole refresh; its deployment is dropped from this round.
+const PER_DEPLOYMENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run the refresh loop forever, polling on `interval_secs` (the scheduler
+/// interval). Each tick recomputes the snapshot and swaps it in.
+pub(crate) async fn run(
+    cache: StatsCache,
+    pool: SqlitePool,
+    runtimes: RuntimeMap,
+    interval_secs: u64,
+    now_unix: impl Fn() -> u64 + Send,
+) {
+    let tick = Duration::from_secs(interval_secs.max(1));
+    loop {
+        refresh(&cache, &pool, &runtimes, now_unix()).await;
+        sleep(tick).await;
+    }
+}
+
+/// Recompute the snapshot once and swap it into the cache. Extracted from the
+/// loop so it is directly testable with a mock runtime.
+pub(crate) async fn refresh(
+    cache: &StatsCache,
+    pool: &SqlitePool,
+    runtimes: &RuntimeMap,
+    now_unix: u64,
+) {
+    let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+    filters.insert("status".to_string(), vec!["running".to_string()]);
+
+    let active = match deployments::find_all(pool, filters).await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!("stats cache: listing active deployments failed: {}", e);
+            return;
+        }
+    };
+
+    let mut out = Vec::with_capacity(active.len());
+    for deployment in active {
+        let Some(runtime) = runtimes.get(&deployment.runtime) else {
+            // Deployment references a runtime not registered on this node
+            // (e.g. disabled at boot). Nothing to read; skip quietly.
+            continue;
+        };
+
+        let stats = match timeout(
+            PER_DEPLOYMENT_TIMEOUT,
+            runtime.get_instance_stats(&deployment.id),
+        )
+        .await
+        {
+            Ok(stats) => stats,
+            Err(_) => {
+                warn!(
+                    "stats cache: get_instance_stats timed out for {} ({}), skipping this round",
+                    deployment.id, deployment.runtime
+                );
+                continue;
+            }
+        };
+
+        if stats.is_empty() {
+            // No live instances (or the runtime reports none) — omit rather
+            // than emit an all-zero series for a deployment with no data.
+            continue;
+        }
+
+        out.push(aggregate(
+            &deployment.name,
+            &deployment.namespace,
+            &deployment.runtime,
+            &stats,
+        ));
+    }
+
+    match cache.write() {
+        Ok(mut guard) => {
+            guard.last_refresh_unix = now_unix;
+            guard.deployments = out;
+        }
+        Err(e) => warn!("stats cache: snapshot lock poisoned: {}", e),
+    }
+}
+
+/// Sum a deployment's instance stats into a single labelled row. CPU and byte
+/// totals add across instances; memory percentage is intentionally not summed
+/// (it is derived from usage/limit by the consumer when needed).
+fn aggregate(
+    name: &str,
+    namespace: &str,
+    runtime: &str,
+    instances: &[InstanceStatsOutput],
+) -> DeploymentRuntimeStats {
+    DeploymentRuntimeStats {
+        name: name.to_string(),
+        namespace: namespace.to_string(),
+        runtime: runtime.to_string(),
+        instance_count: instances.len() as u64,
+        cpu_usage_percent: instances.iter().map(|i| i.cpu_usage_percent).sum(),
+        memory_usage_bytes: instances.iter().map(|i| i.memory.usage_bytes).sum(),
+        memory_limit_bytes: instances.iter().map(|i| i.memory.limit_bytes).sum(),
+        network_rx_bytes: instances.iter().map(|i| i.network.rx_bytes).sum(),
+        network_tx_bytes: instances.iter().map(|i| i.network.tx_bytes).sum(),
+        disk_read_bytes: instances.iter().map(|i| i.disk_io.read_bytes).sum(),
+        disk_write_bytes: instances.iter().map(|i| i.disk_io.write_bytes).sum(),
+        pids: instances.iter().map(|i| i.pids.current).sum(),
+        restarts: instances.iter().map(|i| i.restart_count).sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::dto::stats::{DiskIoStats, MemoryStats, NetworkStats, PidStats};
+
+    fn instance(cpu: f64, mem: u64, rx: u64) -> InstanceStatsOutput {
+        InstanceStatsOutput {
+            instance_id: "i".to_string(),
+            instance_name: "i".to_string(),
+            cpu_usage_percent: cpu,
+            memory: MemoryStats {
+                usage_bytes: mem,
+                limit_bytes: mem * 2,
+                usage_percent: 50.0,
+            },
+            network: NetworkStats {
+                rx_bytes: rx,
+                tx_bytes: 0,
+                rx_packets: 0,
+                tx_packets: 0,
+            },
+            disk_io: DiskIoStats {
+                read_bytes: 0,
+                write_bytes: 0,
+            },
+            pids: PidStats {
+                current: 1,
+                limit: 100,
+            },
+            restart_count: 2,
+        }
+    }
+
+    #[test]
+    fn aggregate_sums_across_instances() {
+        let stats = vec![instance(10.0, 100, 5), instance(20.0, 200, 7)];
+        let agg = aggregate("web", "prod", "docker", &stats);
+        assert_eq!(agg.name, "web");
+        assert_eq!(agg.namespace, "prod");
+        assert_eq!(agg.runtime, "docker");
+        assert_eq!(agg.instance_count, 2);
+        assert_eq!(agg.cpu_usage_percent, 30.0);
+        assert_eq!(agg.memory_usage_bytes, 300);
+        assert_eq!(agg.memory_limit_bytes, 600);
+        assert_eq!(agg.network_rx_bytes, 12);
+        assert_eq!(agg.pids, 2);
+        assert_eq!(agg.restarts, 4);
+    }
+
+    #[test]
+    fn new_cache_starts_empty() {
+        let cache = new_cache();
+        let guard = cache.read().unwrap();
+        assert_eq!(guard.last_refresh_unix, 0);
+        assert!(guard.deployments.is_empty());
+    }
+
+    use crate::hypervisor::lifecycle_trait::RuntimeLifecycle;
+    use crate::hypervisor::mock::MockRuntime;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_deployment(pool: &SqlitePool, id: &str, name: &str, status: &str) {
+        sqlx::query(
+            "INSERT INTO deployment (id, created_at, status, namespace, runtime, kind, name) \
+             VALUES (?, '2024-01-01', ?, 'prod', 'docker', 'worker', ?)",
+        )
+        .bind(id)
+        .bind(status)
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn refresh_caches_stats_for_running_deployments_only() {
+        let pool = test_pool().await;
+        insert_deployment(&pool, "d-run", "web", "running").await;
+        // A non-running deployment must be ignored even though the runtime
+        // would happily return stats for it.
+        insert_deployment(&pool, "d-stop", "old", "completed").await;
+
+        let runtime: Arc<dyn RuntimeLifecycle> =
+            Arc::new(MockRuntime::healthy().with_instance_stats(vec![instance(10.0, 100, 5)]));
+        let mut map: HashMap<String, Arc<dyn RuntimeLifecycle>> = HashMap::new();
+        map.insert("docker".to_string(), runtime);
+        let runtimes: RuntimeMap = Arc::new(map);
+
+        let cache = new_cache();
+        refresh(&cache, &pool, &runtimes, 1_700_000_000).await;
+
+        let guard = cache.read().unwrap();
+        assert_eq!(guard.last_refresh_unix, 1_700_000_000);
+        assert_eq!(guard.deployments.len(), 1, "only the running one is cached");
+        let row = &guard.deployments[0];
+        assert_eq!(row.name, "web");
+        assert_eq!(row.namespace, "prod");
+        assert_eq!(row.runtime, "docker");
+        assert_eq!(row.cpu_usage_percent, 10.0);
+        assert_eq!(row.memory_usage_bytes, 100);
+    }
+
+    #[tokio::test]
+    async fn refresh_omits_deployments_with_no_instance_stats() {
+        let pool = test_pool().await;
+        insert_deployment(&pool, "d-run", "web", "running").await;
+
+        // Runtime returns no stats (e.g. no live instances) → no series.
+        let runtime: Arc<dyn RuntimeLifecycle> = Arc::new(MockRuntime::healthy());
+        let mut map: HashMap<String, Arc<dyn RuntimeLifecycle>> = HashMap::new();
+        map.insert("docker".to_string(), runtime);
+        let runtimes: RuntimeMap = Arc::new(map);
+
+        let cache = new_cache();
+        refresh(&cache, &pool, &runtimes, 1).await;
+
+        let guard = cache.read().unwrap();
+        assert!(guard.deployments.is_empty());
+        // The refresh still ran, so the timestamp advances.
+        assert_eq!(guard.last_refresh_unix, 1);
+    }
+}


### PR DESCRIPTION
Adds a public `GET /metrics` endpoint exposing node-wide metrics for Prometheus.

## What it exposes

- **Inventory** (from the database): deployments by status and by runtime, outbound event queue by delivery status, health checks by status, and counts for namespaces, secrets, volumes, users, webhooks, configs. Every known status is emitted even at `0` so a series never disappears between scrapes.
- **Per-deployment resource usage** (labelled `deployment`/`namespace`/`runtime`): CPU, memory, network and disk byte counters, pids, instance count, restarts.

## Notes

- Content negotiation: Prometheus text exposition `0.0.4` by default, JSON on `Accept: application/json`.
- Unauthenticated, like `/healthz` — Prometheus scrapers send no auth; front with TLS / a network ACL.
- Resource usage is refreshed by a background worker on the scheduler interval (not at request time), so a scrape never blocks on the runtimes. `ring_runtime_last_refresh_seconds` surfaces staleness.

Docs updated in `reference/api.md` and `help/observe-and-debug.md`.