### PR TITLE
feat(firecracker): read and stream guest serial console logs

### DIFF
--- a/documentation/runtimes/firecracker.md
+++ b/documentation/runtimes/firecracker.md
@@ -55,10 +55,20 @@ ring apply -f app.yaml
 
 What Ring does: copies the rootfs per instance, spawns a `firecracker` process, drives its REST API to set the kernel / rootfs / network / machine config, then boots. Networking is a Ring-owned TAP (a /30 subnet per VM) with `socat` host-port forwarding; outbound NAT lets guests reach external networks.
 
+## Logs
+
+The guest serial console (kernel, init, and anything the workload writes to the console) is persisted per instance and readable with the standard commands — same as every other runtime:
+
+```bash
+ring deployment logs <deployment-id>            # whole console
+ring deployment logs <deployment-id> --tail 50  # last 50 lines
+ring deployment logs <deployment-id> --follow   # stream as the guest writes
+```
+
 ## Known gaps (experimental)
 
 - **Volumes are not mounted yet.** Firecracker has no virtio-fs (the Cloud Hypervisor mechanism — its maintainers declined it on attack-surface grounds), so volumes would go through **virtio-block** (one ext4 image per volume, attached as an extra drive). Feasibility is proven; the runtime wiring is pending.
-- **No `command` health checks** (needs an in-guest agent over vsock, like Cloud Hypervisor), no metrics, and **`kind: job` runs as a worker** (no job semantics yet).
+- **No metrics yet** (no per-instance CPU/memory/network/disk stats), and **`kind: job` runs as a worker** (no job semantics yet).
 - `image:` must be a host rootfs file — no registry pull.
 
 ## See also

--- a/src/hypervisor/console_logs.rs
+++ b/src/hypervisor/console_logs.rs
@@ -1,19 +1,21 @@
 //! Read and stream the per-VM serial console log file.
 //!
-//! Cloud Hypervisor's `serial.mode = "File"` makes the VMM append every byte
-//! the guest writes to `/dev/console` (cloud-init banner, kernel messages,
-//! systemd journal when redirected, app stdout when configured) to a single
-//! file. This module turns that file into the line-oriented stream the
-//! `RuntimeLifecycle` trait expects:
+//! Both VM runtimes append every byte the guest writes to its serial console
+//! (cloud-init banner, kernel messages, systemd journal when redirected, app
+//! stdout when configured) to a single per-instance `<id>.console.log` file:
+//! Cloud Hypervisor via `serial.mode = "File"`, Firecracker via the spawned
+//! process' redirected stdout. This module turns that file into the
+//! line-oriented stream the `RuntimeLifecycle` trait expects:
 //!
 //! - [`read_lines`] — synchronous one-shot read with `tail` (last N lines)
 //!   and `since` (drop lines older than N seconds, best-effort: the console
 //!   has no native timestamps so we fall back to file mtime windowing).
-//! - [`stream_lines`] — async streaming reader that follows the file as CH
-//!   appends to it, equivalent to `tail -f`.
+//! - [`stream_lines`] — async streaming reader that follows the file as the
+//!   VMM appends to it, equivalent to `tail -f`.
 //!
-//! Lines are returned raw — callers (`get_logs` / `stream_logs` in
-//! `lifecycle.rs`) wrap them in a `Log` with `classify_log` / `extract_date`.
+//! Lines are returned raw — callers (`get_logs` / `stream_logs` in each
+//! runtime's `lifecycle.rs`) wrap them in a `Log` with `classify_log` /
+//! `extract_date`.
 
 use futures::stream::{self, Stream, StreamExt};
 use std::path::{Path, PathBuf};
@@ -212,10 +214,12 @@ pub(crate) async fn stream_lines(
 /// Rotate `<path>` if it has grown past `max_bytes`.
 ///
 /// Shifts `<path>.{N-1}` → `<path>.N`, dropping anything past `max_backups`,
-/// then renames `<path>` to `<path>.1`. Cloud Hypervisor re-creates the live
-/// file on its next write (the VMM holds the file by name, not by inode,
-/// because `serial.mode = "File"` is a path-based config) so this is safe to
-/// call while a VM is running.
+/// then renames `<path>` to `<path>.1`. Safe to call while a VM is running for
+/// path-based writers like Cloud Hypervisor (`serial.mode = "File"`), which
+/// re-create the live file by name on their next write. Writers that hold the
+/// file by inode (e.g. a redirected process stdout) keep appending to the
+/// rotated path until restarted — callers for those runtimes must account for
+/// that before relying on rotation.
 ///
 /// No-op when:
 /// - `max_bytes == 0` (rotation disabled by config)

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -4,6 +4,7 @@
 //! that `runtime` holds only the concrete runtime implementations.
 
 pub(crate) mod cloud_init;
+pub(crate) mod console_logs;
 pub(crate) mod error;
 pub(crate) mod health_probes;
 pub(crate) mod host_nat;

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -151,7 +151,8 @@ impl CloudHypervisorLifecycle {
             loop {
                 ticker.tick().await;
                 tracing::debug!("CH console log rotator: sweeping {:?}", dir);
-                super::console_logs::rotate_all_in_dir(&dir, max_bytes, max_backups).await;
+                crate::hypervisor::console_logs::rotate_all_in_dir(&dir, max_bytes, max_backups)
+                    .await;
             }
         })
     }
