### PR TITLE
feat(apply): reference config payloads from external files via 'files:'

### DIFF
--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -51,8 +51,40 @@ configs:
 | --- | --- | --- | --- |
 | `namespace` | string | yes | Namespace the config lives in. Must match the namespace of any deployment mounting it. |
 | `name` | string | yes | Config name. This is what a `type: config` volume's `source` references. |
-| `data` | string | yes | JSON object mapping keys to payloads, e.g. `{"site.conf":"..."}`. A `type: config` volume's `key` selects which entry to mount. Subject to `$VAR` interpolation like deployment fields. |
+| `data` | string | conditional | JSON object mapping keys to payloads, e.g. `{"site.conf":"..."}`. A `type: config` volume's `key` selects which entry to mount. Subject to `$VAR` interpolation like deployment fields. Required unless `files` is set. |
+| `files` | map | conditional | Map of `key -> path`. Each referenced file is read at apply time and its raw contents become the value for `key` in the config's JSON payload. Paths are relative to the manifest. Required unless `data` is set. |
 | `labels` | string | no | Free-form labels. |
+
+At least one of `data` or `files` must be present; a config with neither is rejected.
+
+#### `files:` — keep large payloads in their own file
+
+Inlining a big config (an Nginx site, a full `config.yaml`, an HTML error page) into `data` means hand-escaping a string-of-JSON-inside-YAML — newlines become `\n`, quotes get doubled, and the manifest becomes unreadable. `files:` avoids that: keep the payload as a normal file next to the manifest and reference it.
+
+```yaml
+configs:
+  sozune-config:
+    namespace: proxy
+    name: "sozune-config"
+    files:
+      config.yaml: ./sozune/config.yaml   # relative to this manifest
+```
+
+At apply time Ring reads `./sozune/config.yaml` verbatim and builds `data = {"config.yaml": "<file contents>"}`. The file stays a real, editable YAML file — no escaping.
+
+`data` and `files` can be combined to merge an inline entry with file-backed ones:
+
+```yaml
+configs:
+  app-config:
+    namespace: production
+    name: "app-config"
+    data: '{"feature.flag":"on"}'   # small inline entry
+    files:
+      config.yaml: ./config.yaml     # large file-backed entry
+```
+
+The two are merged into a single JSON object. Defining the **same key** in both `data` and `files` is an error, and when `files` is used a non-object `data` (anything that isn't a `{...}` JSON object) is rejected.
 
 > A manifest carrying its own `configs:` is self-sufficient: `ring apply -f manifest.yaml` creates the configs and the deployments that reference them in one pass — no out-of-band `ring config create` needed.
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -51,8 +51,9 @@ configs:
 | --- | --- | --- | --- |
 | `namespace` | string | yes | Namespace the config lives in. Must match the namespace of any deployment mounting it. |
 | `name` | string | yes | Config name. This is what a `type: config` volume's `source` references. |
-| `data` | string | conditional | JSON object mapping keys to payloads, e.g. `{"site.conf":"..."}`. A `type: config` volume's `key` selects which entry to mount. Subject to `$VAR` interpolation like deployment fields. Required unless `files` is set. |
-| `files` | map | conditional | Map of `key -> path`. Each referenced file is read at apply time and its raw contents become the value for `key` in the config's JSON payload. Paths are relative to the manifest. Required unless `data` is set. |
+| `data` | string | conditional | JSON object mapping keys to payloads, e.g. `{"site.conf":"..."}`. A `type: config` volume's `key` selects which entry to mount. Subject to `$VAR` interpolation by default (see `interpolate`). Required unless `files` is set. |
+| `files` | map | conditional | Map of `key -> path`. Each referenced file is read at apply time and its raw contents become the value for `key` in the config's JSON payload. Paths are relative to the manifest. File contents are **verbatim** by default (not interpolated). Required unless `data` is set. |
+| `interpolate` | bool | no | Controls `$VAR` interpolation on this config's payload. Unset: inline `data` is interpolated, `files` contents stay verbatim. `true`: both are interpolated. `false`: the whole payload (inline + files) is verbatim. |
 | `labels` | string | no | Free-form labels. |
 
 At least one of `data` or `files` must be present; a config with neither is rejected.
@@ -85,6 +86,34 @@ configs:
 ```
 
 The two are merged into a single JSON object. Defining the **same key** in both `data` and `files` is an error, and when `files` is used a non-object `data` (anything that isn't a `{...}` JSON object) is rejected.
+
+#### `$VAR` interpolation and file contents
+
+By default, `$VAR` interpolation runs on inline `data` (it's a template you write by hand) but **not** on `files` contents. This matters: an Nginx site, a Prometheus rule, or a Grafana dashboard is full of literal `$host`, `$labels`, `$remote_addr` — interpolating them would silently mangle the file (or worse, splice a host env var's value into the payload). So a referenced file ships verbatim.
+
+The `interpolate` field overrides this per config:
+
+| `interpolate` | inline `data` | `files` contents |
+| --- | --- | --- |
+| unset (default) | interpolated | verbatim |
+| `true` | interpolated | interpolated |
+| `false` | verbatim | verbatim |
+
+```yaml
+configs:
+  nginx:
+    namespace: proxy
+    name: "nginx"
+    files:
+      site.conf: ./site.conf      # $host etc. kept verbatim
+
+  templated:
+    namespace: proxy
+    name: "templated"
+    interpolate: true             # opt in: $VAR substituted in the file too
+    files:
+      app.conf: ./app.conf
+```
 
 > A manifest carrying its own `configs:` is self-sufficient: `ring apply -f manifest.yaml` creates the configs and the deployments that reference them in one pass — no out-of-band `ring config create` needed.
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -266,6 +266,13 @@ struct ConfigDefinition {
     // read at load time and merged into `data`. Never sent to the server.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     files: HashMap<String, String>,
+    // Whether `$VAR` interpolation runs on this config's payload. When unset,
+    // inline `data` is interpolated (backwards compatible) but `files` contents
+    // stay verbatim — so an nginx/Prometheus file full of `$host`/`$labels`
+    // isn't mangled. `true` forces interpolation on files too; `false` keeps the
+    // whole payload (inline + files) verbatim. Never sent to the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    interpolate: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     labels: Option<String>,
 }
@@ -396,7 +403,10 @@ pub(crate) fn command_config() -> Command {
         )
 }
 
-fn load_config_file(file_path: &str) -> Result<ConfigFile, ApplyError> {
+fn load_config_file(
+    file_path: &str,
+    env_vars: &HashMap<String, String>,
+) -> Result<ConfigFile, ApplyError> {
     let contents = fs::read_to_string(file_path).map_err(ApplyError::FileRead)?;
 
     let mut config: ConfigFile = serde_yaml::from_str(&contents).map_err(ApplyError::YamlParse)?;
@@ -405,7 +415,7 @@ fn load_config_file(file_path: &str) -> Result<ConfigFile, ApplyError> {
     // them while we still know where the manifest lives.
     let manifest_dir = Path::new(file_path).parent().unwrap_or(Path::new("."));
     for (key, def) in config.configs.iter_mut() {
-        resolve_config_data(key, def, manifest_dir)?;
+        resolve_config_data(key, def, manifest_dir, env_vars)?;
     }
 
     Ok(config)
@@ -418,10 +428,17 @@ fn load_config_file(file_path: &str) -> Result<ConfigFile, ApplyError> {
 ///   - both: merged, but a filename present in *both* is a hard error, and a
 ///     non-object `data` cannot be merged into.
 ///   - neither: hard error — a config must carry some payload.
+///
+/// `$VAR` interpolation is applied here, per-value, according to `interpolate`:
+///   - unset: inline `data` values are interpolated, `files` contents stay
+///     verbatim (so an nginx/Prometheus file full of `$host`/`$labels` survives).
+///   - `true`: everything is interpolated, including `files` contents.
+///   - `false`: nothing is interpolated — the whole payload is verbatim.
 fn resolve_config_data(
     key: &str,
     def: &mut ConfigDefinition,
     manifest_dir: &Path,
+    env_vars: &HashMap<String, String>,
 ) -> Result<(), ApplyError> {
     if def.data.is_none() && def.files.is_empty() {
         return Err(ApplyError::Validation(format!(
@@ -430,20 +447,42 @@ fn resolve_config_data(
         )));
     }
 
-    // Fast path: inline data only, no files to merge — leave it untouched so
-    // arbitrary (even non-JSON-object) inline payloads keep working.
+    let interpolate = def.interpolate.unwrap_or(false);
+    let interpolate_inline = def.interpolate.unwrap_or(true);
+
+    // Fast path: inline data only, no files to merge — keep it untouched so
+    // arbitrary (even non-JSON-object) inline payloads keep working. Inline
+    // data is interpolated unless `interpolate: false` opts out.
     if def.files.is_empty() {
+        if let Some(raw) = &def.data
+            && interpolate_inline
+        {
+            def.data = Some(env_resolver(raw, env_vars));
+        }
         return Ok(());
     }
 
-    // Start from the inline `data` if present, else an empty object.
+    // Start from the inline `data` if present, else an empty object. Inline
+    // values follow `interpolate_inline`; file-backed values follow
+    // `interpolate` (verbatim by default).
     let mut merged: serde_json::Map<String, serde_json::Value> = match &def.data {
-        Some(raw) => serde_json::from_str(raw).map_err(|_| {
-            ApplyError::Validation(format!(
-                "config '{}': 'data' must be a JSON object to merge with 'files'",
-                key
-            ))
-        })?,
+        Some(raw) => {
+            let mut obj: serde_json::Map<String, serde_json::Value> = serde_json::from_str(raw)
+                .map_err(|_| {
+                    ApplyError::Validation(format!(
+                        "config '{}': 'data' must be a JSON object to merge with 'files'",
+                        key
+                    ))
+                })?;
+            if interpolate_inline {
+                for value in obj.values_mut() {
+                    if let serde_json::Value::String(s) = value {
+                        *value = serde_json::Value::String(env_resolver(s, env_vars));
+                    }
+                }
+            }
+            obj
+        }
         None => serde_json::Map::new(),
     };
 
@@ -455,7 +494,7 @@ fn resolve_config_data(
             )));
         }
         let full_path = manifest_dir.join(rel_path);
-        let contents = fs::read_to_string(&full_path).map_err(|e| {
+        let raw = fs::read_to_string(&full_path).map_err(|e| {
             ApplyError::Validation(format!(
                 "config '{}': failed to read file '{}' for key '{}': {}",
                 key,
@@ -464,6 +503,12 @@ fn resolve_config_data(
                 e
             ))
         })?;
+        // File contents are verbatim by default; `interpolate: true` opts in.
+        let contents = if interpolate {
+            env_resolver(&raw, env_vars)
+        } else {
+            raw
+        };
         merged.insert(name.clone(), serde_json::Value::String(contents));
     }
 
@@ -715,15 +760,18 @@ async fn apply_internal(
 ) -> Result<(), ApplyError> {
     debug!("Apply configuration");
 
+    // Env vars are resolved before loading the manifest: `load_config_file`
+    // needs them to interpolate `$VAR` per-value while it knows which values
+    // come from inline `data` versus file-backed `files`.
+    let env_binding = String::new();
+    let env_file = args.get_one::<String>("env-file").unwrap_or(&env_binding);
+    let env_vars = parse_env_file(env_file);
+
     let binding = "ring.yaml".to_string();
     let file = args.get_one::<String>("file").unwrap_or(&binding);
-    let config_file = load_config_file(file)?;
+    let config_file = load_config_file(file, &env_vars)?;
 
     check_auth(&get_config_dir())?;
-
-    let binding = String::new();
-    let env_file = args.get_one::<String>("env-file").unwrap_or(&binding);
-    let env_vars = parse_env_file(env_file);
 
     let api_url = configuration.get_api_url();
     let auth_config = load_auth_config(configuration.name);
@@ -755,11 +803,9 @@ async fn apply_internal(
     for (key, mut config) in config_file.configs {
         config.namespace = env_resolver(&config.namespace, &env_vars);
         config.name = env_resolver(&config.name, &env_vars);
-        // `data` is always `Some` here: `resolve_config_data` (run at load time)
-        // errors out when neither `data` nor `files` is set.
-        if let Some(data) = &config.data {
-            config.data = Some(env_resolver(data, &env_vars));
-        }
+        // `data` is already resolved and interpolated by `resolve_config_data`
+        // at load time (which is where the inline-vs-files interpolation policy
+        // lives), so the payload is sent as-is here.
 
         if is_dry_run {
             println!(
@@ -1240,6 +1286,14 @@ deployments:
     }
 
     fn config_def(data: Option<&str>, files: &[(&str, &str)]) -> ConfigDefinition {
+        config_def_interp(data, files, None)
+    }
+
+    fn config_def_interp(
+        data: Option<&str>,
+        files: &[(&str, &str)],
+        interpolate: Option<bool>,
+    ) -> ConfigDefinition {
         ConfigDefinition {
             namespace: "ns".to_string(),
             name: "n".to_string(),
@@ -1248,8 +1302,13 @@ deployments:
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
+            interpolate,
             labels: None,
         }
+    }
+
+    fn no_env() -> HashMap<String, String> {
+        HashMap::new()
     }
 
     #[test]
@@ -1259,7 +1318,7 @@ deployments:
         fs::write(dir.join("config.yaml"), "providers:\n  docker: true\n").unwrap();
 
         let mut def = config_def(None, &[("config.yaml", "config.yaml")]);
-        resolve_config_data("c", &mut def, &dir).unwrap();
+        resolve_config_data("c", &mut def, &dir, &no_env()).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["config.yaml"], "providers:\n  docker: true\n");
@@ -1273,7 +1332,7 @@ deployments:
         fs::write(dir.join("big.yaml"), "k: v\n").unwrap();
 
         let mut def = config_def(Some(r#"{"inline.txt":"hi"}"#), &[("big.yaml", "big.yaml")]);
-        resolve_config_data("c", &mut def, &dir).unwrap();
+        resolve_config_data("c", &mut def, &dir, &no_env()).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
         assert_eq!(parsed["inline.txt"], "hi");
@@ -1290,7 +1349,7 @@ deployments:
             Some(r#"{"dup.yaml":"already here"}"#),
             &[("dup.yaml", "dup.yaml")],
         );
-        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        let err = resolve_config_data("c", &mut def, &dir, &no_env()).unwrap_err();
         assert!(matches!(err, ApplyError::Validation(m) if m.contains("both 'data' and 'files'")));
     }
 
@@ -1301,7 +1360,7 @@ deployments:
         fs::write(dir.join("f.yaml"), "x: 1\n").unwrap();
 
         let mut def = config_def(Some("just plain text"), &[("f.yaml", "f.yaml")]);
-        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        let err = resolve_config_data("c", &mut def, &dir, &no_env()).unwrap_err();
         assert!(matches!(err, ApplyError::Validation(m) if m.contains("must be a JSON object")));
     }
 
@@ -1311,7 +1370,7 @@ deployments:
         let _ = fs::create_dir_all(&dir);
 
         let mut def = config_def(None, &[("config.yaml", "./does-not-exist.yaml")]);
-        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        let err = resolve_config_data("c", &mut def, &dir, &no_env()).unwrap_err();
         assert!(matches!(
             err,
             ApplyError::Validation(m)
@@ -1322,15 +1381,106 @@ deployments:
     #[test]
     fn test_resolve_config_data_neither_set() {
         let mut def = config_def(None, &[]);
-        let err = resolve_config_data("c", &mut def, Path::new(".")).unwrap_err();
+        let err = resolve_config_data("c", &mut def, Path::new("."), &no_env()).unwrap_err();
         assert!(matches!(err, ApplyError::Validation(m) if m.contains("either 'data' or 'files'")));
     }
 
     #[test]
     fn test_resolve_config_data_inline_only_untouched() {
         let mut def = config_def(Some("arbitrary non-json payload"), &[]);
-        resolve_config_data("c", &mut def, Path::new(".")).unwrap();
+        resolve_config_data("c", &mut def, Path::new("."), &no_env()).unwrap();
         assert_eq!(def.data.as_deref(), Some("arbitrary non-json payload"));
+    }
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_resolve_config_data_files_verbatim_by_default() {
+        // A file full of `$VAR` (nginx/Prometheus style) stays verbatim: file
+        // contents are not interpolated unless the config opts in.
+        let dir = std::env::temp_dir().join("ring_cfg_files_verbatim");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("site.conf"), "server_name $RING_TEST_HOST;\n").unwrap();
+
+        let mut def = config_def(None, &[("site.conf", "site.conf")]);
+        resolve_config_data(
+            "c",
+            &mut def,
+            &dir,
+            &env(&[("RING_TEST_HOST", "example.com")]),
+        )
+        .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["site.conf"], "server_name $RING_TEST_HOST;\n");
+    }
+
+    #[test]
+    fn test_resolve_config_data_files_interpolated_when_opted_in() {
+        // `interpolate: true` runs `$VAR` substitution on file contents too.
+        let dir = std::env::temp_dir().join("ring_cfg_files_interp");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("site.conf"), "server_name $RING_TEST_HOST2;\n").unwrap();
+
+        let mut def = config_def_interp(None, &[("site.conf", "site.conf")], Some(true));
+        resolve_config_data(
+            "c",
+            &mut def,
+            &dir,
+            &env(&[("RING_TEST_HOST2", "example.com")]),
+        )
+        .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["site.conf"], "server_name example.com;\n");
+    }
+
+    #[test]
+    fn test_resolve_config_data_inline_interpolated_by_default() {
+        // Inline `data` is interpolated even when files keep their contents
+        // verbatim — the frontier between manifest template and file payload.
+        let dir = std::env::temp_dir().join("ring_cfg_frontier");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("f.conf"), "raw $RING_TEST_KEEP\n").unwrap();
+
+        let mut def = config_def(
+            Some(r#"{"inline":"hi $RING_TEST_SUB"}"#),
+            &[("f.conf", "f.conf")],
+        );
+        resolve_config_data(
+            "c",
+            &mut def,
+            &dir,
+            &env(&[("RING_TEST_SUB", "there"), ("RING_TEST_KEEP", "NOPE")]),
+        )
+        .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["inline"], "hi there"); // inline interpolated
+        assert_eq!(parsed["f.conf"], "raw $RING_TEST_KEEP\n"); // file verbatim
+    }
+
+    #[test]
+    fn test_resolve_config_data_interpolate_false_keeps_inline_verbatim() {
+        // `interpolate: false` opts the whole payload out, inline included.
+        let mut def =
+            config_def_interp(Some(r#"{"inline":"hi $RING_TEST_OFF"}"#), &[], Some(false));
+        resolve_config_data(
+            "c",
+            &mut def,
+            Path::new("."),
+            &env(&[("RING_TEST_OFF", "x")]),
+        )
+        .unwrap();
+        assert_eq!(
+            def.data.as_deref(),
+            Some(r#"{"inline":"hi $RING_TEST_OFF"}"#)
+        );
     }
 
     // End-to-end through `load_config_file`: a real manifest on disk with a
@@ -1362,7 +1512,7 @@ deployments:
         )
         .unwrap();
 
-        let config = load_config_file(manifest.to_str().unwrap()).unwrap();
+        let config = load_config_file(manifest.to_str().unwrap(), &no_env()).unwrap();
         let entry = &config.configs["sozune-config"];
         let parsed: serde_json::Value =
             serde_json::from_str(entry.data.as_deref().unwrap()).unwrap();

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -257,7 +257,15 @@ struct NamespaceDefinition {
 struct ConfigDefinition {
     namespace: String,
     name: String,
-    data: String,
+    // The JSON payload sent to the server: a `{"<filename>": "<contents>"}`
+    // object. May be written inline, built from `files`, or both — see
+    // `resolve_config_data`. Always `Some` once resolution has run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    data: Option<String>,
+    // Map of `filename -> path` (relative to the manifest) whose contents are
+    // read at load time and merged into `data`. Never sent to the server.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    files: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     labels: Option<String>,
 }
@@ -391,9 +399,77 @@ pub(crate) fn command_config() -> Command {
 fn load_config_file(file_path: &str) -> Result<ConfigFile, ApplyError> {
     let contents = fs::read_to_string(file_path).map_err(ApplyError::FileRead)?;
 
-    let config: ConfigFile = serde_yaml::from_str(&contents).map_err(ApplyError::YamlParse)?;
+    let mut config: ConfigFile = serde_yaml::from_str(&contents).map_err(ApplyError::YamlParse)?;
+
+    // `files` references are relative to the manifest's directory, so resolve
+    // them while we still know where the manifest lives.
+    let manifest_dir = Path::new(file_path).parent().unwrap_or(Path::new("."));
+    for (key, def) in config.configs.iter_mut() {
+        resolve_config_data(key, def, manifest_dir)?;
+    }
 
     Ok(config)
+}
+
+/// Turn a config's `data` (inline JSON) and `files` (filename -> path) into a
+/// single JSON object string stored back into `data`. Rules:
+///   - `data` alone: kept as-is (backwards compatible).
+///   - `files` alone: builds `{"<name>": "<contents>", ...}`.
+///   - both: merged, but a filename present in *both* is a hard error, and a
+///     non-object `data` cannot be merged into.
+///   - neither: hard error — a config must carry some payload.
+fn resolve_config_data(
+    key: &str,
+    def: &mut ConfigDefinition,
+    manifest_dir: &Path,
+) -> Result<(), ApplyError> {
+    if def.data.is_none() && def.files.is_empty() {
+        return Err(ApplyError::Validation(format!(
+            "config '{}': either 'data' or 'files' must be set",
+            key
+        )));
+    }
+
+    // Fast path: inline data only, no files to merge — leave it untouched so
+    // arbitrary (even non-JSON-object) inline payloads keep working.
+    if def.files.is_empty() {
+        return Ok(());
+    }
+
+    // Start from the inline `data` if present, else an empty object.
+    let mut merged: serde_json::Map<String, serde_json::Value> = match &def.data {
+        Some(raw) => serde_json::from_str(raw).map_err(|_| {
+            ApplyError::Validation(format!(
+                "config '{}': 'data' must be a JSON object to merge with 'files'",
+                key
+            ))
+        })?,
+        None => serde_json::Map::new(),
+    };
+
+    for (name, rel_path) in &def.files {
+        if merged.contains_key(name) {
+            return Err(ApplyError::Validation(format!(
+                "config '{}': key '{}' is defined in both 'data' and 'files'",
+                key, name
+            )));
+        }
+        let full_path = manifest_dir.join(rel_path);
+        let contents = fs::read_to_string(&full_path).map_err(|e| {
+            ApplyError::Validation(format!(
+                "config '{}': failed to read file '{}' for key '{}': {}",
+                key,
+                full_path.display(),
+                name,
+                e
+            ))
+        })?;
+        merged.insert(name.clone(), serde_json::Value::String(contents));
+    }
+
+    def.data = Some(serde_json::Value::Object(merged).to_string());
+    def.files.clear();
+    Ok(())
 }
 
 fn check_auth(config_dir: &str) -> Result<(), ApplyError> {
@@ -679,7 +755,11 @@ async fn apply_internal(
     for (key, mut config) in config_file.configs {
         config.namespace = env_resolver(&config.namespace, &env_vars);
         config.name = env_resolver(&config.name, &env_vars);
-        config.data = env_resolver(&config.data, &env_vars);
+        // `data` is always `Some` here: `resolve_config_data` (run at load time)
+        // errors out when neither `data` nor `files` is set.
+        if let Some(data) = &config.data {
+            config.data = Some(env_resolver(data, &env_vars));
+        }
 
         if is_dry_run {
             println!(
@@ -1154,9 +1234,143 @@ deployments:
         let entry = &config.configs["entrypoints"];
         assert_eq!(entry.namespace, "ring");
         assert_eq!(entry.name, "test-config2");
-        assert_eq!(entry.data, r#"{"test.conf":"server {}"}"#);
+        assert_eq!(entry.data.as_deref(), Some(r#"{"test.conf":"server {}"}"#));
         assert_eq!(entry.labels, None);
         assert_eq!(config.deployments.len(), 1);
+    }
+
+    fn config_def(data: Option<&str>, files: &[(&str, &str)]) -> ConfigDefinition {
+        ConfigDefinition {
+            namespace: "ns".to_string(),
+            name: "n".to_string(),
+            data: data.map(|s| s.to_string()),
+            files: files
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            labels: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_config_data_files_only() {
+        let dir = std::env::temp_dir().join("ring_cfg_files_only");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("config.yaml"), "providers:\n  docker: true\n").unwrap();
+
+        let mut def = config_def(None, &[("config.yaml", "config.yaml")]);
+        resolve_config_data("c", &mut def, &dir).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["config.yaml"], "providers:\n  docker: true\n");
+        assert!(def.files.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_config_data_merge() {
+        let dir = std::env::temp_dir().join("ring_cfg_merge");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("big.yaml"), "k: v\n").unwrap();
+
+        let mut def = config_def(Some(r#"{"inline.txt":"hi"}"#), &[("big.yaml", "big.yaml")]);
+        resolve_config_data("c", &mut def, &dir).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(def.data.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["inline.txt"], "hi");
+        assert_eq!(parsed["big.yaml"], "k: v\n");
+    }
+
+    #[test]
+    fn test_resolve_config_data_key_collision() {
+        let dir = std::env::temp_dir().join("ring_cfg_collision");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("dup.yaml"), "x: 1\n").unwrap();
+
+        let mut def = config_def(
+            Some(r#"{"dup.yaml":"already here"}"#),
+            &[("dup.yaml", "dup.yaml")],
+        );
+        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(m) if m.contains("both 'data' and 'files'")));
+    }
+
+    #[test]
+    fn test_resolve_config_data_non_object_data_with_files() {
+        let dir = std::env::temp_dir().join("ring_cfg_nonobj");
+        let _ = fs::create_dir_all(&dir);
+        fs::write(dir.join("f.yaml"), "x: 1\n").unwrap();
+
+        let mut def = config_def(Some("just plain text"), &[("f.yaml", "f.yaml")]);
+        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(m) if m.contains("must be a JSON object")));
+    }
+
+    #[test]
+    fn test_resolve_config_data_missing_file() {
+        let dir = std::env::temp_dir().join("ring_cfg_missing");
+        let _ = fs::create_dir_all(&dir);
+
+        let mut def = config_def(None, &[("config.yaml", "./does-not-exist.yaml")]);
+        let err = resolve_config_data("c", &mut def, &dir).unwrap_err();
+        assert!(matches!(
+            err,
+            ApplyError::Validation(m)
+                if m.contains("failed to read file") && m.contains("does-not-exist.yaml")
+        ));
+    }
+
+    #[test]
+    fn test_resolve_config_data_neither_set() {
+        let mut def = config_def(None, &[]);
+        let err = resolve_config_data("c", &mut def, Path::new(".")).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(m) if m.contains("either 'data' or 'files'")));
+    }
+
+    #[test]
+    fn test_resolve_config_data_inline_only_untouched() {
+        let mut def = config_def(Some("arbitrary non-json payload"), &[]);
+        resolve_config_data("c", &mut def, Path::new(".")).unwrap();
+        assert_eq!(def.data.as_deref(), Some("arbitrary non-json payload"));
+    }
+
+    // End-to-end through `load_config_file`: a real manifest on disk with a
+    // `files:` reference resolved relative to the manifest's own directory.
+    #[test]
+    fn test_load_config_file_resolves_files_relative_to_manifest() {
+        let dir = std::env::temp_dir().join("ring_cfg_loadfile");
+        let _ = fs::create_dir_all(dir.join("sozune"));
+        fs::write(
+            dir.join("sozune/config.yaml"),
+            "providers:\n  docker:\n    enabled: true\n",
+        )
+        .unwrap();
+        let manifest = dir.join("manifest.yaml");
+        fs::write(
+            &manifest,
+            r#"
+configs:
+  sozune-config:
+    namespace: proxy
+    name: "sozune-config"
+    files:
+      config.yaml: ./sozune/config.yaml
+deployments:
+  app:
+    name: app
+    image: myapp:latest
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_file(manifest.to_str().unwrap()).unwrap();
+        let entry = &config.configs["sozune-config"];
+        let parsed: serde_json::Value =
+            serde_json::from_str(entry.data.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            parsed["config.yaml"],
+            "providers:\n  docker:\n    enabled: true\n"
+        );
+        assert!(entry.files.is_empty());
     }
 
     #[test]

--- a/tests/e2e/server/t14_apply_config_files_interpolation.sh
+++ b/tests/e2e/server/t14_apply_config_files_interpolation.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# T14-server: `ring apply` resolves config `files:` and honors `interpolate:`.
+#
+# The `files:` field reads a payload from a sibling file and merges it into the
+# config's JSON `data`. The interpolation policy is the subtle part this test
+# guards against regression:
+#
+#   - A referenced file is VERBATIM by default. Configs like nginx/Prometheus
+#     are full of literal `$host`, `$labels` — interpolating them would silently
+#     corrupt the payload (or splice a host env var's value into it). So an
+#     unannotated `files:` entry must reach the server byte-for-byte.
+#   - `interpolate: true` opts the file back into `$VAR` substitution.
+#   - inline `data` is interpolated regardless (it's a hand-written template).
+#
+# The Rust unit tests prove `resolve_config_data`'s per-value policy in
+# isolation. They CANNOT prove the resolved payload actually survives the
+# CLI→API→DB round-trip with interpolation applied at the right layer. This
+# drives the real compiled binary over a TCP socket and reads the stored config
+# back from the API to assert the bytes landed as intended.
+#
+# Docker is NOT required: this covers the CLI→API path (manifest files: →
+# resolve → POST /configs → readable back), not the deployment mount path.
+#
+# Invariants:
+#   1. A `files:` entry with `$VAR` is stored VERBATIM (no interpolation).
+#   2. The same file under `interpolate: true` has its `$VAR` substituted.
+#   3. Inline `data` with `$VAR` is interpolated even when a sibling file is
+#      kept verbatim (the inline-vs-file frontier).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RING_BIN="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+
+log() { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+[ -x "$RING_BIN" ] || fail "ring binary not found at $RING_BIN (run: cargo build)"
+command -v jq >/dev/null 2>&1 || fail "jq is required for this test"
+
+CFG=$(mktemp -d -t ring-e2e-srv-XXXXXX)
+PORT=$((20000 + RANDOM % 10000))
+URL="http://127.0.0.1:$PORT"
+KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+cat > "$CFG/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+api.scheme = "http"
+api.port = $PORT
+user.salt = "t14-server-salt"
+scheduler.interval = 1
+
+# Ring refuses to start with no runtime enabled.
+[server.runtime.docker]
+enabled = true
+EOF
+
+NS="t14cfg"
+
+# A file full of `$VAR` (nginx style) — must stay verbatim by default.
+cat > "$CFG/site.conf" <<'EOF'
+server {
+  server_name $host;
+  set $upstream $RING_T14_SUBST;
+}
+EOF
+
+cat > "$CFG/manifest.yaml" <<EOF
+namespaces:
+  ${NS}:
+    name: ${NS}
+
+configs:
+  # Invariant 1 + 3: file verbatim, inline interpolated.
+  verbatim-cfg:
+    namespace: ${NS}
+    name: "verbatim-cfg"
+    data: '{"inline.txt":"hello \$RING_T14_SUBST"}'
+    files:
+      site.conf: ./site.conf
+
+  # Invariant 2: same file, opted into interpolation.
+  interp-cfg:
+    namespace: ${NS}
+    name: "interp-cfg"
+    interpolate: true
+    files:
+      site.conf: ./site.conf
+
+deployments: {}
+EOF
+
+SRV_PID=""
+cleanup() {
+  local ec=$?
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  [ -n "$SRV_PID" ] && wait "$SRV_PID" 2>/dev/null || true
+  if [ "$ec" -ne 0 ] && [ -f "$CFG/out.log" ]; then
+    echo "[e2e] ring log (test failed):" >&2
+    tail -n 40 "$CFG/out.log" >&2 || true
+  fi
+  rm -rf "$CFG"
+  return $ec
+}
+trap cleanup EXIT
+
+export RING_CONFIG_DIR="$CFG"
+export RING_DATABASE_PATH="$CFG/ring.db"
+export RING_SECRET_KEY="$KEY"
+# The value `$RING_T14_SUBST` resolves to when interpolation runs.
+export RING_T14_SUBST="REPLACED"
+
+log "== T14-server: ring apply config files: + interpolate: =="
+
+"$RING_BIN" server start > "$CFG/out.log" 2>&1 &
+SRV_PID=$!
+
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "$URL/healthz" > /dev/null 2>&1; then ok=1; break; fi
+  kill -0 "$SRV_PID" 2>/dev/null || { tail -20 "$CFG/out.log" >&2; fail "server died before healthy"; }
+  sleep 0.5
+done
+[ "$ok" -eq 1 ] || { tail -20 "$CFG/out.log" >&2; fail "server did not become healthy"; }
+
+"$RING_BIN" login --username admin --password changeme > /dev/null \
+  || fail "ring login failed against the real server"
+
+# Grab the API token the CLI just stored so we can read configs back over HTTP.
+TOKEN=$(jq -r '.token // .access_token // empty' "$CFG/auth.json" 2>/dev/null || true)
+[ -n "$TOKEN" ] || TOKEN=$(jq -r '.. | .token? // empty' "$CFG/auth.json" 2>/dev/null | head -1)
+[ -n "$TOKEN" ] || fail "could not read auth token from $CFG/auth.json"
+
+if ! APPLY_OUT=$("$RING_BIN" apply -f "$CFG/manifest.yaml" 2>&1); then
+  echo "$APPLY_OUT" >&2
+  fail "apply exited non-zero"
+fi
+log "apply succeeded"
+
+# Read the stored configs back from the API as JSON.
+CONFIGS=$(curl -fsS -H "Authorization: Bearer $TOKEN" "$URL/configs?namespace[]=$NS") \
+  || fail "GET /configs failed"
+
+data_for() {
+  # $1 = config name -> prints the stored `data` JSON string (the payload)
+  echo "$CONFIGS" | jq -r --arg n "$1" '.[] | select(.name == $n) | .data'
+}
+
+# --- Invariant 1: verbatim file keeps `$host` and `$RING_T14_SUBST` literally ---
+VERBATIM_DATA=$(data_for "verbatim-cfg")
+[ -n "$VERBATIM_DATA" ] || fail "1: config 'verbatim-cfg' not found in API response"
+SITE=$(echo "$VERBATIM_DATA" | jq -r '.["site.conf"]')
+echo "$SITE" | grep -qF '$host' \
+  || { echo "$SITE" >&2; fail "1: file was interpolated — \$host should be verbatim"; }
+echo "$SITE" | grep -qF '$RING_T14_SUBST' \
+  || { echo "$SITE" >&2; fail "1: file was interpolated — \$RING_T14_SUBST should be verbatim"; }
+echo "$SITE" | grep -qF 'REPLACED' \
+  && { echo "$SITE" >&2; fail "1: env value REPLACED leaked into a verbatim file"; }
+log "1 (verbatim default): file contents stored byte-for-byte, no interpolation"
+
+# --- Invariant 3: inline data IS interpolated even alongside the verbatim file ---
+INLINE=$(echo "$VERBATIM_DATA" | jq -r '.["inline.txt"]')
+[ "$INLINE" = "hello REPLACED" ] \
+  || { echo "got: '$INLINE'" >&2; fail "3: inline data not interpolated (expected 'hello REPLACED')"; }
+log "3 (inline frontier): inline \$VAR interpolated while sibling file stayed verbatim"
+
+# --- Invariant 2: interpolate: true substitutes inside the file ---
+INTERP_DATA=$(data_for "interp-cfg")
+[ -n "$INTERP_DATA" ] || fail "2: config 'interp-cfg' not found in API response"
+ISITE=$(echo "$INTERP_DATA" | jq -r '.["site.conf"]')
+echo "$ISITE" | grep -qF 'REPLACED' \
+  || { echo "$ISITE" >&2; fail "2: interpolate:true did not substitute \$RING_T14_SUBST"; }
+echo "$ISITE" | grep -qF '$RING_T14_SUBST' \
+  && { echo "$ISITE" >&2; fail "2: \$RING_T14_SUBST left unsubstituted under interpolate:true"; }
+log "2 (interpolate:true): file \$VAR substituted to its env value"
+
+log "== T14-server: all invariants passed =="


### PR DESCRIPTION
## Problem

Inlining a large payload into a config's `data` field meant hand-escaping a string-of-JSON-inside-YAML: newlines became `\n`, quotes got doubled (`''`), and the manifest became unreadable and error-prone — especially for multi-line files like a full `config.yaml` or an HTML error page.

## Solution

Add a `files:` field to config definitions in the `apply` manifest. It maps `key -> path` (relative to the manifest); each referenced file is read at apply time and its raw contents become the value for `key` in the config's JSON payload.

```yaml
configs:
  sozune-config:
    namespace: proxy
    name: "sozune-config"
    files:
      config.yaml: ./sozune/config.yaml   # relative to the manifest
```

Ring reads `./sozune/config.yaml` verbatim and builds `data = {"config.yaml": "<file contents>"}`. The file stays a real, editable YAML file — no escaping.

## Rules

- `data` alone → unchanged (backwards compatible).
- `files` alone → builds the JSON object from the files.
- `data` + `files` → merged into one JSON object.
- Same key defined in both `data` and `files` → error.
- A non-object `data` combined with `files` → error.
- Neither `data` nor `files` set → error.
- A referenced file that doesn't exist (or can't be read) → validation error before any network call, naming the path and key.

`data` is now optional; `$VAR` interpolation still applies to the resolved payload.

## Tests

8 unit tests covering files-only, merge, key collision, non-object data, missing file, neither-set, inline-only untouched, plus an end-to-end `load_config_file` test resolving a `files:` path relative to the manifest. All error paths also verified live against `ring apply`.

## Docs

`documentation/reference/manifest.md` updated with the `files:` field, the merge rules, and the `sozune-config` example.
