### PR TITLE
feat(firecracker): expose per-instance resource stats

### DIFF
--- a/documentation/runtimes/firecracker.md
+++ b/documentation/runtimes/firecracker.md
@@ -65,10 +65,14 @@ ring deployment logs <deployment-id> --tail 50  # last 50 lines
 ring deployment logs <deployment-id> --follow   # stream as the guest writes
 ```
 
+## Metrics
+
+Per-instance CPU, memory, network, disk I/O, and thread counts are exposed at `GET /deployments/{id}/metrics`, the same as every other runtime. Ring reads them host-side from the `firecracker` process (`/proc/<pid>/{stat,status,io}`) and the per-VM tap counters — no in-guest agent required. Memory `usage_percent` is reported against the deployment's memory limit; network counters read zero for deployments that publish no ports (no tap is created).
+
 ## Known gaps (experimental)
 
 - **Volumes are not mounted yet.** Firecracker has no virtio-fs (the Cloud Hypervisor mechanism — its maintainers declined it on attack-surface grounds), so volumes would go through **virtio-block** (one ext4 image per volume, attached as an extra drive). Feasibility is proven; the runtime wiring is pending.
-- **No metrics yet** (no per-instance CPU/memory/network/disk stats), and **`kind: job` runs as a worker** (no job semantics yet).
+- **`kind: job` runs as a worker** (no job-completion semantics yet).
 - `image:` must be a host rootfs file — no registry pull.
 
 ## See also

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod lifecycle_trait;
 pub(crate) mod mock;
 pub(crate) mod port_forwarder;
 pub(crate) mod resources;
+pub(crate) mod stats;
 pub(crate) mod tap;
 pub(crate) mod types;
 pub(crate) mod virtiofs;

--- a/src/hypervisor/stats.rs
+++ b/src/hypervisor/stats.rs
@@ -1,7 +1,9 @@
-//! Per-VM resource stats for the Cloud Hypervisor runtime.
+//! Per-VM resource stats shared by the KVM-backed runtimes (Cloud Hypervisor,
+//! Firecracker).
 //!
-//! Docker exposes stats through the daemon's API; we have no equivalent for
-//! CH, so we read host-side files directly:
+//! Docker exposes stats through the daemon's API; we have no equivalent for a
+//! bare VMM process, so we read host-side files directly. Everything here keys
+//! off the VMM process PID and the per-VM tap name, so it is VMM-agnostic:
 //!
 //! - **CPU**: two samples of `/proc/<pid>/stat` (utime + stime) divided by
 //!   the elapsed wall time, normalised to 100% per online CPU.
@@ -12,15 +14,15 @@
 //!   (bytes the host wrote toward the guest) maps to guest `rx`, matching
 //!   the convention `ring deployment metrics` users expect from Docker.
 //! - **Disk I/O**: `read_bytes` / `write_bytes` from `/proc/<pid>/io` when
-//!   we can read it. Cloud Hypervisor clears `PR_SET_DUMPABLE` early in
-//!   its init for sandboxing, which makes that file return `EACCES` even
-//!   to the parent under `kernel.yama.ptrace_scope >= 1`. When unreadable,
-//!   we report zeros — counted by host alone, with no other reliable
-//!   source short of cgroup `io.stat` (which Ring does not currently set
-//!   up per-VM).
+//!   we can read it. A hardened VMM (e.g. Cloud Hypervisor) clears
+//!   `PR_SET_DUMPABLE` early for sandboxing, which makes that file return
+//!   `EACCES` even to the parent under `kernel.yama.ptrace_scope >= 1`. When
+//!   unreadable, we report zeros — counted by host alone, with no other
+//!   reliable source short of cgroup `io.stat` (which Ring does not currently
+//!   set up per-VM).
 //! - **PIDs**: `Threads:` from `/proc/<pid>/status` (vCPU threads + io +
-//!   control). CH has no equivalent of a cgroup pids.max, so `limit` is
-//!   reported as 0 (= unlimited) to mirror Docker semantics.
+//!   control). There is no cgroup pids.max per VM, so `limit` is reported as
+//!   0 (= unlimited) to mirror Docker semantics.
 
 use crate::api::dto::stats::{DiskIoStats, MemoryStats, NetworkStats, PidStats};
 

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -1422,22 +1422,23 @@ impl CloudHypervisorLifecycle {
     ) -> Option<crate::api::dto::stats::InstanceStatsOutput> {
         let info = self.process_info(instance_id)?;
 
-        let prev = super::stats::read_cpu_sample(info.pid).await?;
+        let prev = crate::hypervisor::stats::read_cpu_sample(info.pid).await?;
         tokio::time::sleep(tokio::time::Duration::from_millis(CPU_SAMPLE_INTERVAL_MS)).await;
-        let curr = super::stats::read_cpu_sample(info.pid).await?;
+        let curr = crate::hypervisor::stats::read_cpu_sample(info.pid).await?;
 
         let interval_secs = CPU_SAMPLE_INTERVAL_MS as f64 / 1000.0;
         // SC_CLK_TCK is fixed at compile time on Linux (typically 100). Reading
         // it via libc would force a sysconf dependency; the constant is stable.
-        let cpu_usage_percent = super::stats::compute_cpu_percent(prev, curr, interval_secs, 100.0);
+        let cpu_usage_percent =
+            crate::hypervisor::stats::compute_cpu_percent(prev, curr, interval_secs, 100.0);
 
-        let rss = super::stats::read_rss_bytes(info.pid).await;
-        let memory = super::stats::memory_stats(rss, info.memory_limit_bytes);
+        let rss = crate::hypervisor::stats::read_rss_bytes(info.pid).await;
+        let memory = crate::hypervisor::stats::memory_stats(rss, info.memory_limit_bytes);
 
         let tap_name = InstanceNet::for_instance(instance_id).tap_name;
-        let network = super::stats::network_stats_from_tap(&tap_name).await;
-        let disk_io = super::stats::disk_io_stats(info.pid).await;
-        let pids = super::stats::pid_stats(info.pid).await;
+        let network = crate::hypervisor::stats::network_stats_from_tap(&tap_name).await;
+        let disk_io = crate::hypervisor::stats::disk_io_stats(info.pid).await;
+        let pids = crate::hypervisor::stats::pid_stats(info.pid).await;
 
         Some(crate::api::dto::stats::InstanceStatsOutput {
             instance_id: instance_id.to_string(),

--- a/src/runtime/cloud_hypervisor/mod.rs
+++ b/src/runtime/cloud_hypervisor/mod.rs
@@ -1,5 +1,4 @@
 mod client;
 mod lifecycle;
-mod stats;
 
 pub(crate) use lifecycle::{CloudHypervisorLifecycle, CloudHypervisorRuntimeConfig};

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -88,10 +88,11 @@ impl FirecrackerRuntimeConfig {
 
 pub struct FirecrackerLifecycle {
     config: FirecrackerRuntimeConfig,
-    /// PID per instance id, captured at spawn so teardown can kill the right
-    /// process. Absence means the VM is gone (or was never tracked by this
-    /// process — e.g. inherited across a ring-server restart).
-    pids: Mutex<HashMap<String, u32>>,
+    /// Process info per instance id, captured at spawn so teardown can kill the
+    /// right process and stats can report `memory.usage_percent` without a
+    /// round-trip to the VMM. Absence means the VM is gone (or was never
+    /// tracked by this process — e.g. inherited across a ring-server restart).
+    pids: Mutex<HashMap<String, InstanceProcessInfo>>,
     /// Live host tap devices, keyed by instance id. Unlike Cloud Hypervisor,
     /// Firecracker doesn't create the tap itself — Ring owns its whole
     /// lifecycle. Dropping the entry deletes the interface from the host.
@@ -99,6 +100,16 @@ pub struct FirecrackerLifecycle {
     /// Live socat port-forwarders, keyed by instance id. Dropping the entry
     /// kills the socat process.
     port_forwarders: Mutex<HashMap<String, Vec<PortForwarder>>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct InstanceProcessInfo {
+    /// The `firecracker` process PID — used for teardown and `/proc/<pid>` stats.
+    pub pid: u32,
+    /// Memory limit (bytes) handed to the microVM at boot, so stats can report
+    /// `usage_percent`. 0 when the VM was inherited across a restart (we never
+    /// re-read the original limit) — reported as "unlimited", matching Docker.
+    pub memory_limit_bytes: u64,
 }
 
 impl FirecrackerLifecycle {
@@ -297,7 +308,15 @@ impl FirecrackerLifecycle {
             }
         }
 
-        self.pids.lock().unwrap().insert(instance_id.clone(), pid);
+        let (_, mem_mib) = parse_resources(deployment);
+        let memory_limit_bytes = (mem_mib as u64).saturating_mul(1024 * 1024);
+        self.pids.lock().unwrap().insert(
+            instance_id.clone(),
+            InstanceProcessInfo {
+                pid,
+                memory_limit_bytes,
+            },
+        );
         if let Some(t) = tap {
             self.taps.lock().unwrap().insert(instance_id.clone(), t);
         }
@@ -443,6 +462,7 @@ impl FirecrackerLifecycle {
             .lock()
             .unwrap()
             .remove(instance_id)
+            .map(|info| info.pid)
             .or_else(|| find_pid_by_socket(&socket_path));
         if let Some(pid) = pid {
             self.kill_pid(pid).await;
@@ -608,7 +628,15 @@ impl FirecrackerLifecycle {
                     .insert(instance_id.clone(), forwarders);
             }
             if let Some(pid) = find_pid_by_socket(&self.socket_path(&instance_id)) {
-                self.pids.lock().unwrap().insert(instance_id.clone(), pid);
+                let (_, mem_mib) = parse_resources(deployment);
+                let memory_limit_bytes = (mem_mib as u64).saturating_mul(1024 * 1024);
+                self.pids.lock().unwrap().insert(
+                    instance_id.clone(),
+                    InstanceProcessInfo {
+                        pid,
+                        memory_limit_bytes,
+                    },
+                );
             }
             info!(
                 "Firecracker: re-adopted networking for {} after restart",
@@ -942,6 +970,77 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
             ),
         }
     }
+
+    /// Per-instance CPU / memory / network / disk / pid stats for every running
+    /// instance of the deployment. Reads host-side `/proc/<pid>/*` and the
+    /// per-VM tap counters via the shared `stats` helpers — same source and
+    /// semantics as Cloud Hypervisor. Instances we don't have a PID for (e.g.
+    /// inherited across a restart before `readopt_networking` ran) are skipped.
+    async fn get_instance_stats(
+        &self,
+        deployment_id: &str,
+    ) -> Vec<crate::api::dto::stats::InstanceStatsOutput> {
+        let instances = self.scan_instances(deployment_id);
+        let mut out = Vec::with_capacity(instances.len());
+        for instance_id in instances {
+            if let Some(stats) = self.read_instance_stats(&instance_id).await {
+                out.push(stats);
+            }
+        }
+        out
+    }
+}
+
+/// Sampling window for CPU%: long enough for ticks to accumulate on an idle
+/// VM, short enough that an HTTP `metrics` call doesn't feel laggy. Matches
+/// the Cloud Hypervisor runtime and Docker's ~1s frame cadence.
+const CPU_SAMPLE_INTERVAL_MS: u64 = 500;
+
+impl FirecrackerLifecycle {
+    /// The tracked process info for an instance, or `None` if this server
+    /// didn't boot it (no PID — typical after a ring-server restart until
+    /// networking is re-adopted).
+    fn process_info(&self, instance_id: &str) -> Option<InstanceProcessInfo> {
+        self.pids.lock().ok()?.get(instance_id).copied()
+    }
+
+    /// Sample CPU twice with a short delay, read RSS once, and assemble the
+    /// `InstanceStatsOutput`. Returns `None` if the process tracking entry is
+    /// gone (VM stopped, or this server didn't spawn the VM).
+    async fn read_instance_stats(
+        &self,
+        instance_id: &str,
+    ) -> Option<crate::api::dto::stats::InstanceStatsOutput> {
+        let info = self.process_info(instance_id)?;
+
+        let prev = crate::hypervisor::stats::read_cpu_sample(info.pid).await?;
+        tokio::time::sleep(tokio::time::Duration::from_millis(CPU_SAMPLE_INTERVAL_MS)).await;
+        let curr = crate::hypervisor::stats::read_cpu_sample(info.pid).await?;
+
+        let interval_secs = CPU_SAMPLE_INTERVAL_MS as f64 / 1000.0;
+        // SC_CLK_TCK is fixed at compile time on Linux (typically 100).
+        let cpu_usage_percent =
+            crate::hypervisor::stats::compute_cpu_percent(prev, curr, interval_secs, 100.0);
+
+        let rss = crate::hypervisor::stats::read_rss_bytes(info.pid).await;
+        let memory = crate::hypervisor::stats::memory_stats(rss, info.memory_limit_bytes);
+
+        let tap_name = InstanceNet::for_instance(instance_id).tap_name;
+        let network = crate::hypervisor::stats::network_stats_from_tap(&tap_name).await;
+        let disk_io = crate::hypervisor::stats::disk_io_stats(info.pid).await;
+        let pids = crate::hypervisor::stats::pid_stats(info.pid).await;
+
+        Some(crate::api::dto::stats::InstanceStatsOutput {
+            instance_id: instance_id.to_string(),
+            instance_name: instance_id.to_string(),
+            cpu_usage_percent,
+            memory,
+            network,
+            disk_io,
+            pids,
+            restart_count: 0,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -1024,10 +1123,13 @@ mod tests {
 
         // One instance is tracked again (re-adopted or freshly booted): no
         // longer an orphan.
-        lc.pids
-            .lock()
-            .unwrap()
-            .insert("dep-1-aaa".to_string(), 4242);
+        lc.pids.lock().unwrap().insert(
+            "dep-1-aaa".to_string(),
+            InstanceProcessInfo {
+                pid: 4242,
+                memory_limit_bytes: 0,
+            },
+        );
         assert_eq!(lc.orphan_instances("dep-1"), vec!["dep-1-bbb".to_string()]);
 
         std::fs::remove_dir_all(&dir).ok();

--- a/tests/e2e/firecracker/t6_metrics.sh
+++ b/tests/e2e/firecracker/t6_metrics.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# T6-FC: GET /deployments/{id}/metrics returns live CPU/memory/network/disk/pids
+# stats for Firecracker microVMs. Like Cloud Hypervisor, the runtime reads
+# host-side files directly off the firecracker process PID:
+#   - CPU/memory from /proc/<pid>/stat and /status,
+#   - network from /sys/class/net/<tap>/statistics/* (swapped to guest-side),
+#   - disk_io from /proc/<pid>/io,
+#   - pids from /proc/<pid>/status Threads.
+# We assert response shape and that memory + threads are non-zero on a freshly
+# booted VM (always-true invariants for a live VMM).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T6-FC: deployment metrics =="
+
+setup_fc
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-metrics-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-metrics-vm:
+    name: fc-metrics-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "512Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-metrics-vm" "running" 60
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-metrics-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+
+# CPU% is computed from two /proc samples taken 500ms apart inside the
+# handler. Give the VM a moment to settle so the figures are meaningful.
+sleep 2
+
+METRICS=$(curl -fsS "$RING_URL/deployments/$DEPLOYMENT_ID/metrics" \
+  -H "Authorization: Bearer $TOKEN")
+
+# === Shape ===
+echo "$METRICS" | jq -e '.deployment_id, .instance_count, .total_memory, .total_network, .total_disk_io, .instances' \
+  > /dev/null || { echo "$METRICS" >&2; fail "metrics response missing required fields"; }
+log "metrics response has the expected fields"
+
+INST_COUNT=$(echo "$METRICS" | jq -r '.instance_count')
+[ "$INST_COUNT" = "1" ] || { echo "$METRICS" | jq '.' >&2; fail "instance_count=$INST_COUNT, expected 1"; }
+
+INST_LEN=$(echo "$METRICS" | jq -r '.instances | length')
+[ "$INST_LEN" = "1" ] || fail "instances array has $INST_LEN entries (expected 1)"
+
+# === Memory usage > 0 ===
+# A running firecracker process always has VmRSS > 0; if it doesn't, we either
+# lost the PID mapping or the proc reader is broken.
+MEM_USAGE=$(echo "$METRICS" | jq -r '.total_memory.usage_bytes')
+if [ -z "$MEM_USAGE" ] || [ "$MEM_USAGE" = "null" ] || [ "$MEM_USAGE" -le 0 ]; then
+  echo "$METRICS" | jq '.total_memory' >&2
+  fail "total_memory.usage_bytes is $MEM_USAGE (expected > 0)"
+fi
+log "total memory usage: $MEM_USAGE bytes"
+
+# === Memory limit reflects the deployment limit (512 MiB) ===
+EXPECTED_LIMIT=$((512 * 1024 * 1024))
+LIMIT=$(echo "$METRICS" | jq -r '.instances[0].memory.limit_bytes')
+[ "$LIMIT" = "$EXPECTED_LIMIT" ] || {
+  echo "$METRICS" | jq '.instances[0].memory' >&2
+  fail "memory.limit_bytes=$LIMIT, expected $EXPECTED_LIMIT"
+}
+log "memory limit reported as $LIMIT bytes"
+
+# === Each instance has a non-empty instance_id ===
+EMPTY_IDS=$(echo "$METRICS" | jq -r '[.instances[] | select(.instance_id == null or .instance_id == "")] | length')
+[ "$EMPTY_IDS" = "0" ] || { echo "$METRICS" | jq '.instances' >&2; fail "$EMPTY_IDS instance(s) have empty instance_id"; }
+
+# === pids: a running firecracker is multithreaded (vCPU + api + vmm). ===
+THREADS=$(echo "$METRICS" | jq -r '.instances[0].pids.current')
+if [ -z "$THREADS" ] || [ "$THREADS" = "null" ] || [ "$THREADS" -lt 2 ]; then
+  echo "$METRICS" | jq '.instances[0].pids' >&2
+  fail "pids.current is $THREADS (expected >= 2 threads for a live VMM)"
+fi
+log "vmm threads: $THREADS"
+
+# === disk_io: present and numeric (zeros tolerated on hardened hosts). ===
+DISK_READ=$(echo "$METRICS" | jq -r '.instances[0].disk_io.read_bytes')
+DISK_WRITE=$(echo "$METRICS" | jq -r '.instances[0].disk_io.write_bytes')
+if [ -z "$DISK_READ" ] || [ "$DISK_READ" = "null" ] || [ -z "$DISK_WRITE" ] || [ "$DISK_WRITE" = "null" ]; then
+  echo "$METRICS" | jq '.instances[0].disk_io' >&2
+  fail "disk_io stats missing (read=$DISK_READ write=$DISK_WRITE)"
+fi
+log "disk_io read/write: $DISK_READ / $DISK_WRITE bytes"
+
+# === network: counters present and numeric. ===
+# A no-ports deployment has no tap, so counters read as zeros — we only require
+# the shape to be intact, not >0.
+NET_RX=$(echo "$METRICS" | jq -r '.instances[0].network.rx_bytes')
+NET_TX=$(echo "$METRICS" | jq -r '.instances[0].network.tx_bytes')
+if [ -z "$NET_RX" ] || [ "$NET_RX" = "null" ] || [ -z "$NET_TX" ] || [ "$NET_TX" = "null" ]; then
+  echo "$METRICS" | jq '.instances[0].network' >&2
+  fail "network stats missing (rx=$NET_RX tx=$NET_TX)"
+fi
+log "network rx/tx: $NET_RX / $NET_TX bytes"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-metrics-vm >/dev/null 2>&1 || true
+
+log "== T6-FC: PASS =="


### PR DESCRIPTION
## What

Bring Firecracker to parity with Cloud Hypervisor for `GET /deployments/{id}/metrics`. Until now Firecracker used the trait default for `get_instance_stats` (empty), so `ring deployment metrics` and the Prometheus per-deployment gauges returned nothing for Firecracker workloads.

## Changes

- Promote the host-side stats reader from `runtime/cloud_hypervisor/stats.rs` to the shared `hypervisor/stats.rs` module (it is VMM-agnostic — it reads `/proc/<pid>/{stat,status,io}` and `/sys/class/net/<tap>/statistics/*`), alongside the other shared host-side helpers. Repoint Cloud Hypervisor at it (no behaviour change).
- Carry the per-instance memory limit in Firecracker's process map (`InstanceProcessInfo { pid, memory_limit_bytes }`, mirroring CH) so stats can report `memory.usage_percent` without a round-trip to the VMM. Captured at boot and on restart re-adoption.
- Implement `get_instance_stats` / `read_instance_stats` for Firecracker: two-sample CPU%, RSS, tap network counters (guest-side mapped), disk I/O, and thread count — identical semantics to Cloud Hypervisor.

## Tests

- Shared `stats` unit tests (24) pass at the new location; FC + CH suites green.
- New e2e `tests/e2e/firecracker/t6_metrics.sh`, mirroring CH `t18_metrics.sh`. **Validated on real Firecracker** (`/dev/kvm` + `firecracker`): a booted 512 MiB microVM reports ~90 MiB RSS, the correct 512 MiB limit, 4 VMM threads, and intact network/disk shape.

## Docs

- `documentation/runtimes/firecracker.md`: document the metrics endpoint; drop "no metrics" from the known gaps.

Second in the Firecracker-parity series (after console logs #167). Next: console-log rotation, `kind: job`, volumes.