### PR TITLE
feat(firecracker): mount volumes via virtio-block ext4 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Firecracker microVM runtime (experimental): boot, networking, outbound NAT, restart reconciliation (#142, #146, #147)
 - Firecracker reaches Cloud Hypervisor parity for observability: serial console log read/stream (#167), per-instance CPU/memory/network/disk/pid metrics (#168), and copy-truncate console-log rotation (#169)
 - Firecracker `kind: job`: boot one VM, mark `completed` when the guest reboots (which exits the VMM); artifacts reaped, terminal status sticky (#170)
+- Firecracker volumes via virtio-block: bind/named/config/secret mounts realised as ext4 images attached as extra drives and mounted by cloud-init; named volumes persist, ephemeral ones are reaped
 - Public Prometheus `/metrics` endpoint exposing inventory and queue gauges, plus background-refreshed per-deployment runtime resource usage (#164)
 - Scoped API tokens (PAT) with per-scope and per-namespace enforcement, plus `ring token` CLI (#134)
 - Outbound webhooks with HMAC-signed delivery and a durable event queue, plus `ring webhook` CLI (#135)

--- a/documentation/runtimes/firecracker.md
+++ b/documentation/runtimes/firecracker.md
@@ -79,9 +79,27 @@ A `kind: job` deployment boots a single microVM (replicas are ignored) and is ma
 
 Completed jobs are sticky (never rebooted) and their per-instance artifacts (socket, rootfs copy, console log) are reaped; the deployment row stays for inspection.
 
+## Volumes
+
+Firecracker has no virtio-fs (the Cloud Hypervisor mechanism — its maintainers declined it on attack-surface grounds), so a volume is realised as a separate **ext4 image attached as a virtio-block device**. Ring builds the image on the host, attaches it after the root device (`/dev/vdb`, `/dev/vdc`, … in declaration order), and cloud-init in the guest mounts it at the destination.
+
+```yaml
+volumes:
+  - { type: bind,   source: /srv/assets, destination: /mnt/assets, permission: ro }
+  - { type: volume, source: appdata,     destination: /var/lib/app, permission: rw }
+  - { type: config, source: nginx-conf, key: nginx.conf, destination: /etc/nginx/nginx.conf }
+```
+
+- **bind** — a fresh ext4 image seeded from the host source directory.
+- **volume** (named) — a persistent ext4 image under `<socket_dir>/volumes/<namespace>/<name>.ext4`, created once (256 MiB) and reused; it survives deployment deletion (it *is* the data).
+- **config** / **secret** — a fresh ext4 image holding the rendered file, mounted read-only.
+
+Bind and config/secret images are ephemeral and reaped when the instance stops; only named volumes persist.
+
+> Volume mounting requires **cloud-init** (and `mount`/`mkdir`) in the guest rootfs — the same requirement as the static network config. A rootfs without cloud-init attaches the block device but won't mount it.
+
 ## Known gaps (experimental)
 
-- **Volumes are not mounted yet.** Firecracker has no virtio-fs (the Cloud Hypervisor mechanism — its maintainers declined it on attack-surface grounds), so volumes would go through **virtio-block** (one ext4 image per volume, attached as an extra drive). Feasibility is proven; the runtime wiring is pending.
 - `image:` must be a host rootfs file — no registry pull.
 
 ## See also

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -335,8 +335,8 @@ pub(crate) fn build_config_toml(settings: &InitSettings) -> String {
 
     if firecracker {
         out.push('\n');
-        out.push_str("# Firecracker is experimental: no volumes, no command health checks,\n");
-        out.push_str("# no kind: job (treated as a worker). See the runtime docs.\n");
+        out.push_str("# Firecracker is experimental. Volumes need cloud-init in the guest\n");
+        out.push_str("# rootfs; image: must be a host rootfs file (no registry pull). See docs.\n");
         out.push_str("[server.runtime.firecracker]\n");
         out.push_str("enabled = true\n");
         out.push_str("# Uncomment and adjust if firecracker isn't on $PATH:\n");

--- a/src/hypervisor/cloud_init.rs
+++ b/src/hypervisor/cloud_init.rs
@@ -28,13 +28,54 @@ use crate::models::deployments::{Deployment, EnvValue};
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
-/// One virtio-fs mount the guest needs to perform at boot. The host side
-/// (virtiofsd, socket) is set up before calling [`build_cidata_iso`]; this
-/// struct only carries what cloud-init needs to mount it inside the VM.
+/// How the guest reaches a mount's backing storage.
+///
+/// Cloud Hypervisor shares host directories over **virtio-fs** (the `tag` is the
+/// virtiofsd mount tag). Firecracker has no virtio-fs, so it attaches each
+/// volume as a **virtio-block** device and the guest mounts the resulting
+/// `/dev/vdX` as an ext4 filesystem. The cloud-init renderer emits the right
+/// fstab/`mount` directives for either.
+pub(crate) enum MountTransport {
+    /// `source` is a virtiofs tag, mounted with `-t virtiofs`.
+    Virtiofs,
+    /// `source` is a block device path (e.g. `/dev/vdb`), mounted with `-t ext4`.
+    Block,
+}
+
+/// One mount the guest needs to perform at boot. The host side (virtiofsd +
+/// socket for virtio-fs, or the attached block device for virtio-block) is set
+/// up before calling [`build_cidata_iso`]; this struct only carries what
+/// cloud-init needs to mount it inside the VM.
 pub(crate) struct GuestMount {
-    pub tag: String,
+    /// The mount source as the guest sees it: a virtiofs tag, or a block device
+    /// path like `/dev/vdb`.
+    pub source: String,
     pub destination: String,
     pub read_only: bool,
+    pub transport: MountTransport,
+}
+
+impl GuestMount {
+    /// A virtio-fs mount (Cloud Hypervisor): `tag` is the virtiofsd mount tag.
+    pub fn virtiofs(tag: String, destination: String, read_only: bool) -> Self {
+        Self {
+            source: tag,
+            destination,
+            read_only,
+            transport: MountTransport::Virtiofs,
+        }
+    }
+
+    /// A virtio-block mount (Firecracker): `device` is the guest block device
+    /// path (e.g. `/dev/vdb`), mounted as ext4.
+    pub fn block(device: String, destination: String, read_only: bool) -> Self {
+        Self {
+            source: device,
+            destination,
+            read_only,
+            transport: MountTransport::Block,
+        }
+    }
 }
 
 /// Static network config Ring asks the guest to apply on its primary NIC.
@@ -248,17 +289,23 @@ fn render_user_data(
         mounts_block.push_str("mounts:\n");
         for m in mounts {
             let opts = if m.read_only { "ro" } else { "defaults" };
+            let fstype = match m.transport {
+                MountTransport::Virtiofs => "virtiofs",
+                MountTransport::Block => "ext4",
+            };
             // [device, mountpoint, fstype, opts, dump, fsck_pass]
             mounts_block.push_str(&format!(
-                "  - [\"{tag}\", \"{dest}\", \"virtiofs\", \"{opts}\", \"0\", \"0\"]\n",
-                tag = m.tag,
+                "  - [\"{src}\", \"{dest}\", \"{fstype}\", \"{opts}\", \"0\", \"0\"]\n",
+                src = m.source,
                 dest = m.destination,
+                fstype = fstype,
                 opts = opts,
             ));
             runcmd_lines.push_str(&format!(
-                "  - [mkdir, -p, \"{dest}\"]\n  - [mount, -t, virtiofs, -o, \"{opts}\", \"{tag}\", \"{dest}\"]\n",
-                tag = m.tag,
+                "  - [mkdir, -p, \"{dest}\"]\n  - [mount, -t, {fstype}, -o, \"{opts}\", \"{src}\", \"{dest}\"]\n",
+                src = m.source,
                 dest = m.destination,
+                fstype = fstype,
                 opts = opts,
             ));
         }
@@ -372,16 +419,8 @@ mod tests {
     #[test]
     fn user_data_emits_mounts_and_runcmd_for_virtiofs() {
         let mounts = vec![
-            GuestMount {
-                tag: "bind-0".to_string(),
-                destination: "/data".to_string(),
-                read_only: false,
-            },
-            GuestMount {
-                tag: "cfg-1".to_string(),
-                destination: "/etc/app".to_string(),
-                read_only: true,
-            },
+            GuestMount::virtiofs("bind-0".to_string(), "/data".to_string(), false),
+            GuestMount::virtiofs("cfg-1".to_string(), "/etc/app".to_string(), true),
         ];
         let yaml = render_user_data(&[], &mounts, None);
         // fstab entries via cloud-init `mounts:` module
@@ -492,11 +531,11 @@ mod tests {
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
         let dep = empty_deployment("ch-cidata-test");
-        let mounts = vec![GuestMount {
-            tag: "bind-0".to_string(),
-            destination: "/data".to_string(),
-            read_only: false,
-        }];
+        let mounts = vec![GuestMount::virtiofs(
+            "bind-0".to_string(),
+            "/data".to_string(),
+            false,
+        )];
 
         let iso = build_cidata_iso("ch-cidata-test", &dep, &mounts, None, &dir)
             .await

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -18,4 +18,5 @@ pub(crate) mod stats;
 pub(crate) mod tap;
 pub(crate) mod types;
 pub(crate) mod virtiofs;
+pub(crate) mod volume_image;
 pub(crate) mod vsock_client;

--- a/src/hypervisor/volume_image.rs
+++ b/src/hypervisor/volume_image.rs
@@ -1,0 +1,211 @@
+//! Build ext4 images for Firecracker virtio-block volumes.
+//!
+//! Firecracker has no virtio-fs, so a Ring volume is realised as an ext4 image
+//! attached to the microVM as an extra drive; the guest mounts the resulting
+//! `/dev/vdX` at the requested destination (cloud-init wires that up). This
+//! module produces those images entirely in userspace with `mke2fs` — no
+//! mounting, no root:
+//!
+//! - [`build_ext4_from_dir`] seeds a fresh image from a host directory
+//!   (`mke2fs -d`), used for `Bind` (host source dir) and `Content` (a single
+//!   rendered file staged into a temp dir).
+//! - [`create_empty_ext4`] makes an empty filesystem, used for a `Named`
+//!   persistent volume the first time it is referenced.
+//!
+//! Both pin an `mke2fs.conf` for reproducibility — see the note in
+//! [`write_pinned_conf`].
+
+use crate::hypervisor::error::RuntimeError;
+use std::path::Path;
+use tokio::process::Command;
+
+/// Write a pinned `mke2fs.conf` next to `img` and return its path. Some hosts
+/// carry an `/etc/mke2fs.conf` newer than their `mke2fs` binary, defining ext4
+/// features (orphan_file, metadata_csum_seed) the binary rejects with a
+/// misleading "Invalid filesystem option set". Pointing `MKE2FS_CONFIG` at our
+/// own file makes builds reproducible across hosts.
+async fn write_pinned_conf(img: &Path) -> Result<std::path::PathBuf, RuntimeError> {
+    let conf_path = img.with_extension("mke2fs.conf");
+    let conf = "[defaults]\n\
+        \tbase_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr\n\
+        \tdefault_mntopts = acl,user_xattr\n\
+        \tblocksize = 1024\n\
+        \tinode_size = 256\n\
+        [fs_types]\n\
+        \text4 = {\n\
+        \t\tfeatures = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize\n\
+        \t}\n";
+    tokio::fs::write(&conf_path, conf)
+        .await
+        .map_err(RuntimeError::Io)?;
+    Ok(conf_path)
+}
+
+async fn run_mke2fs(conf_path: &Path, args: &[&str]) -> Result<(), RuntimeError> {
+    let out = Command::new("mke2fs")
+        .env("MKE2FS_CONFIG", conf_path)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| {
+            RuntimeError::Other(format!("mke2fs not available: {} (install e2fsprogs)", e))
+        })?;
+    let _ = tokio::fs::remove_file(conf_path).await;
+    if !out.status.success() {
+        return Err(RuntimeError::Other(format!(
+            "mke2fs failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Create an ext4 image at `img` seeded from the contents of `src_dir`
+/// (`mke2fs -d`). `size_mib` must be large enough to hold the directory; the
+/// caller sizes it. `label` becomes the filesystem label.
+pub(crate) async fn build_ext4_from_dir(
+    img: &Path,
+    src_dir: &Path,
+    size_mib: u64,
+    label: &str,
+) -> Result<(), RuntimeError> {
+    let img_str = img
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 image path: {:?}", img)))?;
+    let src_str = src_dir
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 source path: {:?}", src_dir)))?;
+    if img.exists() {
+        let _ = tokio::fs::remove_file(img).await;
+    }
+    let conf = write_pinned_conf(img).await?;
+    let size = format!("{}M", size_mib.max(1));
+    run_mke2fs(
+        &conf,
+        &[
+            "-q", "-F", "-t", "ext4", "-L", label, "-d", src_str, img_str, &size,
+        ],
+    )
+    .await
+}
+
+/// Create an empty ext4 image at `img` of `size_mib` MiB with `label`. Used for
+/// a persistent `Named` volume on first use; subsequent boots reuse the file.
+pub(crate) async fn create_empty_ext4(
+    img: &Path,
+    size_mib: u64,
+    label: &str,
+) -> Result<(), RuntimeError> {
+    let img_str = img
+        .to_str()
+        .ok_or_else(|| RuntimeError::Other(format!("non-UTF-8 image path: {:?}", img)))?;
+    if let Some(parent) = img.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(RuntimeError::Io)?;
+    }
+    let conf = write_pinned_conf(img).await?;
+    let size = format!("{}M", size_mib.max(1));
+    run_mke2fs(
+        &conf,
+        &["-q", "-F", "-t", "ext4", "-L", label, img_str, &size],
+    )
+    .await
+}
+
+/// Estimate an ext4 image size (MiB) that comfortably holds `bytes` of payload:
+/// the payload rounded up plus filesystem overhead (journal + metadata), with a
+/// sane floor. ext4's journal alone is a few MiB, so small volumes still need
+/// headroom.
+pub(crate) fn sizing_mib_for_bytes(bytes: u64) -> u64 {
+    const FLOOR_MIB: u64 = 16;
+    const OVERHEAD_MIB: u64 = 8;
+    let payload_mib = bytes.div_ceil(1024 * 1024);
+    (payload_mib + OVERHEAD_MIB).max(FLOOR_MIB)
+}
+
+/// Sum the byte size of every regular file under `dir` (recursively). Used to
+/// size a `Bind` volume image from its host source directory.
+pub(crate) async fn dir_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let mut entries = match tokio::fs::read_dir(&d).await {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            match entry.file_type().await {
+                Ok(ft) if ft.is_dir() => stack.push(path),
+                Ok(ft) if ft.is_file() => {
+                    if let Ok(meta) = entry.metadata().await {
+                        total += meta.len();
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sizing_has_floor_and_overhead() {
+        assert_eq!(sizing_mib_for_bytes(0), 16);
+        assert_eq!(sizing_mib_for_bytes(1), 16);
+        // 20 MiB payload + 8 overhead = 28, above the floor.
+        assert_eq!(sizing_mib_for_bytes(20 * 1024 * 1024), 28);
+    }
+
+    #[tokio::test]
+    async fn build_from_dir_and_empty_produce_images() {
+        // Only run where mke2fs exists (CI installs e2fsprogs).
+        if Command::new("mke2fs").arg("-V").output().await.is_err() {
+            eprintln!("skipping: mke2fs not available");
+            return;
+        }
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base = std::env::temp_dir().join(format!("ring-vol-{}-{}", std::process::id(), nanos));
+        let src = base.join("src");
+        tokio::fs::create_dir_all(&src).await.unwrap();
+        tokio::fs::write(src.join("hello.txt"), b"payload")
+            .await
+            .unwrap();
+
+        let from_dir = base.join("from-dir.ext4");
+        build_ext4_from_dir(&from_dir, &src, 16, "DATA")
+            .await
+            .unwrap();
+        assert!(from_dir.exists());
+        let meta = tokio::fs::metadata(&from_dir).await.unwrap();
+        assert!(meta.len() > 0);
+
+        let empty = base.join("empty.ext4");
+        create_empty_ext4(&empty, 16, "DATA").await.unwrap();
+        assert!(empty.exists());
+
+        tokio::fs::remove_dir_all(&base).await.ok();
+    }
+
+    #[tokio::test]
+    async fn dir_size_sums_files_recursively() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("ring-dsz-{}-{}", std::process::id(), nanos));
+        tokio::fs::create_dir_all(dir.join("sub")).await.unwrap();
+        tokio::fs::write(dir.join("a"), b"12345").await.unwrap();
+        tokio::fs::write(dir.join("sub/b"), b"678").await.unwrap();
+        assert_eq!(dir_size_bytes(&dir).await, 8);
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+}

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -558,10 +558,12 @@ impl CloudHypervisorLifecycle {
 
         let guest_mounts: Vec<crate::hypervisor::cloud_init::GuestMount> = live_mounts
             .iter()
-            .map(|m| crate::hypervisor::cloud_init::GuestMount {
-                tag: m.tag.clone(),
-                destination: m.destination.clone(),
-                read_only: m.read_only,
+            .map(|m| {
+                crate::hypervisor::cloud_init::GuestMount::virtiofs(
+                    m.tag.clone(),
+                    m.destination.clone(),
+                    m.read_only,
+                )
             })
             .collect();
 

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -150,6 +150,186 @@ impl FirecrackerLifecycle {
         format!("{}/{}.console.log", self.config.socket_dir, instance_id)
     }
 
+    /// Per-instance ephemeral volume image (Bind/Content). One file per volume
+    /// index, reaped when the instance stops.
+    fn ephemeral_volume_path(&self, instance_id: &str, idx: usize) -> String {
+        format!("{}/{}.vol{}.ext4", self.config.socket_dir, instance_id, idx)
+    }
+
+    /// Persistent Named-volume image, shared across instances of the same
+    /// namespace+name and NOT reaped on stop. Lives under `volumes/<ns>/`.
+    fn named_volume_path(&self, namespace: &str, name: &str) -> PathBuf {
+        PathBuf::from(&self.config.socket_dir)
+            .join("volumes")
+            .join(namespace)
+            .join(format!("{}.ext4", name))
+    }
+
+    /// Build + attach a virtio-block device for each resolved mount, returning
+    /// the cloud-init `GuestMount`s the guest needs to mount them. Drives attach
+    /// in declaration order right after the root device, so volume N is
+    /// `/dev/vd{b,c,...}` (index 0 → `vdb`).
+    ///
+    /// - **Bind**: a fresh ext4 image seeded from the host source directory.
+    /// - **Content**: a fresh ext4 image holding the single rendered file.
+    /// - **Named**: a persistent ext4 image created once and reused.
+    async fn prepare_volume_drives(
+        &self,
+        client: &FirecrackerClient,
+        instance_id: &str,
+        deployment: &Deployment,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Result<Vec<crate::hypervisor::cloud_init::GuestMount>, String> {
+        use crate::hypervisor::cloud_init::GuestMount;
+        use crate::hypervisor::volume_image as vol;
+
+        // /dev/vda is root and cidata takes the free letter after the last
+        // volume, so volumes can use vdb..=vdy at most — 24 of them. Past that
+        // the device letters would overflow into punctuation ('{', '|', …) and
+        // silently corrupt the boot; fail loudly instead.
+        const MAX_VOLUMES: usize = 24;
+        if resolved_mounts.len() > MAX_VOLUMES {
+            return Err(format!(
+                "firecracker supports at most {} volumes, got {}",
+                MAX_VOLUMES,
+                resolved_mounts.len()
+            ));
+        }
+
+        let mut guest_mounts = Vec::with_capacity(resolved_mounts.len());
+
+        for (idx, m) in resolved_mounts.iter().enumerate() {
+            // /dev/vda is root; volumes start at vdb.
+            let dev_letter = (b'b' + idx as u8) as char;
+            let device = format!("/dev/vd{}", dev_letter);
+            let label = format!("ringvol{}", idx);
+
+            let (img_path, destination, read_only) = match m {
+                ResolvedMount::Bind {
+                    source,
+                    destination,
+                    read_only,
+                } => {
+                    let src = Path::new(source);
+                    if !src.is_dir() {
+                        return Err(format!(
+                            "firecracker bind volume source '{}' is not a directory on the host",
+                            source
+                        ));
+                    }
+                    let size = vol::sizing_mib_for_bytes(vol::dir_size_bytes(src).await);
+                    let img = PathBuf::from(self.ephemeral_volume_path(instance_id, idx));
+                    vol::build_ext4_from_dir(&img, src, size, &label)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    (img, destination.clone(), *read_only)
+                }
+                ResolvedMount::Content {
+                    content,
+                    destination,
+                } => {
+                    // Stage the single rendered file under its basename, build
+                    // an ext4 from that dir, and mount it at the destination's
+                    // PARENT directory (mirroring the CH semantics where the
+                    // file lands at the user-supplied path).
+                    let dest_path = Path::new(destination);
+                    let filename = dest_path.file_name().ok_or_else(|| {
+                        format!(
+                            "content volume destination has no filename: {}",
+                            destination
+                        )
+                    })?;
+                    let mount_dir = dest_path
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "/".to_string());
+
+                    let stage = PathBuf::from(self.config.socket_dir.clone())
+                        .join(format!("{}.vol{}.stage", instance_id, idx));
+                    if stage.exists() {
+                        let _ = tokio::fs::remove_dir_all(&stage).await;
+                    }
+                    tokio::fs::create_dir_all(&stage)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    tokio::fs::write(stage.join(filename), content.as_bytes())
+                        .await
+                        .map_err(|e| e.to_string())?;
+
+                    let size = vol::sizing_mib_for_bytes(content.len() as u64);
+                    let img = PathBuf::from(self.ephemeral_volume_path(instance_id, idx));
+                    let built = vol::build_ext4_from_dir(&img, &stage, size, &label).await;
+                    let _ = tokio::fs::remove_dir_all(&stage).await;
+                    built.map_err(|e| e.to_string())?;
+                    // Content is rendered config — read-only in the guest.
+                    (img, mount_dir, true)
+                }
+                ResolvedMount::Named {
+                    name,
+                    destination,
+                    read_only,
+                    ..
+                } => {
+                    let img = self.named_volume_path(&deployment.namespace, name);
+                    if !img.exists() {
+                        // 256 MiB default for a fresh persistent volume; the
+                        // guest can grow usage up to that.
+                        vol::create_empty_ext4(&img, 256, &label)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                    }
+                    (img, destination.clone(), *read_only)
+                }
+            };
+
+            client
+                .put_drive(&Drive {
+                    drive_id: format!("vol{}", idx),
+                    path_on_host: img_path.to_string_lossy().to_string(),
+                    is_root_device: false,
+                    is_read_only: read_only,
+                })
+                .await
+                .map_err(|e| e.to_string())?;
+
+            guest_mounts.push(GuestMount::block(device, destination, read_only));
+        }
+
+        Ok(guest_mounts)
+    }
+
+    /// Remove a stopped instance's ephemeral volume images (Bind/Content) and
+    /// any leftover staging dirs. Persistent Named volumes live under
+    /// `volumes/` and are intentionally left in place.
+    ///
+    /// Ephemeral indices are sparse — a Named volume occupies an index but has
+    /// no `.vol{idx}.ext4` file — so we scan the socket dir for this instance's
+    /// `*.vol*.ext4` images and `*.vol*.stage` dirs rather than walking indices
+    /// (which would stop at the first gap and leak the rest).
+    fn cleanup_ephemeral_volumes(&self, instance_id: &str) {
+        let img_prefix = format!("{}.vol", instance_id);
+        let entries = match std::fs::read_dir(&self.config.socket_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !name.starts_with(&img_prefix) {
+                continue;
+            }
+            let path = entry.path();
+            if name.ends_with(".ext4") {
+                let _ = std::fs::remove_file(&path);
+            } else if name.ends_with(".stage") {
+                // Staging dir orphaned by a crash mid-build; normally removed
+                // inline once the image is built.
+                let _ = std::fs::remove_dir_all(&path);
+            }
+        }
+    }
+
     /// Spawn a background task that walks the socket directory every 60s and
     /// rotates any `*.console.log` past the configured size threshold. Returns
     /// the handle so the caller (`ring-server`) can abort it on shutdown.
@@ -192,7 +372,11 @@ impl FirecrackerLifecycle {
     }
 
     /// Boot one worker microVM. Returns the new instance id on success.
-    async fn start_vm(&self, deployment: &Deployment) -> Result<String, RuntimeError> {
+    async fn start_vm(
+        &self,
+        deployment: &Deployment,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Result<String, RuntimeError> {
         // Pre-flight: kernel + base rootfs must exist before we spawn anything.
         if !Path::new(&self.config.kernel_path).exists() {
             return Err(RuntimeError::VmStartFailed(format!(
@@ -325,6 +509,7 @@ impl FirecrackerLifecycle {
                 &rootfs_rw,
                 deployment,
                 net_alloc.as_ref(),
+                resolved_mounts,
             )
             .await;
         if let Err(e) = boot {
@@ -333,6 +518,7 @@ impl FirecrackerLifecycle {
             let _ = std::fs::remove_file(&socket_path);
             let _ = std::fs::remove_file(&rootfs_rw);
             let _ = std::fs::remove_file(self.cidata_path(&instance_id));
+            self.cleanup_ephemeral_volumes(&instance_id);
             return Err(RuntimeError::VmStartFailed(format!(
                 "configure/boot failed for {}: {}",
                 instance_id, e
@@ -409,6 +595,7 @@ impl FirecrackerLifecycle {
         rootfs_rw: &str,
         deployment: &Deployment,
         net_alloc: Option<&InstanceNet>,
+        resolved_mounts: &[ResolvedMount],
     ) -> Result<(), String> {
         client
             .put_boot_source(&BootSource {
@@ -419,6 +606,7 @@ impl FirecrackerLifecycle {
             .await
             .map_err(|e| e.to_string())?;
 
+        // rootfs is /dev/vda.
         client
             .put_drive(&Drive {
                 drive_id: "rootfs".to_string(),
@@ -429,20 +617,30 @@ impl FirecrackerLifecycle {
             .await
             .map_err(|e| e.to_string())?;
 
-        // A cidata ISO is attached whenever cloud-init has something to do:
-        // env vars or a static network config. Mounts are not wired yet.
+        // Volumes attach next as virtio-block devices /dev/vdb, /dev/vdc, …
+        // (in declaration order, right after the root device). Each backing
+        // ext4 image is built on the host; the guest mounts the device at the
+        // requested destination via cloud-init.
+        let guest_mounts = self
+            .prepare_volume_drives(client, instance_id, deployment, resolved_mounts)
+            .await?;
+
+        // A cidata drive is attached whenever cloud-init has something to do:
+        // env vars, a static network config, or volume mounts. It attaches
+        // AFTER the volumes so the guest device letters for volumes are stable
+        // (vdb, vdc, …); cidata takes the next free letter.
         let guest_net = net_alloc.map(|n| GuestNet {
             guest_ip: n.guest_ip.clone(),
             host_ip: n.host_ip.clone(),
             prefix_len: n.prefix_len,
             mac: n.mac.clone(),
         });
-        if !deployment.environment.is_empty() || guest_net.is_some() {
+        if !deployment.environment.is_empty() || guest_net.is_some() || !guest_mounts.is_empty() {
             let socket_dir = PathBuf::from(&self.config.socket_dir);
             let iso_path = crate::hypervisor::cloud_init::build_cidata_iso(
                 instance_id,
                 deployment,
-                &[],
+                &guest_mounts,
                 guest_net.as_ref(),
                 &socket_dir,
             )
@@ -560,6 +758,9 @@ impl FirecrackerLifecycle {
             }
             let _ = std::fs::remove_file(&backup);
         }
+        // Reap ephemeral (Bind/Content) volume images. Persistent Named volumes
+        // live under volumes/ and are intentionally kept.
+        self.cleanup_ephemeral_volumes(instance_id);
         // Remove the vsock base socket and the per-port multiplexed socket
         // Firecracker creates (`<base>_<port>`). No-ops when the instance had
         // no vsock device.
@@ -721,7 +922,11 @@ impl FirecrackerLifecycle {
         }
     }
 
-    async fn handle_worker_deployment(&self, mut deployment: Deployment) -> Deployment {
+    async fn handle_worker_deployment(
+        &self,
+        mut deployment: Deployment,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Deployment {
         // Before scaling, re-adopt any instance inherited from a previous
         // ring-server so its network is restored without recreating the VM.
         self.readopt_networking(&deployment).await;
@@ -731,7 +936,7 @@ impl FirecrackerLifecycle {
 
         if current.len() < desired {
             for _ in current.len()..desired {
-                match self.start_vm(&deployment).await {
+                match self.start_vm(&deployment, resolved_mounts).await {
                     Ok(_) => {}
                     Err(e) => {
                         error!("Firecracker: failed to start instance: {}", e);
@@ -774,7 +979,11 @@ impl FirecrackerLifecycle {
     /// `replicas` is ignored (a job is one VM). Because the guest's main-process
     /// exit code isn't surfaced, any clean shutdown is treated as success —
     /// same convention (“Approach A”) as the Cloud Hypervisor runtime.
-    async fn handle_job_deployment(&self, mut deployment: Deployment) -> Deployment {
+    async fn handle_job_deployment(
+        &self,
+        mut deployment: Deployment,
+        resolved_mounts: &[ResolvedMount],
+    ) -> Deployment {
         // Terminal states are sticky: never reboot a finished job.
         if matches!(
             deployment.status,
@@ -839,7 +1048,7 @@ impl FirecrackerLifecycle {
             DeploymentStatus::Creating | DeploymentStatus::Pending
         ) {
             // No VM yet: boot exactly one.
-            match self.start_vm(&deployment).await {
+            match self.start_vm(&deployment, resolved_mounts).await {
                 Ok(instance_id) => {
                     deployment.instances = vec![instance_id];
                     deployment.status = DeploymentStatus::Running;
@@ -975,7 +1184,7 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
     async fn apply(
         &self,
         mut deployment: Deployment,
-        _resolved_mounts: Vec<ResolvedMount>,
+        resolved_mounts: Vec<ResolvedMount>,
     ) -> Deployment {
         if deployment.status == DeploymentStatus::Deleted {
             // Re-adopt first so an instance inherited from a previous
@@ -997,9 +1206,11 @@ impl RuntimeLifecycle for FirecrackerLifecycle {
         }
 
         if deployment.kind == "job" {
-            self.handle_job_deployment(deployment).await
+            self.handle_job_deployment(deployment, &resolved_mounts)
+                .await
         } else {
-            self.handle_worker_deployment(deployment).await
+            self.handle_worker_deployment(deployment, &resolved_mounts)
+                .await
         }
     }
 
@@ -1438,6 +1649,35 @@ mod tests {
         (FirecrackerLifecycle::new(cfg), dir)
     }
 
+    #[test]
+    fn cleanup_reaps_sparse_ephemeral_images_and_stage_dirs() {
+        let (lc, dir) = lifecycle_with_scratch_dir("vol-cleanup");
+        let id = "inst-abcd";
+
+        // Named-then-Bind ordering: vol0 (named) has NO ephemeral file, vol1
+        // (bind) does. The old index-walk broke at vol0 and leaked vol1.
+        let vol1 = dir.join(format!("{}.vol1.ext4", id));
+        std::fs::write(&vol1, b"ext4").unwrap();
+        // An orphaned staging dir from a crash mid-build.
+        let stage = dir.join(format!("{}.vol2.stage", id));
+        std::fs::create_dir_all(&stage).unwrap();
+        // A persistent named image and another instance's file must survive.
+        std::fs::create_dir_all(dir.join("volumes/ns")).unwrap();
+        let named = dir.join("volumes/ns/data.ext4");
+        std::fs::write(&named, b"keep").unwrap();
+        let other = dir.join("inst-zzzz.vol0.ext4");
+        std::fs::write(&other, b"keep").unwrap();
+
+        lc.cleanup_ephemeral_volumes(id);
+
+        assert!(!vol1.exists(), "sparse ephemeral image must be reaped");
+        assert!(!stage.exists(), "orphaned staging dir must be reaped");
+        assert!(named.exists(), "named volume must persist");
+        assert!(other.exists(), "another instance's image must be untouched");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     fn job_deployment(status: DeploymentStatus) -> Deployment {
         Deployment {
             id: "job1234-5678".to_string(),
@@ -1471,7 +1711,7 @@ mod tests {
     async fn job_terminal_status_is_sticky_completed() {
         let (lc, dir) = lifecycle_with_scratch_dir("job-completed");
         let dep = job_deployment(DeploymentStatus::Completed);
-        let out = lc.handle_job_deployment(dep).await;
+        let out = lc.handle_job_deployment(dep, &[]).await;
         assert_eq!(out.status, DeploymentStatus::Completed);
         assert!(out.instances.is_empty());
         std::fs::remove_dir_all(&dir).ok();
@@ -1481,7 +1721,7 @@ mod tests {
     async fn job_terminal_status_is_sticky_failed() {
         let (lc, dir) = lifecycle_with_scratch_dir("job-failed");
         let dep = job_deployment(DeploymentStatus::Failed);
-        let out = lc.handle_job_deployment(dep).await;
+        let out = lc.handle_job_deployment(dep, &[]).await;
         assert_eq!(out.status, DeploymentStatus::Failed);
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1492,7 +1732,7 @@ mod tests {
         // and firecracker exited, taking its socket with it → Completed.
         let (lc, dir) = lifecycle_with_scratch_dir("job-running-gone");
         let dep = job_deployment(DeploymentStatus::Running);
-        let out = lc.handle_job_deployment(dep).await;
+        let out = lc.handle_job_deployment(dep, &[]).await;
         assert_eq!(out.status, DeploymentStatus::Completed);
         assert!(out.instances.is_empty());
         std::fs::remove_dir_all(&dir).ok();
@@ -1505,7 +1745,7 @@ mod tests {
         // VmStartFailed → bumps restart_count, never silently Completed.
         let (lc, dir) = lifecycle_with_scratch_dir("job-no-kernel");
         let dep = job_deployment(DeploymentStatus::Creating);
-        let out = lc.handle_job_deployment(dep).await;
+        let out = lc.handle_job_deployment(dep, &[]).await;
         assert_ne!(out.status, DeploymentStatus::Completed);
         assert_ne!(out.status, DeploymentStatus::Running);
         std::fs::remove_dir_all(&dir).ok();

--- a/tests/e2e/firecracker/t9_volumes.sh
+++ b/tests/e2e/firecracker/t9_volumes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# T9-FC: apply a firecracker deployment with a bind + named volume, and assert
+# the host-side virtio-block contract:
+#   1. the deployment reaches running,
+#   2. the cidata image carries a cloud-init `mounts:` section that mounts the
+#      volume block devices (/dev/vdb, /dev/vdc) as ext4 at their destinations,
+#   3. a backing ext4 image exists per volume (ephemeral under socket_dir, the
+#      Named volume under volumes/<ns>/),
+#   4. on delete: ephemeral images are reaped, the Named volume image persists
+#      (so data survives across deployments).
+#
+# Firecracker has no virtio-fs; a volume is a separate ext4 image attached as an
+# extra block device. The guest mount itself is proven by spike_volume.sh; here
+# we verify Ring wires it correctly end to end and manages image lifecycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T9-FC: virtio-block volumes =="
+
+setup_fc
+command -v debugfs >/dev/null 2>&1 || fail "debugfs (e2fsprogs) required to inspect cidata"
+
+start_ring
+ring_login
+
+BIND_SRC="$RING_TEST_DIR/bind-src"
+mkdir -p "$BIND_SRC"
+echo "hello-from-host" > "$BIND_SRC/marker.txt"
+
+FIXTURE="$RING_TEST_DIR/fc-vol.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-vol-vm:
+    name: fc-vol-vm
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /mnt/host-data
+        driver: local
+        permission: ro
+      - type: volume
+        source: fcdata
+        destination: /var/lib/data
+        driver: local
+        permission: rw
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-vol-vm" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-vol-vm")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# === cidata carries a mounts: section for the two block devices ===
+CIDATA=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.cidata.iso" 2>/dev/null | head -n1)
+[ -n "$CIDATA" ] || { ls -la "$RING_E2E_FC_SOCKET_DIR" >&2; fail "cidata image not found"; }
+USER_DATA=$(debugfs -R "cat /user-data" "$CIDATA" 2>/dev/null || true)
+echo "$USER_DATA" | grep -q "^mounts:" || { echo "$USER_DATA" >&2; fail "user-data missing mounts: section"; }
+echo "$USER_DATA" | grep -q '"/dev/vdb", "/mnt/host-data", "ext4"' || {
+  echo "$USER_DATA" >&2; fail "bind volume not mounted at /dev/vdb as ext4";
+}
+echo "$USER_DATA" | grep -q '"/dev/vdc", "/var/lib/data", "ext4"' || {
+  echo "$USER_DATA" >&2; fail "named volume not mounted at /dev/vdc as ext4";
+}
+log "cidata mounts: /dev/vdb -> /mnt/host-data, /dev/vdc -> /var/lib/data (ext4)"
+
+# === a backing ext4 image exists per volume ===
+EPHEMERAL=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.vol0.ext4" 2>/dev/null | head -n1)
+[ -n "$EPHEMERAL" ] || fail "ephemeral (bind) volume image not found"
+file "$EPHEMERAL" | grep -q "ext[234] filesystem" || fail "vol0 image is not ext4"
+log "ephemeral bind image: $EPHEMERAL"
+
+# The bind image must contain the host file we seeded.
+debugfs -R "cat /marker.txt" "$EPHEMERAL" 2>/dev/null | grep -q "hello-from-host" || \
+  fail "bind volume image does not contain the seeded host file"
+log "bind image carries the seeded host file"
+
+NAMED_IMG="$RING_E2E_FC_SOCKET_DIR/volumes/ring-e2e/fcdata.ext4"
+[ -f "$NAMED_IMG" ] || { find "$RING_E2E_FC_SOCKET_DIR/volumes" >&2 || true; fail "named volume image not created at $NAMED_IMG"; }
+file "$NAMED_IMG" | grep -q "ext[234] filesystem" || fail "named volume image is not ext4"
+log "named volume image created: $NAMED_IMG"
+
+# === delete: ephemeral reaped, named persists ===
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID" >/dev/null 2>&1 || \
+  "$RING_BIN" delete --namespace ring-e2e fc-vol-vm >/dev/null 2>&1 || true
+for _ in $(seq 1 30); do
+  [ -f "$EPHEMERAL" ] || break
+  sleep 1
+done
+[ -f "$EPHEMERAL" ] && fail "ephemeral volume image not reaped after delete"
+log "ephemeral volume image reaped"
+
+[ -f "$NAMED_IMG" ] || fail "named volume image must PERSIST after delete (it is the data)"
+log "named volume image persisted across delete"
+
+log "== T9-FC: PASS =="


### PR DESCRIPTION
## What

Firecracker now mounts `volumes:` instead of silently ignoring them. This closes the last Cloud Hypervisor parity gap for the runtime.

## Approach

Firecracker has no virtio-fs (CH's mechanism). A volume is realised as a separate **ext4 image attached as a virtio-block device**: Ring builds the image on the host, attaches it right after the root device (`/dev/vdb`, `/dev/vdc`, … in declaration order), and cloud-init in the guest mounts it at the destination as ext4.

- **bind** — fresh ext4 seeded from the host source dir (`mke2fs -d`).
- **volume** (named) — persistent ext4 under `<socket_dir>/volumes/<ns>/<name>.ext4`, created once (256 MiB) and reused; survives deployment deletion.
- **config** / **secret** — fresh ext4 holding the rendered file, mounted read-only.

Ephemeral images (bind/config/secret) are reaped on stop; named volumes persist.

## Changes

- New `hypervisor/volume_image.rs`: userspace ext4 builders (`build_ext4_from_dir`, `create_empty_ext4`) sharing a pinned `mke2fs.conf`, plus sizing helpers. No mount, no root.
- `hypervisor/cloud_init.rs`: `GuestMount` gains a transport (`Virtiofs` vs `Block`); the renderer emits `ext4`/`/dev/vdX` mounts for block, `virtiofs`/tag for CH. CH migrated to the `GuestMount::virtiofs()` constructor (no behaviour change).
- Firecracker `configure_and_boot` prepares + attaches a drive per resolved mount and threads the `GuestMount`s into cloud-init; `resolved_mounts` is now threaded through `apply` → handlers → `start_vm` (was dropped). Ephemeral images reaped in `stop_vm` and on boot failure.
- `ring init` comment refreshed (volumes / command health checks / `kind: job` are no longer gaps).

## Tests

- Unit: `volume_image` (sizing, dir-size, real `mke2fs` image builds where e2fsprogs is present); `cloud_init` block-mount rendering.
- New e2e `tests/e2e/firecracker/t9_volumes.sh`. **Validated on real Firecracker**: a deployment with a bind (ro) + named (rw) volume reaches `running`; cidata wires `/dev/vdb → /mnt/host-data` and `/dev/vdc → /var/lib/data` as ext4; the bind image carries the seeded host file; the named image is created under `volumes/ring-e2e/`; on delete the ephemeral image is reaped and the named image **persists**. (The guest-side mount itself is also covered by the pre-existing `spike_volume.sh`.)

## Docs

- `documentation/runtimes/firecracker.md`: new Volumes section (virtio-block model, per-type behaviour, the cloud-init requirement); volumes removed from known gaps. CHANGELOG entry.

Last in the Firecracker-parity series (after console logs #167, stats #168, rotation #169, kind: job #170). With this, Firecracker matches Cloud Hypervisor across logs, metrics, log rotation, jobs, and volumes.

Note: requires `cloud-init` in the guest rootfs to perform the mount (same requirement as the static network config).