### PR TITLE
feat(firecracker): rotate per-VM console logs via copy-truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - containerd runtime over native gRPC: index/entrypoint resolution for multi-arch images, CNI networking, logs, command health checks (#144)
 - Podman runtime, opt-in under `[server.runtime.podman]` (#139)
 - Firecracker microVM runtime (experimental): boot, networking, outbound NAT, restart reconciliation (#142, #146, #147)
+- Firecracker reaches Cloud Hypervisor parity for observability: serial console log read/stream (#167), per-instance CPU/memory/network/disk/pid metrics (#168), and copy-truncate console-log rotation
 - Public Prometheus `/metrics` endpoint exposing inventory and queue gauges, plus background-refreshed per-deployment runtime resource usage (#164)
 - Scoped API tokens (PAT) with per-scope and per-namespace enforcement, plus `ring token` CLI (#134)
 - Outbound webhooks with HMAC-signed delivery and a durable event queue, plus `ring webhook` CLI (#135)

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -110,6 +110,8 @@ containerd speaks its own native gRPC API on a Unix socket — no Docker daemon 
 | `firmware_path` | string | `$RING_CONFIG_DIR/cloud-hypervisor/vmlinux` | Path to `hypervisor-fw` (the EFI firmware) |
 | `socket_dir` | string | `$RING_CONFIG_DIR/cloud-hypervisor/sockets` | Where Ring puts per-VM Unix sockets, console logs, volume shares |
 | `seccomp` | string | unset (CH default: kill on violation) | Forwarded to `cloud-hypervisor --seccomp`. Accepts `"true"`, `"false"`, `"log"`. Set to `"false"` only on hosts where the kernel uses syscalls not whitelisted by CH (otherwise VMs die with `SIGSYS`) |
+| `max_console_log_bytes` | int | `10485760` (10 MiB) | Size at which a per-VM console log is rotated. `0` disables rotation |
+| `max_console_log_backups` | int | `3` | How many rotated backups (`<id>.console.log.1`, `.2`, …) to keep |
 
 ### `[server.runtime.firecracker]`
 
@@ -120,6 +122,8 @@ containerd speaks its own native gRPC API on a Unix socket — no Docker daemon 
 | `kernel_path` | string | `$RING_CONFIG_DIR/firecracker/vmlinux` | Path to the uncompressed kernel image. Firecracker boots a kernel directly — there is no firmware step |
 | `socket_dir` | string | `$RING_CONFIG_DIR/firecracker/sockets` | Where Ring puts per-VM API sockets and per-instance rootfs copies |
 | `boot_args` | string | `console=ttyS0 reboot=k panic=1 pci=off` | Kernel command line passed to every microVM |
+| `max_console_log_bytes` | int | `10485760` (10 MiB) | Size at which a per-VM console log is rotated. `0` disables rotation. Firecracker rotates by copy-truncate (it holds the log by inode), so the live file keeps its path across rotations |
+| `max_console_log_backups` | int | `3` | How many rotated backups (`<id>.console.log.1`, `.2`, …) to keep |
 
 ## Examples
 

--- a/documentation/runtimes/firecracker.md
+++ b/documentation/runtimes/firecracker.md
@@ -65,6 +65,8 @@ ring deployment logs <deployment-id> --tail 50  # last 50 lines
 ring deployment logs <deployment-id> --follow   # stream as the guest writes
 ```
 
+Console logs are rotated once they cross `max_console_log_bytes` (10 MiB by default; see [config reference](/documentation/reference/config-toml)). Because Firecracker holds the log open by inode — it's the VM process' stdout — rotation is done by **copy-truncate**: the content is copied to `<id>.console.log.1` and the live file is truncated in place, so the VM keeps writing to the same path without a sparse hole. `ring deployment logs` reads back through the rotated backups.
+
 ## Metrics
 
 Per-instance CPU, memory, network, disk I/O, and thread counts are exposed at `GET /deployments/{id}/metrics`, the same as every other runtime. Ring reads them host-side from the `firecracker` process (`/proc/<pid>/{stat,status,io}`) and the per-VM tap counters — no in-guest agent required. Memory `usage_percent` is reported against the deployment's memory limit; network counters read zero for deployments that publish no ports (no tap is created).

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -206,6 +206,7 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
 
     // Firecracker: same opt-in contract. Its binary must resolve when enabled,
     // else the runtime is skipped (best-effort, like the others).
+    let mut _fc_log_rotator = None;
     if configuration.server.runtime.firecracker.enabled {
         let fc_runtime_config =
             FirecrackerRuntimeConfig::from_user_config(&configuration.server.runtime.firecracker);
@@ -216,10 +217,9 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
                 fc_runtime_config.kernel_path,
                 fc_runtime_config.socket_dir,
             );
-            runtimes_map.insert(
-                "firecracker".to_string(),
-                Arc::new(FirecrackerLifecycle::new(fc_runtime_config)),
-            );
+            let fc_lifecycle = FirecrackerLifecycle::new(fc_runtime_config);
+            _fc_log_rotator = Some(fc_lifecycle.spawn_console_log_rotator());
+            runtimes_map.insert("firecracker".to_string(), Arc::new(fc_lifecycle));
         } else {
             let reason = format!(
                 "binary '{}' could not be found",

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -196,6 +196,12 @@ pub(crate) struct FirecrackerConfig {
     pub(crate) socket_dir: Option<String>,
     /// Kernel command line passed to every microVM.
     pub(crate) boot_args: Option<String>,
+    /// Maximum size (bytes) for a per-VM console log before rotation kicks
+    /// in. Defaults to 10 MiB. Set to 0 to disable rotation entirely.
+    pub(crate) max_console_log_bytes: Option<u64>,
+    /// How many rotated console log backups to keep alongside the live file
+    /// (`.console.log.1`, `.console.log.2`, ...). Defaults to 3.
+    pub(crate) max_console_log_backups: Option<u32>,
 }
 
 /// User-facing configuration for the embedded web dashboard. Off by default

--- a/src/hypervisor/console_logs.rs
+++ b/src/hypervisor/console_logs.rs
@@ -246,29 +246,8 @@ pub(crate) async fn rotate_if_needed(path: &Path, max_bytes: u64, max_backups: u
         return;
     }
 
-    let oldest = backup_path(path, max_backups);
-    if oldest.exists()
-        && let Err(e) = tokio::fs::remove_file(&oldest).await
-    {
-        warn!(
-            "console log rotate: failed to remove oldest backup {:?}: {}",
-            oldest, e
-        );
-    }
-
-    // Shift .N-1 → .N down to .1 → .2.
-    for idx in (1..max_backups).rev() {
-        let from = backup_path(path, idx);
-        let to = backup_path(path, idx + 1);
-        if from.exists()
-            && let Err(e) = tokio::fs::rename(&from, &to).await
-        {
-            warn!(
-                "console log rotate: failed to shift {:?} -> {:?}: {}",
-                from, to, e
-            );
-            return;
-        }
+    if !shift_backups(path, max_backups).await {
+        return;
     }
 
     // Finally, live -> .1.
@@ -286,9 +265,118 @@ pub(crate) async fn rotate_if_needed(path: &Path, max_bytes: u64, max_backups: u
     );
 }
 
-/// Walk `socket_dir` once and rotate every `*.console.log` that has grown
-/// past the threshold. Called on a 60-second cadence by the rotator task.
-pub(crate) async fn rotate_all_in_dir(dir: &Path, max_bytes: u64, max_backups: u32) {
+/// Drop the oldest backup and shift `.N-1` → `.N` down to `.1` → `.2`, freeing
+/// the `.1` slot for the live file. Returns `false` if a rename failed (caller
+/// should abort the rotation). Shared by the rename-based ([`rotate_if_needed`])
+/// and copy-truncate ([`copy_truncate_if_needed`]) strategies.
+async fn shift_backups(path: &Path, max_backups: u32) -> bool {
+    let oldest = backup_path(path, max_backups);
+    if oldest.exists()
+        && let Err(e) = tokio::fs::remove_file(&oldest).await
+    {
+        warn!(
+            "console log rotate: failed to remove oldest backup {:?}: {}",
+            oldest, e
+        );
+    }
+
+    for idx in (1..max_backups).rev() {
+        let from = backup_path(path, idx);
+        let to = backup_path(path, idx + 1);
+        if from.exists()
+            && let Err(e) = tokio::fs::rename(&from, &to).await
+        {
+            warn!(
+                "console log rotate: failed to shift {:?} -> {:?}: {}",
+                from, to, e
+            );
+            return false;
+        }
+    }
+    true
+}
+
+/// Rotate `<path>` by **copy-truncate**, for writers that hold the live file by
+/// inode (a redirected process stdout, e.g. Firecracker) rather than by name.
+///
+/// A rename would leave such a writer appending to the now-rotated path
+/// forever; instead we copy the live content into `<path>.1` and truncate the
+/// live file in place. The writer keeps the same fd, so it must have opened
+/// with `O_APPEND` — otherwise its write offset is unchanged by the truncate
+/// and the next write leaves a sparse hole. (Firecracker's console fd is opened
+/// `O_APPEND` in the runtime's `start_vm` for exactly this reason.)
+///
+/// Same no-op conditions as [`rotate_if_needed`].
+pub(crate) async fn copy_truncate_if_needed(path: &Path, max_bytes: u64, max_backups: u32) {
+    if max_bytes == 0 {
+        return;
+    }
+    let size = match tokio::fs::metadata(path).await {
+        Ok(m) => m.len(),
+        Err(_) => return,
+    };
+    if size <= max_bytes {
+        return;
+    }
+
+    // No backups kept: just truncate the live file in place.
+    if max_backups == 0 {
+        if let Err(e) = truncate_in_place(path).await {
+            warn!(
+                "console log copy-truncate: failed to truncate {:?}: {}",
+                path, e
+            );
+        }
+        return;
+    }
+
+    if !shift_backups(path, max_backups).await {
+        return;
+    }
+
+    // Copy live content into .1, then truncate the live file in place so the
+    // inode the writer holds stays the same.
+    let target = backup_path(path, 1);
+    if let Err(e) = tokio::fs::copy(path, &target).await {
+        warn!(
+            "console log copy-truncate: failed to copy {:?} -> {:?}: {}",
+            path, target, e
+        );
+        return;
+    }
+    if let Err(e) = truncate_in_place(path).await {
+        warn!(
+            "console log copy-truncate: failed to truncate {:?}: {}",
+            path, e
+        );
+        return;
+    }
+    debug!(
+        "console log copy-truncated: {:?} (size {} > {})",
+        path, size, max_bytes
+    );
+}
+
+/// Truncate `path` to zero bytes without unlinking it (the writer's inode must
+/// survive). Opening with `write(true).truncate(true)` keeps the same inode.
+async fn truncate_in_place(path: &Path) -> std::io::Result<()> {
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .await
+        .map(|_| ())
+}
+
+/// Walk `socket_dir` once and rotate every `*.console.log` that has grown past
+/// the threshold, using the given `strategy`. Called on a 60-second cadence by
+/// each runtime's rotator task.
+async fn rotate_all_in_dir_with(
+    dir: &Path,
+    max_bytes: u64,
+    max_backups: u32,
+    strategy: RotateStrategy,
+) {
     if max_bytes == 0 {
         return;
     }
@@ -304,8 +392,31 @@ pub(crate) async fn rotate_all_in_dir(dir: &Path, max_bytes: u64, max_backups: u
         if !name.ends_with(".console.log") {
             continue;
         }
-        rotate_if_needed(&path, max_bytes, max_backups).await;
+        match strategy {
+            RotateStrategy::Rename => rotate_if_needed(&path, max_bytes, max_backups).await,
+            RotateStrategy::CopyTruncate => {
+                copy_truncate_if_needed(&path, max_bytes, max_backups).await
+            }
+        }
     }
+}
+
+#[derive(Clone, Copy)]
+enum RotateStrategy {
+    /// Rename the live file to `.1` (path-based writers like Cloud Hypervisor).
+    Rename,
+    /// Copy then truncate in place (inode-held writers like Firecracker).
+    CopyTruncate,
+}
+
+/// Rename-based directory sweep — Cloud Hypervisor.
+pub(crate) async fn rotate_all_in_dir(dir: &Path, max_bytes: u64, max_backups: u32) {
+    rotate_all_in_dir_with(dir, max_bytes, max_backups, RotateStrategy::Rename).await;
+}
+
+/// Copy-truncate directory sweep — Firecracker (inode-held console fd).
+pub(crate) async fn copy_truncate_all_in_dir(dir: &Path, max_bytes: u64, max_backups: u32) {
+    rotate_all_in_dir_with(dir, max_bytes, max_backups, RotateStrategy::CopyTruncate).await;
 }
 
 #[cfg(test)]
@@ -561,5 +672,99 @@ mod tests {
         assert!(other.exists(), "non-console files must be left alone");
 
         tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn copy_truncate_copies_to_backup_and_keeps_inode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let path = scratch_file("ct-inode");
+        tokio::fs::write(&path, b"payload-over-threshold")
+            .await
+            .unwrap();
+        let inode_before = std::fs::metadata(&path).unwrap().ino();
+
+        copy_truncate_if_needed(&path, 8, 3).await;
+
+        // Live file still exists at the SAME inode (the writer's fd survives).
+        assert!(path.exists(), "live file must not be unlinked");
+        let inode_after = std::fs::metadata(&path).unwrap().ino();
+        assert_eq!(inode_before, inode_after, "inode must be preserved");
+        // Live file truncated to zero.
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 0);
+        // Content copied into .1.
+        assert_eq!(
+            tokio::fs::read(backup_path(&path, 1)).await.unwrap(),
+            b"payload-over-threshold"
+        );
+
+        tokio::fs::remove_file(&path).await.ok();
+        tokio::fs::remove_file(backup_path(&path, 1)).await.ok();
+    }
+
+    #[tokio::test]
+    async fn copy_truncate_appending_writer_resumes_at_zero() {
+        // The whole reason copy-truncate needs an O_APPEND writer: after the
+        // truncate, the next write must land at offset 0, not leave a sparse
+        // hole the size of the pre-rotation file.
+        use tokio::io::AsyncWriteExt;
+
+        let path = scratch_file("ct-append");
+        let mut writer = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .truncate(false)
+            .open(&path)
+            .await
+            .unwrap();
+        writer.write_all(b"before-rotation\n").await.unwrap();
+        writer.flush().await.unwrap();
+
+        copy_truncate_if_needed(&path, 4, 1).await;
+
+        // Writer keeps the same fd and appends after the truncate.
+        writer.write_all(b"after\n").await.unwrap();
+        writer.flush().await.unwrap();
+
+        // No sparse hole: the live file is exactly the post-rotation bytes.
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"after\n");
+        assert_eq!(
+            tokio::fs::read(backup_path(&path, 1)).await.unwrap(),
+            b"before-rotation\n"
+        );
+
+        drop(writer);
+        tokio::fs::remove_file(&path).await.ok();
+        tokio::fs::remove_file(backup_path(&path, 1)).await.ok();
+    }
+
+    #[tokio::test]
+    async fn copy_truncate_zero_backups_truncates_in_place() {
+        use std::os::unix::fs::MetadataExt;
+
+        let path = scratch_file("ct-zero-backups");
+        tokio::fs::write(&path, b"payload-over-threshold")
+            .await
+            .unwrap();
+        let inode_before = std::fs::metadata(&path).unwrap().ino();
+
+        copy_truncate_if_needed(&path, 4, 0).await;
+
+        assert!(path.exists());
+        assert_eq!(std::fs::metadata(&path).unwrap().ino(), inode_before);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 0);
+        assert!(!backup_path(&path, 1).exists());
+
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn copy_truncate_no_op_under_threshold() {
+        let path = scratch_file("ct-under");
+        tokio::fs::write(&path, b"small").await.unwrap();
+        copy_truncate_if_needed(&path, 1024, 3).await;
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"small");
+        assert!(!backup_path(&path, 1).exists());
+        tokio::fs::remove_file(&path).await.ok();
     }
 }

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -47,6 +47,11 @@ pub(crate) struct FirecrackerRuntimeConfig {
     /// Kernel command line. The default enables the serial console so console
     /// logs are capturable, and panics reboot rather than hang.
     pub boot_args: String,
+    /// Maximum size (bytes) for a per-VM console log before rotation. Defaults
+    /// to 10 MiB. Set to 0 to disable rotation entirely.
+    pub max_console_log_bytes: u64,
+    /// How many rotated console log backups to keep. Defaults to 3.
+    pub max_console_log_backups: u32,
 }
 
 impl Default for FirecrackerRuntimeConfig {
@@ -57,6 +62,8 @@ impl Default for FirecrackerRuntimeConfig {
             kernel_path: format!("{}/firecracker/vmlinux", base_dir),
             socket_dir: format!("{}/firecracker/sockets", base_dir),
             boot_args: "console=ttyS0 reboot=k panic=1 pci=off".to_string(),
+            max_console_log_bytes: 10 * 1024 * 1024,
+            max_console_log_backups: 3,
         }
     }
 }
@@ -82,6 +89,12 @@ impl FirecrackerRuntimeConfig {
             kernel_path: user.kernel_path.clone().unwrap_or(defaults.kernel_path),
             socket_dir: user.socket_dir.clone().unwrap_or(defaults.socket_dir),
             boot_args: user.boot_args.clone().unwrap_or(defaults.boot_args),
+            max_console_log_bytes: user
+                .max_console_log_bytes
+                .unwrap_or(defaults.max_console_log_bytes),
+            max_console_log_backups: user
+                .max_console_log_backups
+                .unwrap_or(defaults.max_console_log_backups),
         }
     }
 }
@@ -137,6 +150,47 @@ impl FirecrackerLifecycle {
         format!("{}/{}.console.log", self.config.socket_dir, instance_id)
     }
 
+    /// Spawn a background task that walks the socket directory every 60s and
+    /// rotates any `*.console.log` past the configured size threshold. Returns
+    /// the handle so the caller (`ring-server`) can abort it on shutdown.
+    ///
+    /// Unlike Cloud Hypervisor, Firecracker holds its console fd by inode (it's
+    /// the spawned process' stdout), so this uses **copy-truncate** rather than
+    /// rename — see [`crate::hypervisor::console_logs::copy_truncate_all_in_dir`].
+    /// No-op (logs once) when rotation is disabled.
+    pub fn spawn_console_log_rotator(&self) -> tokio::task::JoinHandle<()> {
+        let dir = std::path::PathBuf::from(&self.config.socket_dir);
+        let max_bytes = self.config.max_console_log_bytes;
+        let max_backups = self.config.max_console_log_backups;
+        tokio::spawn(async move {
+            if max_bytes == 0 {
+                tracing::info!(
+                    "Firecracker console log rotation disabled (max_console_log_bytes = 0)"
+                );
+                return;
+            }
+            tracing::info!(
+                "Firecracker console log rotator armed: dir={:?} max_bytes={} max_backups={}",
+                dir,
+                max_bytes,
+                max_backups
+            );
+            let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(60));
+            // Skip the initial tick so we don't sweep before socket_dir exists.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                tracing::debug!("Firecracker console log rotator: sweeping {:?}", dir);
+                crate::hypervisor::console_logs::copy_truncate_all_in_dir(
+                    &dir,
+                    max_bytes,
+                    max_backups,
+                )
+                .await;
+            }
+        })
+    }
+
     /// Boot one worker microVM. Returns the new instance id on success.
     async fn start_vm(&self, deployment: &Deployment) -> Result<String, RuntimeError> {
         // Pre-flight: kernel + base rootfs must exist before we spawn anything.
@@ -177,9 +231,21 @@ impl FirecrackerLifecycle {
         // boot/runtime issues are diagnosable and log shippers can tail it.
         // Falls back to null if the file can't be opened — never block boot on
         // logging. stderr (firecracker's own diagnostics) shares the same file.
+        //
+        // Opened with O_APPEND (not a plain create): Firecracker holds this fd
+        // for the VM's whole life, so the rotator can't make it reopen by name
+        // the way Cloud Hypervisor does. With O_APPEND every write seeks to EOF
+        // first, which makes copy-truncate rotation land new output at offset 0
+        // instead of leaving a sparse hole. The instance id is unique per boot
+        // (`<deployment>-<tiny_id>`), so there is no stale file to clear.
         let console_log = self.console_log_path(&instance_id);
         let (out, err): (std::process::Stdio, std::process::Stdio) =
-            match std::fs::File::create(&console_log) {
+            match std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .truncate(false)
+                .open(&console_log)
+            {
                 Ok(f) => match f.try_clone() {
                     Ok(f2) => (f.into(), f2.into()),
                     Err(_) => (f.into(), std::process::Stdio::null()),
@@ -483,7 +549,17 @@ impl FirecrackerLifecycle {
         let _ = std::fs::remove_file(&socket_path);
         let _ = std::fs::remove_file(self.rootfs_path(instance_id));
         let _ = std::fs::remove_file(self.cidata_path(instance_id));
-        let _ = std::fs::remove_file(self.console_log_path(instance_id));
+        let console_log = self.console_log_path(instance_id);
+        let _ = std::fs::remove_file(&console_log);
+        // Sweep any rotated backups (`<id>.console.log.1`, `.2`, ...) the
+        // rotator left behind. Stop at the first missing index.
+        for idx in 1u32..=1000 {
+            let backup = format!("{}.{}", console_log, idx);
+            if !Path::new(&backup).exists() {
+                break;
+            }
+            let _ = std::fs::remove_file(&backup);
+        }
         // Remove the vsock base socket and the per-port multiplexed socket
         // Firecracker creates (`<base>_<port>`). No-ops when the instance had
         // no vsock device.
@@ -1176,6 +1252,8 @@ mod tests {
             kernel_path: None,
             socket_dir: Some("/var/run/fc".to_string()),
             boot_args: None,
+            max_console_log_bytes: None,
+            max_console_log_backups: None,
         };
         let cfg = FirecrackerRuntimeConfig::from_user_config(&user);
         assert_eq!(cfg.binary_path, "/opt/fc/firecracker");
@@ -1184,6 +1262,11 @@ mod tests {
         let defaults = FirecrackerRuntimeConfig::default();
         assert_eq!(cfg.kernel_path, defaults.kernel_path);
         assert_eq!(cfg.boot_args, defaults.boot_args);
+        assert_eq!(cfg.max_console_log_bytes, defaults.max_console_log_bytes);
+        assert_eq!(
+            cfg.max_console_log_backups,
+            defaults.max_console_log_backups
+        );
     }
 
     #[test]

--- a/tests/e2e/firecracker/t7_log_rotation.sh
+++ b/tests/e2e/firecracker/t7_log_rotation.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# T7-FC: the per-VM serial console log must rotate once it crosses the
+# configured size threshold. Firecracker holds the log by inode (the spawned
+# process' stdout), so rotation is copy-truncate, not rename. We point Ring at
+# a 4 KiB limit / 2 backups, boot a VM, wait for the boot output to push the
+# file past 4 KiB, then wait one sweep cycle and assert:
+#   1. <id>.console.log.1 appears AND the live file stays at the same path
+#      (copy-truncate keeps the inode the writer holds),
+#   2. ring deployment logs still returns the full history (reads through the
+#      rotated backup),
+#   3. deleting the deployment cleans up both .console.log and its backups.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T7-FC: console log rotation =="
+
+setup_fc
+
+# Append the rotation knobs to the firecracker config block produced by
+# setup_fc. A tiny threshold so a single boot crosses it.
+RING_EXTRA_CONFIG="${RING_EXTRA_CONFIG}
+max_console_log_bytes = 4096
+max_console_log_backups = 2
+"
+export RING_EXTRA_CONFIG
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-log-rotation-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-log-rotation-vm:
+    name: fc-log-rotation-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-log-rotation-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-log-rotation-vm")
+[ -z "$DEPLOYMENT_ID" ] && fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === wait until the live log crosses the threshold ===
+LOG_FILE=""
+for _ in $(seq 1 60); do
+  LOG_FILE=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.console.log" 2>/dev/null | head -n1 || true)
+  if [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
+    SIZE=$(stat -c %s "$LOG_FILE")
+    [ "$SIZE" -gt 4096 ] && break
+  fi
+  sleep 1
+done
+[ -z "$LOG_FILE" ] && fail "no console log file appeared"
+SIZE=$(stat -c %s "$LOG_FILE")
+[ "$SIZE" -gt 4096 ] || fail "console log $LOG_FILE did not cross 4 KiB (size=$SIZE)"
+log "console log past threshold: $LOG_FILE ($SIZE bytes)"
+INODE_BEFORE=$(stat -c %i "$LOG_FILE")
+
+# === wait one rotator cycle (60s) ===
+BACKUP="${LOG_FILE}.1"
+log "waiting up to 90s for rotation sweep..."
+ROTATED=0
+for _ in $(seq 1 90); do
+  if [ -f "$BACKUP" ]; then
+    ROTATED=1
+    break
+  fi
+  sleep 1
+done
+[ "$ROTATED" -eq 1 ] || fail "rotation did not produce $BACKUP within 90s"
+log "backup created: $BACKUP ($(stat -c %s "$BACKUP") bytes)"
+
+# === copy-truncate kept the live file's inode (so firecracker keeps writing) ===
+[ -f "$LOG_FILE" ] || fail "live console log vanished after rotation (copy-truncate should keep it)"
+INODE_AFTER=$(stat -c %i "$LOG_FILE")
+[ "$INODE_BEFORE" = "$INODE_AFTER" ] || \
+  fail "live log inode changed on rotation ($INODE_BEFORE -> $INODE_AFTER); firecracker would write to a sparse file"
+log "live log inode preserved across rotation ($INODE_AFTER)"
+
+# === ring deployment logs reads through the backup ===
+LOGS_OUT=$("$RING_BIN" deployment logs "$DEPLOYMENT_ID" --tail 100000 2>&1 || true)
+LINE_COUNT=$(printf '%s\n' "$LOGS_OUT" | grep -c . || true)
+if [ "$LINE_COUNT" -lt 5 ]; then
+  fail "expected at least 5 lines across live+backup, got $LINE_COUNT"
+fi
+log "ring deployment logs --tail 100000 returned $LINE_COUNT line(s) across backups"
+
+# === delete teardown removes the log AND its backups ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-log-rotation-vm >/dev/null 2>&1 || true
+for _ in $(seq 1 60); do
+  if ! [ -f "$LOG_FILE" ] && ! [ -f "$BACKUP" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -f "$LOG_FILE" ] || [ -f "$BACKUP" ]; then
+  fail "rotated logs still present after delete (live=$LOG_FILE backup=$BACKUP)"
+fi
+log "rotated logs cleaned up"
+
+log "== T7-FC: PASS =="


### PR DESCRIPTION
## What

Bring Firecracker to parity with Cloud Hypervisor for console-log rotation. Until now a Firecracker `*.console.log` grew unbounded, while Cloud Hypervisor has a background rotator. This adds the same for Firecracker — correctly, for its different file-handling model.

## The wrinkle: inode vs name

Cloud Hypervisor holds the console **by name** (`serial.mode = "File"`), so it re-creates the live file after a rename — plain rename-based rotation works. Firecracker holds the console **by inode** (it's the spawned process' stdout), so a rename would leave Firecracker appending to the now-rotated path forever. Rotation here is therefore **copy-truncate**: copy the live content to `<id>.console.log.1`, then truncate the live file in place so the VM keeps writing to the same inode.

Copy-truncate only works without a sparse hole if the writer opened with `O_APPEND` (every write seeks to EOF first). This PR opens Firecracker's console fd with `O_APPEND` for exactly that reason. (Verified empirically — without it, the post-truncate file carries a NUL hole the size of the pre-rotation content.)

## Changes

- `hypervisor/console_logs.rs`: factor out the shared backup-shift, add `copy_truncate_if_needed` / `copy_truncate_all_in_dir` alongside the existing rename-based path.
- Firecracker opens its console log `O_APPEND`; adds `spawn_console_log_rotator` (copy-truncate, 60s sweep) wired at server startup; sweeps rotated backups on instance teardown.
- Config: `max_console_log_bytes` (default 10 MiB) and `max_console_log_backups` (default 3) under `[server.runtime.firecracker]`.

## Tests

- 4 new unit tests in `console_logs`: inode preservation, append-resumes-at-offset-0 (no sparse hole), zero-backups in-place truncate, no-op under threshold.
- New e2e `tests/e2e/firecracker/t7_log_rotation.sh`. **Validated on real Firecracker** (`/dev/kvm` + `firecracker`): boot crosses the 4 KiB threshold, the sweep produces `.console.log.1`, **the live file keeps its inode** (297590) so the VM keeps writing, logs read back through the backup (413 lines), and teardown cleans up live + backups.

## Docs

- `documentation/runtimes/firecracker.md`: rotation note explaining the copy-truncate model. `documentation/reference/config-toml.md`: document the two knobs (and the previously-undocumented CH equivalents). CHANGELOG entry.

Third in the Firecracker-parity series (after console logs #167, stats #168). Next: `kind: job`, then volumes.