### PR TITLE
feat(firecracker): run-to-completion semantics for kind: job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - containerd runtime over native gRPC: index/entrypoint resolution for multi-arch images, CNI networking, logs, command health checks (#144)
 - Podman runtime, opt-in under `[server.runtime.podman]` (#139)
 - Firecracker microVM runtime (experimental): boot, networking, outbound NAT, restart reconciliation (#142, #146, #147)
-- Firecracker reaches Cloud Hypervisor parity for observability: serial console log read/stream (#167), per-instance CPU/memory/network/disk/pid metrics (#168), and copy-truncate console-log rotation
+- Firecracker reaches Cloud Hypervisor parity for observability: serial console log read/stream (#167), per-instance CPU/memory/network/disk/pid metrics (#168), and copy-truncate console-log rotation (#169)
+- Firecracker `kind: job`: boot one VM, mark `completed` when the guest reboots (which exits the VMM); artifacts reaped, terminal status sticky (#170)
 - Public Prometheus `/metrics` endpoint exposing inventory and queue gauges, plus background-refreshed per-deployment runtime resource usage (#164)
 - Scoped API tokens (PAT) with per-scope and per-namespace enforcement, plus `ring token` CLI (#134)
 - Outbound webhooks with HMAC-signed delivery and a durable event queue, plus `ring webhook` CLI (#135)

--- a/documentation/runtimes/firecracker.md
+++ b/documentation/runtimes/firecracker.md
@@ -71,10 +71,17 @@ Console logs are rotated once they cross `max_console_log_bytes` (10 MiB by defa
 
 Per-instance CPU, memory, network, disk I/O, and thread counts are exposed at `GET /deployments/{id}/metrics`, the same as every other runtime. Ring reads them host-side from the `firecracker` process (`/proc/<pid>/{stat,status,io}`) and the per-VM tap counters — no in-guest agent required. Memory `usage_percent` is reported against the deployment's memory limit; network counters read zero for deployments that publish no ports (no tap is created).
 
+## Jobs (`kind: job`)
+
+A `kind: job` deployment boots a single microVM (replicas are ignored) and is marked **`completed`** once the guest finishes. Firecracker exposes no VM-state API, so completion is signalled by the **guest rebooting**: with the default `reboot=k` kernel cmdline, a guest `reboot` is trapped by Firecracker and exits the VMM cleanly. Ring's next scheduler tick sees the process gone and finalizes the deployment.
+
+> Your job's workload must end by issuing `reboot` (e.g. `reboot -f` once the work is done), **not** `poweroff`. A `poweroff` only halts the vCPU and leaves the Firecracker process running, so the job would never be observed as complete. Because the guest's exit code isn't surfaced, any clean reboot is treated as success.
+
+Completed jobs are sticky (never rebooted) and their per-instance artifacts (socket, rootfs copy, console log) are reaped; the deployment row stays for inspection.
+
 ## Known gaps (experimental)
 
 - **Volumes are not mounted yet.** Firecracker has no virtio-fs (the Cloud Hypervisor mechanism — its maintainers declined it on attack-surface grounds), so volumes would go through **virtio-block** (one ext4 image per volume, attached as an extra drive). Feasibility is proven; the runtime wiring is pending.
-- **`kind: job` runs as a worker** (no job-completion semantics yet).
 - `image:` must be a host rootfs file — no registry pull.
 
 ## See also

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -20,7 +20,7 @@ use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, ex
 use crate::hypervisor::port_forwarder::{self, PortForwarder};
 use crate::hypervisor::tap::TapDevice;
 use crate::hypervisor::vsock_client::{self, VsockError};
-use crate::models::deployments::{Deployment, DeploymentStatus};
+use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::health_check::{HealthCheck, HealthCheckStatus};
 use crate::models::volume::ResolvedMount;
 use crate::runtime::docker::tiny_id;
@@ -754,6 +754,135 @@ impl FirecrackerLifecycle {
         }
         deployment
     }
+
+    /// Whether an instance is genuinely alive: its API socket is on disk AND a
+    /// `firecracker` process is still bound to it. Firecracker removes the
+    /// socket on a clean exit (guest poweroff), but a crash can leave a stale
+    /// socket behind — so socket presence alone is not "running". Used by the
+    /// job path to tell "still running" from "guest powered off / crashed".
+    fn instance_alive(&self, instance_id: &str) -> bool {
+        let socket = self.socket_path(instance_id);
+        Path::new(&socket).exists() && find_pid_by_socket(&socket).is_some()
+    }
+
+    /// Run a `kind: job` deployment: boot a single VM and mark it `Completed`
+    /// once the guest powers off. Firecracker exposes no VM-state API like
+    /// Cloud Hypervisor's `info()`, but the guest powering off makes the
+    /// `firecracker` process exit, which is an equally clean signal — a job
+    /// that was `Running` and now has no live process has completed.
+    ///
+    /// `replicas` is ignored (a job is one VM). Because the guest's main-process
+    /// exit code isn't surfaced, any clean shutdown is treated as success —
+    /// same convention (“Approach A”) as the Cloud Hypervisor runtime.
+    async fn handle_job_deployment(&self, mut deployment: Deployment) -> Deployment {
+        // Terminal states are sticky: never reboot a finished job.
+        if matches!(
+            deployment.status,
+            DeploymentStatus::Completed
+                | DeploymentStatus::Failed
+                | DeploymentStatus::CrashLoopBackOff
+        ) {
+            return deployment;
+        }
+
+        // Re-adopt across a restart so an inherited job VM isn't double-booted.
+        self.readopt_networking(&deployment).await;
+
+        let instance = self.scan_instances(&deployment.id).into_iter().next();
+
+        if let Some(instance_id) = instance {
+            if self.instance_alive(&instance_id) {
+                // Still running.
+                deployment.instances = vec![instance_id];
+                if matches!(
+                    deployment.status,
+                    DeploymentStatus::Creating | DeploymentStatus::Pending
+                ) {
+                    deployment.status = DeploymentStatus::Running;
+                }
+            } else {
+                // Socket on disk but no live process: the guest powered off (or
+                // the VM crashed). Either way the job is done — finalize and
+                // sweep the leftover socket/rootfs/console artifacts.
+                info!(
+                    "Firecracker job VM {} has no live process, finalizing as Completed",
+                    instance_id
+                );
+                self.stop_vm(&instance_id).await;
+                deployment.instances.clear();
+                deployment.status = DeploymentStatus::Completed;
+                deployment.emit_event(
+                    "info",
+                    format!("Job VM {} completed", instance_id),
+                    "firecracker",
+                    Some("job_completed"),
+                );
+            }
+        } else if deployment.status == DeploymentStatus::Running {
+            // Was Running, now nothing on disk: firecracker exited cleanly on
+            // guest poweroff and took its socket with it. A clean exit is
+            // success.
+            info!(
+                "Firecracker job deployment {} has no live VM after Running; finalizing as Completed",
+                deployment.id
+            );
+            deployment.instances.clear();
+            deployment.status = DeploymentStatus::Completed;
+            deployment.emit_event(
+                "info",
+                "Job VM exited and firecracker terminated; finalized as completed".to_string(),
+                "firecracker",
+                Some("job_completed"),
+            );
+        } else if matches!(
+            deployment.status,
+            DeploymentStatus::Creating | DeploymentStatus::Pending
+        ) {
+            // No VM yet: boot exactly one.
+            match self.start_vm(&deployment).await {
+                Ok(instance_id) => {
+                    deployment.instances = vec![instance_id];
+                    deployment.status = DeploymentStatus::Running;
+                }
+                Err(e) => {
+                    error!(
+                        "Firecracker: failed to start job VM for deployment {}: {}",
+                        deployment.id, e
+                    );
+                    let (status, reason) = classify_vm_start_error(&e);
+                    deployment.emit_event("error", format!("{}", e), "firecracker", Some(reason));
+                    if let Some(terminal) = status {
+                        deployment.status = terminal;
+                    } else {
+                        deployment.restart_count += 1;
+                        if deployment.restart_count >= MAX_RESTART_COUNT {
+                            deployment.status = DeploymentStatus::Failed;
+                        }
+                    }
+                }
+            }
+        }
+
+        deployment
+    }
+}
+
+/// Classify a VM start failure into either a terminal deployment status
+/// (permanent: missing kernel/rootfs) or `None` for transient errors that
+/// should bump `restart_count` and let the scheduler retry. Mirrors the Cloud
+/// Hypervisor classifier so the two runtimes converge identically.
+fn classify_vm_start_error(e: &RuntimeError) -> (Option<DeploymentStatus>, &'static str) {
+    match e {
+        RuntimeError::ImageNotFound(_) => {
+            (Some(DeploymentStatus::ImagePullBackOff), "ImageNotFound")
+        }
+        RuntimeError::PortAlreadyInUse(_) => (None, "PortAllocationFailed"),
+        RuntimeError::InsufficientResources(_) => (
+            Some(DeploymentStatus::InsufficientResources),
+            "insufficient_resources",
+        ),
+        _ => (None, "VmStartFailed"),
+    }
 }
 
 /// Find the PID of the `firecracker` process bound to `socket_path`, by scanning
@@ -868,9 +997,10 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
         }
 
         if deployment.kind == "job" {
-            warn!("Firecracker: kind 'job' not yet supported, treating as worker");
+            self.handle_job_deployment(deployment).await
+        } else {
+            self.handle_worker_deployment(deployment).await
         }
-        self.handle_worker_deployment(deployment).await
     }
 
     async fn list_instances(&self, deployment_id: String, _status: &str) -> Vec<String> {
@@ -1287,5 +1417,97 @@ mod tests {
         let lc = FirecrackerLifecycle::new(cfg);
         assert_eq!(lc.socket_path("dep-1-abc"), "/tmp/fc/dep-1-abc.sock");
         assert_eq!(lc.rootfs_path("dep-1-abc"), "/tmp/fc/dep-1-abc.ext4");
+    }
+
+    fn lifecycle_with_scratch_dir(label: &str) -> (FirecrackerLifecycle, std::path::PathBuf) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ring-fc-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = FirecrackerRuntimeConfig {
+            socket_dir: dir.to_string_lossy().to_string(),
+            ..FirecrackerRuntimeConfig::default()
+        };
+        (FirecrackerLifecycle::new(cfg), dir)
+    }
+
+    fn job_deployment(status: DeploymentStatus) -> Deployment {
+        Deployment {
+            id: "job1234-5678".to_string(),
+            created_at: String::new(),
+            updated_at: None,
+            status,
+            restart_count: 0,
+            namespace: "default".to_string(),
+            name: "job".to_string(),
+            image: "/tmp/does-not-exist.ext4".to_string(),
+            config: None,
+            runtime: "firecracker".to_string(),
+            kind: "job".to_string(),
+            replicas: 1,
+            command: vec![],
+            instances: vec![],
+            labels: std::collections::HashMap::new(),
+            environment: std::collections::HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: vec![],
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: None,
+            network: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn job_terminal_status_is_sticky_completed() {
+        let (lc, dir) = lifecycle_with_scratch_dir("job-completed");
+        let dep = job_deployment(DeploymentStatus::Completed);
+        let out = lc.handle_job_deployment(dep).await;
+        assert_eq!(out.status, DeploymentStatus::Completed);
+        assert!(out.instances.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn job_terminal_status_is_sticky_failed() {
+        let (lc, dir) = lifecycle_with_scratch_dir("job-failed");
+        let dep = job_deployment(DeploymentStatus::Failed);
+        let out = lc.handle_job_deployment(dep).await;
+        assert_eq!(out.status, DeploymentStatus::Failed);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn job_running_with_no_live_vm_completes() {
+        // A job that was Running but has nothing on disk: the guest powered off
+        // and firecracker exited, taking its socket with it → Completed.
+        let (lc, dir) = lifecycle_with_scratch_dir("job-running-gone");
+        let dep = job_deployment(DeploymentStatus::Running);
+        let out = lc.handle_job_deployment(dep).await;
+        assert_eq!(out.status, DeploymentStatus::Completed);
+        assert!(out.instances.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn job_missing_kernel_does_not_complete_silently() {
+        // Creating with no kernel/rootfs on disk: start_vm fails. The default
+        // kernel path doesn't exist in the scratch dir, so this is a transient
+        // VmStartFailed → bumps restart_count, never silently Completed.
+        let (lc, dir) = lifecycle_with_scratch_dir("job-no-kernel");
+        let dep = job_deployment(DeploymentStatus::Creating);
+        let out = lc.handle_job_deployment(dep).await;
+        assert_ne!(out.status, DeploymentStatus::Completed);
+        assert_ne!(out.status, DeploymentStatus::Running);
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/tests/e2e/firecracker/ensure-job-image.sh
+++ b/tests/e2e/firecracker/ensure-job-image.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Build a "job" variant of the Firecracker e2e rootfs: the same Ubuntu 22.04
+# ext4 image the other FC tests boot, plus a one-shot systemd unit that powers
+# the VM off ~5s after multi-user.target. Used by t8_job_kind.sh to drive the
+# Running → Completed transition end-to-end.
+#
+# Unlike the Cloud Hypervisor equivalent, the Firecracker rootfs is already a
+# bare ext4 filesystem (no GPT partition to carve out), so debugfs edits it in
+# place. No sudo required.
+#
+# Idempotent: re-running with the artifact already built from the same base is
+# a no-op.
+
+set -euo pipefail
+
+# Derive paths from the base rootfs that setup_fc already resolved+exported, so
+# we land in the same cache dir (and don't double-append `/firecracker` when
+# this is sourced after setup.sh, which also sets RING_E2E_CACHE_DIR).
+RING_E2E_FC_ROOTFS="${RING_E2E_FC_ROOTFS:-${RING_E2E_CACHE_DIR:-$HOME/.cache/ring-e2e}/firecracker/ubuntu-22.04.ext4}"
+_RING_E2E_FC_DIR="$(dirname "$RING_E2E_FC_ROOTFS")"
+RING_E2E_FC_JOB_IMAGE="${RING_E2E_FC_JOB_IMAGE:-$_RING_E2E_FC_DIR/fc-job.ext4}"
+RING_E2E_FC_JOB_STAMP="${RING_E2E_FC_JOB_STAMP:-$_RING_E2E_FC_DIR/fc-job.ext4.built-from-ubuntu}"
+
+ensure_fc_job_image() {
+  if [ -f "$RING_E2E_FC_JOB_IMAGE" ] && [ -f "$RING_E2E_FC_JOB_STAMP" ]; then
+    local base_stat
+    base_stat=$(stat -c '%Y %s' "$RING_E2E_FC_ROOTFS" 2>/dev/null || echo "")
+    if [ "$(cat "$RING_E2E_FC_JOB_STAMP" 2>/dev/null)" = "$base_stat" ]; then
+      echo "[fc-job-image] reuse $RING_E2E_FC_JOB_IMAGE"
+      export RING_E2E_FC_JOB_IMAGE
+      return 0
+    fi
+  fi
+
+  if [ ! -f "$RING_E2E_FC_ROOTFS" ]; then
+    echo "[fc-job-image] FAIL: base rootfs $RING_E2E_FC_ROOTFS missing (run setup_fc first)" >&2
+    return 1
+  fi
+  if ! command -v debugfs > /dev/null 2>&1; then
+    echo "[fc-job-image] FAIL: 'debugfs' not found in PATH (install e2fsprogs)" >&2
+    return 1
+  fi
+
+  echo "[fc-job-image] building $RING_E2E_FC_JOB_IMAGE from $RING_E2E_FC_ROOTFS..."
+
+  local work_dir
+  work_dir=$(mktemp -d -t ring-e2e-fc-job-XXXXXX)
+  trap 'rm -rf "${work_dir:-}"' RETURN EXIT
+  local service_file="$work_dir/ring-job-poweroff.service"
+
+  # Start from a private copy so the shared base rootfs stays pristine.
+  cp "$RING_E2E_FC_ROOTFS" "$RING_E2E_FC_JOB_IMAGE"
+
+  # NOTE: the guest must `reboot`, not `poweroff`. With `reboot=k` in the
+  # kernel cmdline a guest reboot is a keyboard-controller reset that
+  # Firecracker traps and exits the VMM on (exit_code=0). A `poweroff` only
+  # halts the vCPU ("System halted") and leaves the firecracker process alive,
+  # so Ring would never see the VM go away. This mirrors how `kind: job`
+  # workloads are expected to signal completion on this runtime.
+  cat > "$service_file" <<'EOF'
+[Unit]
+Description=Ring kind:job E2E auto-reboot (signals job completion)
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'sleep 5; /sbin/reboot -f'
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  echo "[fc-job-image] injecting auto-reboot systemd unit..."
+  debugfs -w -R "write $service_file /etc/systemd/system/ring-job-poweroff.service" "$RING_E2E_FC_JOB_IMAGE" 2>&1 \
+    | grep -v "^debugfs " >&2 || true
+  # Enable via the standard *.wants symlink (idempotent: drop a stale one first).
+  debugfs -w -R "rm /etc/systemd/system/multi-user.target.wants/ring-job-poweroff.service" "$RING_E2E_FC_JOB_IMAGE" 2>&1 \
+    | grep -v "^debugfs " >&2 || true
+  debugfs -w -R "symlink /etc/systemd/system/multi-user.target.wants/ring-job-poweroff.service /etc/systemd/system/ring-job-poweroff.service" "$RING_E2E_FC_JOB_IMAGE" 2>&1 \
+    | grep -v "^debugfs " >&2 || true
+
+  stat -c '%Y %s' "$RING_E2E_FC_ROOTFS" > "$RING_E2E_FC_JOB_STAMP"
+  echo "[fc-job-image] built $RING_E2E_FC_JOB_IMAGE ($(du -h "$RING_E2E_FC_JOB_IMAGE" | cut -f1))"
+  export RING_E2E_FC_JOB_IMAGE
+}
+
+# Allow standalone invocation.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  ensure_fc_job_image
+fi

--- a/tests/e2e/firecracker/t8_job_kind.sh
+++ b/tests/e2e/firecracker/t8_job_kind.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# T8-FC: apply a `kind: job` deployment on firecracker, watch it boot,
+# auto-poweroff inside the guest, and assert that Ring observes the transition
+# Running → Completed end-to-end. Firecracker has no VM-state API like Cloud
+# Hypervisor's info(); instead the guest poweroff makes the firecracker process
+# exit, which Ring detects (socket gone / no live process) and finalizes as
+# Completed. Per-instance artifacts must be cleaned up afterwards.
+#
+# The job image is built on the fly by ensure-job-image.sh: the same Ubuntu
+# rootfs as the other FC tests plus a one-shot systemd unit that powers the VM
+# off ~5s after multi-user.target.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+# shellcheck source=./ensure-job-image.sh
+source "$SCRIPT_DIR/ensure-job-image.sh"
+
+log "== T8-FC: kind: job dispatch + Running → Completed =="
+
+setup_fc
+ensure_fc_job_image
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-job-vm.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-job-vm:
+    name: fc-job-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_JOB_IMAGE"
+    kind: job
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "1Gi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# First gate: dispatch worked, VM booted, Ring sees it as Running.
+wait_deployment_status "ring-e2e" "fc-job-vm" "running" 120
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-job-vm")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+kind=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json | jq -r '.kind')
+[ "$kind" = "job" ] || fail "expected kind=job, got '$kind'"
+log "deployment kind reported as job"
+
+socket_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+[ "$socket_count" -ge 1 ] || {
+  ls -la "$RING_E2E_FC_SOCKET_DIR" >&2 || true
+  fail "expected at least 1 firecracker socket while Running, got $socket_count"
+}
+log "firecracker socket exists while Running (count=$socket_count)"
+
+# Second gate: the in-guest unit fires `poweroff -f` ~5s after multi-user.target.
+# firecracker exits and Ring's next scheduler tick finalizes the job as Completed.
+wait_deployment_status "ring-e2e" "fc-job-vm" "completed" 180
+log "deployment transitioned to completed"
+
+# Artifacts must be cleaned just like a manual delete: no leftover socket, no
+# per-instance rootfs copy. The job row stays in the database for inspection.
+socket_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+[ "$socket_count" -eq 0 ] || {
+  ls -la "$RING_E2E_FC_SOCKET_DIR" >&2 || true
+  fail "firecracker socket still present after completion (count=$socket_count)"
+}
+log "firecracker socket cleaned up after completion"
+
+rootfs_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type f -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$rootfs_count" -eq 0 ] || fail "per-instance rootfs still present after completion (count=$rootfs_count)"
+log "per-instance rootfs cleaned up"
+
+# Terminal status is sticky: another scheduler tick must not reboot the VM.
+sleep 5
+status=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json | jq -r '.status')
+[ "$status" = "completed" ] || fail "expected completed to stay sticky, got '$status'"
+log "completed status is sticky across scheduler ticks"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-job-vm >/dev/null 2>&1 || true
+
+log "== T8-FC: PASS =="


### PR DESCRIPTION
## What

Firecracker `kind: job` deployments now run to completion and reach `completed`, instead of being silently treated as workers (which restarted them forever). Brings Firecracker to parity with the Cloud Hypervisor job behaviour.

## How completion is detected

Cloud Hypervisor reads VM state via its API (`info()` → `Shutdown`). Firecracker has no equivalent — but it doesn't need one: when the guest **reboots**, the default `reboot=k` kernel cmdline makes Firecracker trap the keyboard-controller reset and exit the VMM cleanly (`exit_code=0`). Ring's job handler detects the gone process (socket unlinked / no live PID) and finalizes the deployment as `completed`.

`handle_job_deployment`:
- terminal states (`completed`/`failed`/`crash_loop_back_off`) are sticky — never rebooted;
- `creating`/`pending` → boot exactly one VM (replicas ignored), classify start failures (terminal vs transient → `restart_count`) like CH;
- `running` + live process → stay running; `running` + no live process → `completed`, artifacts reaped;
- re-adopts an inherited job VM across a `ring-server` restart so it isn't double-booted.

## Important: jobs must `reboot`, not `poweroff`

A guest `poweroff` only halts the vCPU (`System halted`) and leaves the Firecracker process alive — the job would never be seen as complete. A guest `reboot` exits the VMM. This is documented for users, and the e2e image reflects it.

I verified both behaviours directly against the firecracker binary before settling on `reboot`:
- guest `poweroff -f` → `reboot: System halted`, firecracker **stays alive**;
- guest `reboot -f` → `reboot: Restarting system` → `Vmm is stopping` → `Firecracker exiting successfully. exit_code=0`.

## Tests

- 4 unit tests: sticky completed/failed, `running`-with-no-VM → completed, missing-kernel never silently completes.
- New e2e `tests/e2e/firecracker/t8_job_kind.sh` + `ensure-job-image.sh` (injects a one-shot systemd unit that `reboot`s ~5s after `multi-user.target`, via `debugfs`, no sudo). **Validated on real Firecracker**: `running` → guest reboots → firecracker exits → Ring finalizes `completed`, socket + rootfs reaped, status sticky across ticks.
- Also fixes a cache-path double-append (`firecracker/firecracker/`) in the job-image helper.

## Docs

- `documentation/runtimes/firecracker.md`: new Jobs section (with the reboot-not-poweroff note); `kind: job` removed from known gaps. CHANGELOG entry.

Fourth in the Firecracker-parity series (after console logs #167, stats #168, rotation #169). Last remaining: volumes.