### PR TITLE
feat(firecracker): command health checks via ring-agent over vsock

### DIFF
--- a/src/hypervisor/vsock_client.rs
+++ b/src/hypervisor/vsock_client.rs
@@ -1,14 +1,20 @@
-//! Host-side client that talks to `ring-agent` running inside a CH guest VM.
+//! Host-side client that talks to `ring-agent` running inside a guest VM.
 //!
 //! Wire format mirrors `crates/ring-agent/src/main.rs`:
 //!   - request:  [u32 BE length][JSON `Request`]
 //!   - response: [u32 BE length][JSON `Response`]
 //!
 //! One TCP-style connection per request. The agent does not multiplex.
+//!
+//! Two transports reach the same agent protocol:
+//!   - Cloud Hypervisor: kernel AF_VSOCK on the host (`exec`).
+//!   - Firecracker: vsock multiplexed over a host Unix socket (`exec_uds`),
+//!     which first performs Firecracker's `CONNECT <port>` handshake.
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::UnixStream;
 use tokio_vsock::{VsockAddr, VsockStream};
 
 const VSOCK_PORT: u32 = 2375;
@@ -81,7 +87,7 @@ pub(crate) async fn exec(
 
     let addr = VsockAddr::new(cid, VSOCK_PORT);
 
-    let mut stream = tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))
+    let stream = tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))
         .await
         .map_err(|_| VsockError::Connect {
             cid,
@@ -89,6 +95,107 @@ pub(crate) async fn exec(
         })?
         .map_err(|e| VsockError::Connect { cid, source: e })?;
 
+    exchange(stream, argv, env, timeout).await
+}
+
+/// Firecracker variant: connect to the host-side multiplexing Unix socket
+/// (`<uds_path>` is the device's `uds_path`; the agent port is appended as
+/// `<uds_path>_<port>`), perform the `CONNECT <port>` handshake, then speak the
+/// same agent protocol as [`exec`].
+///
+/// `cid` is carried only so connect failures report a stable identifier
+/// consistent with the Cloud Hypervisor path; Firecracker addresses the agent
+/// through the socket, not the CID.
+pub(crate) async fn exec_uds(
+    cid: u32,
+    uds_path: &str,
+    argv: &[String],
+    env: &[(String, String)],
+    timeout: Duration,
+) -> Result<ExecResponse, VsockError> {
+    debug_assert!(
+        timeout < READ_TIMEOUT,
+        "vsock exec timeout {:?} must be < READ_TIMEOUT {:?}",
+        timeout,
+        READ_TIMEOUT
+    );
+
+    let port_path = format!("{}_{}", uds_path, VSOCK_PORT);
+    let mut stream = tokio::time::timeout(CONNECT_TIMEOUT, UnixStream::connect(&port_path))
+        .await
+        .map_err(|_| VsockError::Connect {
+            cid,
+            source: std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timed out"),
+        })?
+        .map_err(|e| VsockError::Connect { cid, source: e })?;
+
+    // Firecracker host-initiated handshake: write `CONNECT <port>\n`, then the
+    // device replies `OK <host_port>\n` before relaying bytes to the guest
+    // listener. Treat a missing/!OK line as a connect failure.
+    let handshake = format!("CONNECT {}\n", VSOCK_PORT);
+    tokio::time::timeout(WRITE_TIMEOUT, stream.write_all(handshake.as_bytes()))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "vsock connect write timed out",
+            )
+        })??;
+    read_ok_line(&mut stream, cid).await?;
+
+    exchange(stream, argv, env, timeout).await
+}
+
+/// Read Firecracker's `OK <port>\n` acknowledgement line, byte by byte (the
+/// payload that follows must not be over-read into a buffer). Anything other
+/// than a line starting with `OK` is a failed guest-side connect.
+async fn read_ok_line<S: AsyncRead + Unpin>(stream: &mut S, cid: u32) -> Result<(), VsockError> {
+    let mut line = Vec::with_capacity(16);
+    let mut byte = [0u8; 1];
+    loop {
+        tokio::time::timeout(CONNECT_TIMEOUT, stream.read_exact(&mut byte))
+            .await
+            .map_err(|_| VsockError::Connect {
+                cid,
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "handshake read timed out",
+                ),
+            })?
+            .map_err(|e| VsockError::Connect { cid, source: e })?;
+        if byte[0] == b'\n' {
+            break;
+        }
+        line.push(byte[0]);
+        if line.len() > 64 {
+            break;
+        }
+    }
+    if line.starts_with(b"OK") {
+        Ok(())
+    } else {
+        Err(VsockError::Connect {
+            cid,
+            source: std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!(
+                    "Firecracker vsock handshake rejected: {}",
+                    String::from_utf8_lossy(&line)
+                ),
+            ),
+        })
+    }
+}
+
+/// Send one framed `Exec` request and read the framed response over an already
+/// connected stream. Transport-agnostic: shared by the kernel-AF_VSOCK (CH) and
+/// Unix-socket (Firecracker) paths.
+async fn exchange<S: AsyncRead + AsyncWrite + Unpin>(
+    mut stream: S,
+    argv: &[String],
+    env: &[(String, String)],
+    timeout: Duration,
+) -> Result<ExecResponse, VsockError> {
     let request = Request::Exec {
         argv,
         env,

--- a/src/runtime/firecracker/client.rs
+++ b/src/runtime/firecracker/client.rs
@@ -58,6 +58,19 @@ pub(crate) struct NetworkInterface {
     pub guest_mac: Option<String>,
 }
 
+/// A virtio-vsock device. Unlike Cloud Hypervisor's vhost-vsock (a kernel
+/// AF_VSOCK endpoint on the host), Firecracker multiplexes vsock over a host
+/// Unix socket: the host connects to `<uds_path>_<port>`, writes
+/// `CONNECT <port>\n`, and from then on speaks the guest agent's protocol.
+/// `guest_cid` is informational on the host side (the guest sees it as its
+/// AF_VSOCK CID); the host addresses ports through `uds_path`, not the CID.
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct Vsock {
+    pub vsock_id: String,
+    pub guest_cid: u32,
+    pub uds_path: String,
+}
+
 /// Instance actions. The only one used at boot is `InstanceStart`; graceful
 /// shutdown uses `SendCtrlAltDel` (the guest must run an ACPI handler).
 #[derive(Debug, Serialize, Clone)]
@@ -187,6 +200,15 @@ impl FirecrackerClient {
         let endpoint = format!("/network-interfaces/{}", iface.iface_id);
         let body = serde_json::to_string(iface).map_err(|e| ClientError::Json(e.to_string()))?;
         self.request(Method::PUT, &endpoint, Some(body)).await?;
+        Ok(())
+    }
+
+    /// `PUT /vsock` — attach the virtio-vsock device. Firecracker allows a
+    /// single vsock device per VM, so the id is fixed by convention. Must be
+    /// called before `InstanceStart`.
+    pub async fn put_vsock(&self, vsock: &Vsock) -> Result<(), ClientError> {
+        let body = serde_json::to_string(vsock).map_err(|e| ClientError::Json(e.to_string()))?;
+        self.request(Method::PUT, "/vsock", Some(body)).await?;
         Ok(())
     }
 

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -15,15 +15,17 @@
 use crate::config::server::FirecrackerConfig;
 use crate::hypervisor::cloud_init::GuestNet;
 use crate::hypervisor::error::RuntimeError;
-use crate::hypervisor::host_net::InstanceNet;
+use crate::hypervisor::host_net::{InstanceNet, cid_for_instance};
 use crate::hypervisor::lifecycle_trait::RuntimeLifecycle;
 use crate::hypervisor::port_forwarder::{self, PortForwarder};
 use crate::hypervisor::tap::TapDevice;
+use crate::hypervisor::vsock_client::{self, VsockError};
 use crate::models::deployments::{Deployment, DeploymentStatus};
+use crate::models::health_check::{HealthCheck, HealthCheckStatus};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::docker::tiny_id;
 use crate::runtime::firecracker::client::{
-    BootSource, Drive, FirecrackerClient, MachineConfig, NetworkInterface,
+    BootSource, Drive, FirecrackerClient, MachineConfig, NetworkInterface, Vsock,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -307,6 +309,14 @@ impl FirecrackerLifecycle {
         format!("{}/{}.cidata.iso", self.config.socket_dir, instance_id)
     }
 
+    /// Host-side base path of the multiplexing Unix socket for the guest's
+    /// vsock device. Firecracker appends `_<port>` per guest listener, so this
+    /// base is what `PUT /vsock` receives and what teardown must clean up
+    /// (alongside the per-port `<base>_<port>` files Firecracker creates).
+    fn vsock_path(&self, instance_id: &str) -> String {
+        format!("{}/{}.vsock", self.config.socket_dir, instance_id)
+    }
+
     async fn configure_and_boot(
         &self,
         client: &FirecrackerClient,
@@ -385,6 +395,23 @@ impl FirecrackerLifecycle {
             .await
             .map_err(|e| e.to_string())?;
 
+        // Attach a vsock device only when the deployment declares a `command`
+        // health check — its sole consumer, mirroring the Cloud Hypervisor
+        // runtime. The guest reaches `ring-agent` over AF_VSOCK; the host
+        // reaches it through the multiplexing Unix socket at `vsock_path`.
+        // Same boot-time limitation as CH: adding a `command` check to a
+        // running deployment only takes effect after the next restart.
+        if needs_vsock(deployment) {
+            client
+                .put_vsock(&Vsock {
+                    vsock_id: "vsock0".to_string(),
+                    guest_cid: cid_for_instance(instance_id),
+                    uds_path: self.vsock_path(instance_id),
+                })
+                .await
+                .map_err(|e| e.to_string())?;
+        }
+
         client.start().await.map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -437,6 +464,12 @@ impl FirecrackerLifecycle {
         let _ = std::fs::remove_file(self.rootfs_path(instance_id));
         let _ = std::fs::remove_file(self.cidata_path(instance_id));
         let _ = std::fs::remove_file(self.console_log_path(instance_id));
+        // Remove the vsock base socket and the per-port multiplexed socket
+        // Firecracker creates (`<base>_<port>`). No-ops when the instance had
+        // no vsock device.
+        let vsock_base = self.vsock_path(instance_id);
+        let _ = std::fs::remove_file(&vsock_base);
+        let _ = std::fs::remove_file(format!("{}_{}", vsock_base, RING_AGENT_VSOCK_PORT));
         !Path::new(&socket_path).exists()
     }
 
@@ -657,6 +690,21 @@ fn cmdline_matches_socket(cmdline: &[u8], socket_path: &str) -> bool {
 /// (falling back to requests). vCPUs round up from a fractional CPU quantity to
 /// at least 1; memory falls back to a sane floor so a microVM has room to run a
 /// real service rather than OOMing at boot.
+/// AF_VSOCK port `ring-agent` listens on inside the guest. Must match
+/// `crates/ring-agent` and `hypervisor::vsock_client::VSOCK_PORT`. Used here
+/// only to clean up the per-port multiplexing socket Firecracker creates.
+const RING_AGENT_VSOCK_PORT: u32 = 2375;
+
+/// A deployment needs a vsock device iff it declares a `command` health check
+/// — the only consumer of the in-guest agent today. Mirrors the gate in the
+/// Cloud Hypervisor runtime so the two behave identically.
+fn needs_vsock(deployment: &Deployment) -> bool {
+    deployment
+        .health_checks
+        .iter()
+        .any(|hc| matches!(hc, HealthCheck::Command { .. }))
+}
+
 fn parse_resources(deployment: &Deployment) -> (u32, u32) {
     use crate::models::deployments::{parse_cpu_string, parse_memory_string};
 
@@ -746,6 +794,54 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
             return None;
         }
         net.guest_ip.parse().ok()
+    }
+
+    /// Run a `command` health check inside the guest via `ring-agent` over the
+    /// Firecracker vsock-over-Unix-socket transport. Mirrors the Cloud
+    /// Hypervisor implementation; only the transport differs (`exec_uds` does
+    /// Firecracker's `CONNECT` handshake before speaking the agent protocol).
+    async fn execute_command_probe(
+        &self,
+        instance_id: &str,
+        command: &str,
+    ) -> (HealthCheckStatus, Option<String>) {
+        let cid = cid_for_instance(instance_id);
+        let uds_path = self.vsock_path(instance_id);
+        let argv = vec!["/bin/sh".to_string(), "-c".to_string(), command.to_string()];
+        let timeout = std::time::Duration::from_secs(30);
+
+        match vsock_client::exec_uds(cid, &uds_path, &argv, &[], timeout).await {
+            Ok(resp) if resp.timed_out => (
+                HealthCheckStatus::Timeout,
+                Some(format!("command timed out: {}", command)),
+            ),
+            Ok(resp) if resp.exit_code == 0 => (HealthCheckStatus::Success, None),
+            Ok(resp) => (
+                HealthCheckStatus::Failed,
+                Some(format!(
+                    "exit code {}: {}",
+                    resp.exit_code,
+                    resp.stderr.trim()
+                )),
+            ),
+            // A connect failure almost always means the guest image doesn't
+            // ship `ring-agent` listening on AF_VSOCK port 2375 (or it hasn't
+            // started yet) — the most common `command` health-check pitfall on
+            // this runtime. Point the operator straight at it.
+            Err(VsockError::Connect { cid, source }) => (
+                HealthCheckStatus::Failed,
+                Some(format!(
+                    "cannot reach ring-agent in the guest (CID {cid}): {source}. \
+                     `command` health checks on firecracker require ring-agent \
+                     running in the guest image on AF_VSOCK port 2375 — see the \
+                     firecracker runtime docs"
+                )),
+            ),
+            Err(e) => (
+                HealthCheckStatus::Failed,
+                Some(format!("vsock probe failed: {}", e)),
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
Brings the Firecracker runtime to parity with Cloud Hypervisor for `command` health checks, previously unsupported.

## Changes
- `client.rs`: `Vsock` resource + `put_vsock()` (Firecracker `PUT /vsock`).
- `vsock_client.rs`: extract the framed request/response logic into a shared, transport-agnostic `exchange()`. Cloud Hypervisor keeps the kernel AF_VSOCK path (`exec`); Firecracker gets `exec_uds`, which performs Firecracker's `CONNECT <port>` handshake over the host Unix socket before speaking the agent protocol.
- `firecracker/lifecycle.rs`: attach the vsock device at boot, gated on a deployment declaring a `command` health check (same gate as Cloud Hypervisor); implement `execute_command_probe`; clean up the vsock sockets on teardown.

The in-guest `ring-agent` is unchanged.

## Tests
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check` clean; full test suite passes.
- Not yet exercised against a live Firecracker microVM: the `CONNECT` handshake and the `<uds>_<port>` socket naming follow the Firecracker spec but have not been observed end-to-end. Needs validation on a guest image shipping ring-agent.