@@ -1245,7 +1246,7 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
                 continue;
             }
             let path = self.console_log_path(&instance_id);
-            let lines = super::console_logs::read_lines(&path, tail, since).await;
+            let lines = crate::hypervisor::console_logs::read_lines(&path, tail, since).await;
             for message in lines {
                 logs.push(Log {
                     instance: instance_id.clone(),
@@ -1298,8 +1299,12 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
         for instance_id in filtered {
             let path = self.console_log_path(&instance_id);
             let owned_id = instance_id.clone();
-            let raw =
-                super::console_logs::stream_lines(path, tail.map(|s| s.to_string()), since).await;
+            let raw = crate::hypervisor::console_logs::stream_lines(
+                path,
+                tail.map(|s| s.to_string()),
+                since,
+            )
+            .await;
 
             let mapped = raw.map(move |line| {
                 let log = Log {

--- a/src/runtime/cloud_hypervisor/mod.rs
+++ b/src/runtime/cloud_hypervisor/mod.rs
@@ -1,5 +1,4 @@
 mod client;
-mod console_logs;
 mod lifecycle;
 mod stats;
 

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -16,7 +16,7 @@ use crate::config::server::FirecrackerConfig;
 use crate::hypervisor::cloud_init::GuestNet;
 use crate::hypervisor::error::RuntimeError;
 use crate::hypervisor::host_net::{InstanceNet, cid_for_instance};
-use crate::hypervisor::lifecycle_trait::RuntimeLifecycle;
+use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, extract_date};
 use crate::hypervisor::port_forwarder::{self, PortForwarder};
 use crate::hypervisor::tap::TapDevice;
 use crate::hypervisor::vsock_client::{self, VsockError};
@@ -775,6 +775,105 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
 
     async fn remove_instance(&self, instance_id: String) -> bool {
         self.stop_vm(&instance_id).await
+    }
+
+    /// Read the persisted serial console for every instance of the deployment.
+    /// Scans disk (not just our PID map) so a crashed or restart-inherited VM's
+    /// console is still readable. Reads through rotated backups via the shared
+    /// `console_logs` helper.
+    async fn get_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> Vec<Log> {
+        let mut logs = Vec::new();
+        for instance_id in self.scan_instances(deployment_id) {
+            if let Some(want) = instance_filter
+                && instance_id != want
+            {
+                continue;
+            }
+            let path = PathBuf::from(self.console_log_path(&instance_id));
+            let lines = crate::hypervisor::console_logs::read_lines(&path, tail, since).await;
+            for message in lines {
+                logs.push(Log {
+                    instance: instance_id.clone(),
+                    level: classify_log(&message),
+                    timestamp: extract_date(&message),
+                    message,
+                });
+            }
+        }
+        logs
+    }
+
+    /// Follow the serial console of every matching instance, equivalent to
+    /// `tail -f`, emitting each new line as an SSE event. Mirrors
+    /// `get_logs` instance selection (disk scan + optional filter).
+    async fn stream_logs(
+        &self,
+        deployment_id: &str,
+        tail: Option<&str>,
+        since: Option<i32>,
+        instance_filter: Option<&str>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn futures::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>
+                + Send,
+        >,
+    > {
+        use futures::stream::{self, StreamExt};
+
+        let filtered: Vec<String> = self
+            .scan_instances(deployment_id)
+            .into_iter()
+            .filter(|id| match instance_filter {
+                Some(want) => id == want,
+                None => true,
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            return Box::pin(stream::empty());
+        }
+
+        let mut streams: Vec<
+            std::pin::Pin<
+                Box<
+                    dyn futures::Stream<
+                            Item = Result<axum::response::sse::Event, std::convert::Infallible>,
+                        > + Send,
+                >,
+            >,
+        > = Vec::new();
+
+        for instance_id in filtered {
+            let path = PathBuf::from(self.console_log_path(&instance_id));
+            let owned_id = instance_id.clone();
+            let raw = crate::hypervisor::console_logs::stream_lines(
+                path,
+                tail.map(|s| s.to_string()),
+                since,
+            )
+            .await;
+
+            let mapped = raw.map(move |line| {
+                let log = Log {
+                    instance: owned_id.clone(),
+                    level: classify_log(&line),
+                    timestamp: extract_date(&line),
+                    message: line,
+                };
+                let json = serde_json::to_string(&log).unwrap_or_default();
+                Ok(axum::response::sse::Event::default().data(json))
+            });
+
+            streams.push(Box::pin(mapped));
+        }
+
+        Box::pin(stream::select_all(streams))
     }
 
     /// The guest IP is a pure function of the instance id (same allocation as

--- a/tests/e2e/firecracker/t5_logs.sh
+++ b/tests/e2e/firecracker/t5_logs.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# T5-FC: a Firecracker deployment must produce a serial console log file that
+# `ring deployment logs` can read back. We verify the host-side contract:
+#   1. Firecracker's redirected stdout is persisted to
+#      <socket_dir>/<instance>.console.log,
+#   2. the file grows as the guest boots (kernel banner, init, etc.),
+#   3. `ring deployment logs <id>` returns non-empty output,
+#   4. --tail caps the output,
+#   5. cleanup removes the log file on delete.
+#
+# We don't assert specific guest-side content beyond "non-empty" because what
+# the kernel/init prints over the serial console varies between rootfs images.
+# Any byte that reached the console proves the get_logs/stream_logs wiring works
+# end-to-end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T5-FC: serial console logs =="
+
+setup_fc
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-logs-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-logs-vm:
+    name: fc-logs-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-logs-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-logs-vm")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === log file is created by Firecracker and grows ===
+log "looking for console log file..."
+LOG_FILE=""
+for _ in $(seq 1 30); do
+  LOG_FILE=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.console.log" 2>/dev/null | head -n1 || true)
+  [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ] && break
+  sleep 1
+done
+if [ -z "$LOG_FILE" ]; then
+  ls -la "$RING_E2E_FC_SOCKET_DIR" >&2
+  fail "no console log file found in $RING_E2E_FC_SOCKET_DIR"
+fi
+INITIAL_SIZE=$(stat -c %s "$LOG_FILE")
+if [ "$INITIAL_SIZE" -le 0 ]; then
+  fail "console log $LOG_FILE is empty after 30s of boot"
+fi
+log "console log: $LOG_FILE ($INITIAL_SIZE bytes)"
+
+# === ring deployment logs returns non-empty output ===
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 50 2>&1 || true)
+if [ -z "$LOGS_OUT" ]; then
+  echo "$LOGS_OUT" >&2
+  fail "ring deployment logs returned no output"
+fi
+LINE_COUNT=$(printf '%s\n' "$LOGS_OUT" | grep -c .)
+if [ "$LINE_COUNT" -lt 1 ]; then
+  fail "expected at least one log line, got $LINE_COUNT"
+fi
+log "ring deployment logs returned $LINE_COUNT line(s)"
+
+# === --tail caps the output ===
+TAIL_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 5 2>&1 || true)
+TAIL_LINES=$(printf '%s\n' "$TAIL_OUT" | grep -c . || true)
+if [ "$TAIL_LINES" -gt 8 ]; then
+  # Allow some slack: the CLI may print a header/footer line in addition to
+  # the 5 log lines. 8 is generous; anything bigger means tail is ignored.
+  fail "--tail 5 returned $TAIL_LINES lines (expected ≤ 8)"
+fi
+log "--tail 5 returned $TAIL_LINES line(s) (within bounds)"
+
+# === delete teardown removes the log file ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-logs-vm >/dev/null 2>&1 || true
+for _ in $(seq 1 60); do
+  if ! [ -f "$LOG_FILE" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -f "$LOG_FILE" ]; then
+  fail "console log $LOG_FILE still exists after delete"
+fi
+log "console log cleaned up"
+
+log "== T5-FC: PASS =="


### PR DESCRIPTION
## What

Bring Firecracker to parity with Cloud Hypervisor for log access. Until now `ring deployment logs` returned nothing for Firecracker deployments even though the guest serial console was already being persisted to `<socket_dir>/<instance>.console.log` — the runtime simply never overrode `get_logs`/`stream_logs`.

## Changes

- Promote the console-log reader/streamer/rotator from `runtime/cloud_hypervisor/console_logs.rs` to the shared `hypervisor/console_logs.rs` module (it is fully VMM-agnostic — it just reads a file), alongside the other shared host-side helpers.
- Repoint Cloud Hypervisor at the shared module (no behaviour change).
- Implement `get_logs` and `stream_logs` for Firecracker: scan instances on disk (so crashed / restart-inherited VMs are still readable), read through rotated backups, honour `--tail`/`--since`, and stream new lines over SSE — mirroring the Cloud Hypervisor implementation.
- Generalise the rotation doc to flag the by-name (CH) vs by-inode (process stdout) writer distinction, which the rotation work will build on.

## Tests

- Existing `console_logs` unit tests (13) pass unchanged at the new location.
- New e2e `tests/e2e/firecracker/t5_logs.sh`, mirroring the CH `t7_logs.sh`. **Validated on real Firecracker** (`/dev/kvm` + `firecracker`): a booted microVM produces a growing console log, `ring deployment logs` returns 50 lines, `--tail 5` caps output, and the log is cleaned up on delete.

## Docs

- `documentation/runtimes/firecracker.md`: document log access; drop the now-stale "no `command` health checks" gap (shipped via vsock/ring-agent) and the logs gap.

First in a series bringing Firecracker to parity with Cloud Hypervisor (next: instance stats, console-log rotation, `kind: job`, volumes).