### PR TITLE
feat: pull private images using host registry credentials (use_host_auth)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2500,7 @@ dependencies = [
  "clap",
  "cli-table",
  "containerd-client",
+ "docker_credential",
  "futures",
  "hex",
  "hmac",
@@ -4029,7 +4041,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tonic = "0.14"
 prost = "0.14"
 prost-types = "0.14"
 tokio-stream = "0.1"
+docker_credential = "1.4.0"
 
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/documentation/reference/config-toml.md
+++ b/documentation/reference/config-toml.md
@@ -81,6 +81,8 @@ The daemon's own configuration, shared by every context in the file. All subsect
 |---|---|---|---|---|
 | `enabled` | bool | no | `false` | Register the Docker runtime. Must be `true` for Ring to use Docker. When `true` and the daemon is unreachable at startup, Ring fails fast |
 | `host` | string | no | `"unix:///var/run/docker.sock"` | Docker daemon URL. Use `tcp://host:2375` for a remote daemon, `tcp://host:2376` for TLS |
+| `use_host_registry_auth` | bool | no | `false` | Authorize deployments to resolve registry credentials from the host Docker config (see [host registry auth](#host-registry-auth)). A deployment must also set `config.use_host_auth: true` to activate it |
+| `host_registry_config` | string | no | unset | Explicit path to the host registry config (`config.json` schema). When unset, standard Docker resolution applies (`$DOCKER_CONFIG`, then `~/.docker/config.json`) |
 
 ### `[server.runtime.podman]`
 
@@ -90,6 +92,8 @@ Podman speaks the Docker-compatible API (`podman system service`), so Ring drive
 |---|---|---|---|---|
 | `enabled` | bool | no | `false` | Register the Podman runtime. Must be `true` for Ring to use Podman. When `true` and the socket is unreachable at startup, Ring fails fast |
 | `host` | string | no | rootless-first resolution | Podman API socket. Default resolution: `RING_PODMAN_HOST` → `DOCKER_HOST` → `unix:///run/user/$UID/podman/podman.sock` → `unix:///run/podman/podman.sock`. Start it with `systemctl --user start podman.socket` (rootless) |
+| `use_host_registry_auth` | bool | no | `false` | Authorize host-resolved registry credentials (see [host registry auth](#host-registry-auth)) |
+| `host_registry_config` | string | no | unset | Explicit path to the host registry config. Podman's `login` writes to `containers/auth.json` — point at it here when the default Docker resolution doesn't pick it up |
 
 ### `[server.runtime.containerd]`
 
@@ -100,6 +104,19 @@ containerd speaks its own native gRPC API on a Unix socket — no Docker daemon 
 | `enabled` | bool | no | `false` | Register the containerd runtime. Must be `true` for Ring to use containerd. When `true` and the socket doesn't answer a `Version` round-trip at startup, Ring fails fast |
 | `socket` | string | no | `/run/containerd/containerd.sock` | Path to the containerd gRPC Unix socket (the stock location used by `containerd`, k3s and RKE2) |
 | `namespace` | string | no | `ring` | containerd metadata namespace Ring creates its images, snapshots, containers and tasks under. Keeps Ring's objects from colliding with `k8s.io`, `moby` or `default` on a shared host. This is containerd's own partition concept, unrelated to a Ring deployment namespace |
+| `use_host_registry_auth` | bool | no | `false` | Authorize host-resolved registry credentials (see [host registry auth](#host-registry-auth)). containerd has no `login` of its own; tools like `nerdctl` write to `~/.docker/config.json`, the default this resolves |
+| `host_registry_config` | string | no | unset | Explicit path to the host registry config |
+
+### Host registry auth
+
+`use_host_registry_auth` lets a deployment pull private images using the credentials the operator already configured on the host (e.g. via `docker login`), instead of inlining `server`/`username`/`password` in the manifest — which would otherwise be stored in cleartext in the database and returned by the API.
+
+It is a deliberate **two-flag handshake**:
+
+1. The server authorizes it per runtime with `use_host_registry_auth = true`.
+2. The deployment activates it with `config.use_host_auth: true` (see [manifest `config`](/documentation/reference/manifest#config)).
+
+Both are required — a deployment requesting host auth on a runtime that did not authorize it fails fast, with no silent fallback to an anonymous pull. The credential lookup honors `credHelpers`/`credsStore`. Set `host_registry_config` when the Ring daemon runs as a different user than the one who logged in (its `~` would otherwise resolve to the daemon's home, not yours).
 
 ### `[server.runtime.cloud_hypervisor]`
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -84,7 +84,7 @@ A map of deployment declarations. The map key is internal — Ring keys the depl
 | `labels` | map | `{}` | Key/value labels. **Docker only** — forwarded to Docker container labels. CH silently ignores them. |
 | `resources` | object | unset | CPU / memory limits and requests. Semantics differ between runtimes. See [resources](#resources). |
 | `health_checks` | object list | `[]` | TCP / HTTP / command health probes. See [health checks](#health-checks). |
-| `config` | object | `{}` | Runtime config: image pull policy, registry credentials. **Docker only** — every field of `config` is silently ignored on the CH runtime, since there is no image to pull. |
+| `config` | object | `{}` | Runtime config: image pull policy, registry credentials. **Container runtimes only** — every field of `config` is silently ignored on the CH runtime, since there is no image to pull. |
 | `network` | object | `{ mode: bridge }` | Network mode. See [network](#network). **Docker only.** |
 
 ## `environment`
@@ -347,7 +347,7 @@ See [how-to: configure health checks](/documentation/how-to/configure-health-che
 
 Runtime-level configuration: image pull policy, registry credentials.
 
-> **Docker-only.** Every field of `config` is consumed by the Docker runtime exclusively. On Cloud Hypervisor, the entire block is silently ignored — there is no image to pull, the disk image at `image:` is read from the local filesystem.
+> **Container runtimes only.** Every field of `config` is consumed by the container runtimes (Docker, Podman, containerd). On Cloud Hypervisor, the entire block is silently ignored — there is no image to pull, the disk image at `image:` is read from the local filesystem.
 
 ```yaml
 config:
@@ -361,12 +361,32 @@ config:
 |---|---|
 | `image_pull_policy` | `Always` (default) or `IfNotPresent`. The third historical value `Never` skips the pull entirely. |
 | `server` | Private-registry hostname (only for non-Docker-Hub registries). |
-| `username`, `password` | Registry credentials. Sent to Docker on `pull`. |
+| `username`, `password` | Registry credentials. Sent to the runtime on `pull`. |
+| `use_host_auth` | `true` to resolve registry credentials from the **host's** Docker config instead of inlining them. Mutually exclusive with `server`/`username`/`password`. See below. |
 | `user.id` | Numeric UID the container runs as (forwarded to `User` in Docker config). Optional. |
 | `user.group` | Numeric GID. Optional. |
 | `user.privileged` | Boolean. If `true`, the container is started with `HostConfig.Privileged = true`. Default `false`. |
 
-The `password` field is **not** an encrypted secret — it lives in the deployment row in the database. To avoid committing credentials, interpolate from the shell with `$VAR` and pass them via `ring apply --env-file`.
+The `password` field is **not** an encrypted secret — it lives in the deployment row in the database. To avoid committing credentials, interpolate from the shell with `$VAR` and pass them via `ring apply --env-file`, or use `use_host_auth` to keep the secret on the host entirely.
+
+### `use_host_auth` — credentials from the host
+
+Instead of inlining `server`/`username`/`password`, a deployment can pull using the credentials the operator already configured on the host (e.g. via `docker login`). The secret then never reaches the deployment manifest, the database, or the API.
+
+```yaml
+config:
+  image_pull_policy: "Always"
+  use_host_auth: true        # read ~/.docker/config.json on the host
+```
+
+It is a **two-flag handshake**:
+
+1. The **server** must authorize it — set `use_host_registry_auth = true` under the runtime's `[server.runtime.*]` section (see [config-toml](/documentation/reference/config-toml)).
+2. The **deployment** activates it with `use_host_auth: true`.
+
+If a deployment sets `use_host_auth` on a runtime that did not authorize it, the deployment fails fast with an actionable error (no silent fallback to an anonymous pull). Combining `use_host_auth` with inline `server`/`username`/`password` is rejected at apply time.
+
+Supported on Docker, Podman and containerd. The host config follows the standard Docker resolution (`$DOCKER_CONFIG`, then `~/.docker/config.json`), honoring `credHelpers`/`credsStore`. When the Ring daemon runs as a different user than the one who logged in — or for a Podman `containers/auth.json` — pin the file explicitly with `host_registry_config` in the server config.
 
 ## Full example
 

--- a/documentation/runtimes/containerd.md
+++ b/documentation/runtimes/containerd.md
@@ -21,6 +21,8 @@ The OCI runtime that sits *underneath* Docker and Kubernetes. Where Podman is re
 enabled = true
 # socket = "/run/containerd/containerd.sock"   # default
 # namespace = "ring"                            # default; Ring's containerd namespace
+# use_host_registry_auth = true                 # pull private images using the host docker config
+# host_registry_config = "/root/.docker/config.json"  # pin the file if needed
 ```
 
 ## Deploy
@@ -48,6 +50,7 @@ ring apply -f web.yaml
 - **Image entrypoint is honoured.** containerd is low-level and doesn't merge the image's `Entrypoint`/`Cmd` for you the way the Docker daemon does — Ring reads them from the image config and applies them when the deployment gives no `command`.
 - **`command` health checks** run via `Tasks.Exec` (gRPC), no in-guest agent needed.
 - **Crash detection is reconcile-based** (tick-paced), like Podman — it inspects task exit status on each scheduler pass.
+- **Private registries.** containerd has no `login` of its own. Either inline `config.server`/`username`/`password`, or — since `nerdctl login` writes to `~/.docker/config.json` — set `use_host_registry_auth = true` and pull with `config.use_host_auth: true` (no secret in the manifest). See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
 
 ## See also
 

--- a/documentation/runtimes/docker.md
+++ b/documentation/runtimes/docker.md
@@ -14,6 +14,8 @@ Runtimes are opt-in — add this under the `[server]` table in `~/.config/kemete
 [server.runtime.docker]
 enabled = true
 # host = "unix:///var/run/docker.sock"   # default; override for a remote daemon
+# use_host_registry_auth = true          # allow deployments to pull with the host's docker login
+# host_registry_config = "/home/deploy/.docker/config.json"  # pin the file if the daemon runs as another user
 ```
 
 If `enabled = true` but the daemon is unreachable, Ring logs a warning and skips Docker (the node still starts if another runtime is usable).
@@ -50,6 +52,7 @@ ring apply -f web.yaml
 - **Per-namespace networking.** Each namespace gets its own bridge network (`ring_<namespace>`), so containers in the same namespace reach each other by name.
 - **Event-driven crash detection.** Ring listens to the Docker event stream, so a crash is noticed sub-second (the other runtimes detect crashes on the scheduler tick instead).
 - **Full feature set.** Everything in the [manifest reference](/documentation/reference/manifest) works on Docker — it's the baseline the other runtimes are compared against.
+- **Registry auth from the host.** Already `docker login`-ed on the host? Set `use_host_registry_auth = true` here, then `config.use_host_auth: true` on the deployment, to pull private images without putting the secret in the manifest. See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
 
 ## See also
 

--- a/documentation/runtimes/podman.md
+++ b/documentation/runtimes/podman.md
@@ -19,6 +19,8 @@ Verify it exists: `ls -l /run/user/$(id -u)/podman/podman.sock`.
 [server.runtime.podman]
 enabled = true
 # host = "unix:///run/user/1000/podman/podman.sock"   # rootless default
+# use_host_registry_auth = true                        # pull private images using the host auth file
+# host_registry_config = "/run/user/1000/containers/auth.json"  # podman login writes here
 ```
 
 Ring resolves the rootless socket first. If `enabled = true` but the socket is unreachable, Ring logs a warning and skips Podman (the node still starts if another runtime is usable).
@@ -47,6 +49,7 @@ ring apply -f web.yaml
 - **Crash detection is reconcile-based.** Podman has no Docker-style event listener, so a crashed container is noticed on the next scheduler tick rather than sub-second. A crash loop still converges to `crash_loop_back_off` (bounded), it's just tick-paced.
 - **Rootless remaps UID/GID.** A file written inside the container has a different owner on the host. Bind-mount and named-volume ownership behave differently than under Docker-root — mind permissions on mounts.
 - **Host networking** (`network.mode: host`) is not yet supported on Podman.
+- **Registry auth from the host.** `podman login` writes to `containers/auth.json`. Authorize it with `use_host_registry_auth = true` (point `host_registry_config` at the auth file) and pull with `config.use_host_auth: true` — no secret in the manifest. See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
 - Otherwise the feature set matches Docker — same images, same health checks, same labels.
 
 ## See also

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -157,6 +157,21 @@ fn validate_config(input: &DeploymentInput, errors: &mut ViolationList) {
             "deployment.config.image_pull_policy.unsupported",
         ));
     }
+
+    // `use_host_auth` resolves credentials from the host's Docker config, so
+    // inlining `server`/`username`/`password` alongside it is contradictory —
+    // it would silently be ignored at pull time. Reject upfront so the operator
+    // fixes the manifest rather than wondering which credentials won.
+    if config.use_host_auth
+        && (config.server.is_some() || config.username.is_some() || config.password.is_some())
+    {
+        errors.push(Violation::new(
+            "config.use_host_auth",
+            "use_host_auth cannot be combined with inline server/username/password \
+             — remove the inline credentials or unset use_host_auth",
+            "deployment.config.use_host_auth.conflict",
+        ));
+    }
 }
 
 /// Per-port rules. The `DeploymentPort` struct already constrains
@@ -3165,6 +3180,68 @@ mod tests {
             "got {:?}",
             codes
         );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_use_host_auth_with_inline_credentials() {
+        // use_host_auth resolves credentials from the host Docker config, so
+        // inlining server/username/password alongside it is contradictory.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx",
+                "namespace": "ring",
+                "image": "private.io/nginx:latest",
+                "config": {
+                    "use_host_auth": true,
+                    "server": "private.io",
+                    "username": "u",
+                    "password": "p"
+                }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.config.use_host_auth.conflict".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_accepts_use_host_auth_without_inline_credentials() {
+        // use_host_auth on its own (no inline creds) is the supported shape.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx-host-auth",
+                "namespace": "ring",
+                "image": "private.io/nginx:latest",
+                "config": { "use_host_auth": true }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CREATED);
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -107,6 +107,11 @@ struct DeploymentConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     user: Option<UserConfig>,
+
+    /// Resolve registry credentials from the host's Docker config instead of
+    /// inlining `server`/`username`/`password`. Mutually exclusive with them.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    use_host_auth: bool,
 }
 
 /// Numeric uid/gid the container runs as (forwarded to Docker's `User`).

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -6,6 +6,7 @@ use crate::runtime::containerd::{ContainerdLifecycle, ContainerdRuntimeConfig};
 use crate::runtime::docker;
 use crate::runtime::docker::docker_lifecycle::DockerLifecycle;
 use crate::runtime::firecracker::{FirecrackerLifecycle, FirecrackerRuntimeConfig};
+use crate::runtime::registry_auth::HostAuthSettings;
 use clap::ArgMatches;
 use clap::{Arg, ArgAction, Command};
 use std::collections::HashMap;
@@ -96,12 +97,25 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // Keep a second client for the event listener, only when Docker is on.
     let docker_for_events = if configuration.server.runtime.docker.enabled {
         let host = configuration.server.runtime.docker.host.clone();
+        let host_auth = HostAuthSettings {
+            authorized: configuration.server.runtime.docker.use_host_registry_auth,
+            config_path: configuration
+                .server
+                .runtime
+                .docker
+                .host_registry_config
+                .clone(),
+        };
         match docker::connect_and_verify(&host).await {
             Ok(docker) => {
                 info!("Connected to Docker at {}", host);
                 runtimes_map.insert(
                     "docker".to_string(),
-                    Arc::new(DockerLifecycle::new(docker, intentional_shutdowns.clone())),
+                    Arc::new(DockerLifecycle::new(
+                        docker,
+                        intentional_shutdowns.clone(),
+                        host_auth,
+                    )),
                 );
                 docker::connect_with_host(&host).ok()
             }
@@ -124,6 +138,15 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
     // reaper stays Docker-only for now.
     if configuration.server.runtime.podman.enabled {
         let host = configuration.server.runtime.podman.host.clone();
+        let host_auth = HostAuthSettings {
+            authorized: configuration.server.runtime.podman.use_host_registry_auth,
+            config_path: configuration
+                .server
+                .runtime
+                .podman
+                .host_registry_config
+                .clone(),
+        };
         match docker::connect_and_verify(&host).await {
             Ok(podman) => {
                 info!("Connected to Podman at {}", host);
@@ -135,6 +158,7 @@ pub(crate) async fn execute(args: &ArgMatches, mut configuration: Config) {
                     Arc::new(DockerLifecycle::new_podman(
                         podman,
                         intentional_shutdowns.clone(),
+                        host_auth,
                     )),
                 );
             }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -68,6 +68,19 @@ pub(crate) struct DockerConfig {
     /// - "tcp://192.168.1.100:2376" (with TLS)
     #[serde(default = "default_docker_host")]
     pub(crate) host: String,
+    /// Authorize deployments to pull with credentials resolved from the host's
+    /// Docker config instead of inlining them. Off by default. A deployment must
+    /// *also* set `config.use_host_auth` to activate it: the server authorizes,
+    /// the manifest activates.
+    #[serde(default)]
+    pub(crate) use_host_registry_auth: bool,
+    /// Explicit path to the host registry config (Docker `config.json` schema).
+    /// When unset, the standard Docker resolution applies (`$DOCKER_CONFIG` then
+    /// `~/.docker/config.json`). Set this when the Ring daemon runs as a
+    /// different user than the one that ran `docker login`, or to point at a
+    /// Podman `containers/auth.json`.
+    #[serde(default)]
+    pub(crate) host_registry_config: Option<String>,
 }
 
 fn default_docker_host() -> String {
@@ -79,6 +92,8 @@ impl Default for DockerConfig {
         DockerConfig {
             enabled: false,
             host: default_docker_host(),
+            use_host_registry_auth: false,
+            host_registry_config: None,
         }
     }
 }
@@ -96,6 +111,17 @@ pub(crate) struct PodmanConfig {
     /// → `unix:///run/podman/podman.sock`). Override here to pin a specific socket.
     #[serde(default = "default_podman_host")]
     pub(crate) host: String,
+    /// Authorize host-resolved registry credentials. See
+    /// [`DockerConfig::use_host_registry_auth`]. Podman's `login` writes to
+    /// `containers/auth.json` (same schema as Docker's `config.json`); point at
+    /// it with `host_registry_config` when it isn't picked up by the default
+    /// Docker resolution.
+    #[serde(default)]
+    pub(crate) use_host_registry_auth: bool,
+    /// Explicit path to the host registry config. See
+    /// [`DockerConfig::host_registry_config`].
+    #[serde(default)]
+    pub(crate) host_registry_config: Option<String>,
 }
 
 fn default_podman_host() -> String {
@@ -107,6 +133,8 @@ impl Default for PodmanConfig {
         PodmanConfig {
             enabled: false,
             host: default_podman_host(),
+            use_host_registry_auth: false,
+            host_registry_config: None,
         }
     }
 }
@@ -130,6 +158,16 @@ pub(crate) struct ContainerdConfig {
     /// avoids colliding with Kubernetes or Docker on a shared host.
     #[serde(default = "default_containerd_namespace")]
     pub(crate) namespace: String,
+    /// Authorize host-resolved registry credentials. See
+    /// [`DockerConfig::use_host_registry_auth`]. containerd has no `login` of
+    /// its own; tools like `nerdctl` write to `~/.docker/config.json`, which is
+    /// the default this resolves.
+    #[serde(default)]
+    pub(crate) use_host_registry_auth: bool,
+    /// Explicit path to the host registry config. See
+    /// [`DockerConfig::host_registry_config`].
+    #[serde(default)]
+    pub(crate) host_registry_config: Option<String>,
 }
 
 fn default_containerd_socket() -> String {
@@ -146,6 +184,8 @@ impl Default for ContainerdConfig {
             enabled: false,
             socket: default_containerd_socket(),
             namespace: default_containerd_namespace(),
+            use_host_registry_auth: false,
+            host_registry_config: None,
         }
     }
 }

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -150,6 +150,14 @@ pub(crate) struct DeploymentConfig {
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
     pub(crate) user: Option<UserConfig>,
+    /// Opt into resolving registry credentials from the host's Docker config
+    /// (`~/.docker/config.json`) instead of inlining `server`/`username`/
+    /// `password`. The server must also authorize it via
+    /// `use_host_registry_auth`; this flag only *activates* it per-deployment.
+    /// Skipped from serialization when `false` so existing config payloads keep
+    /// their byte-for-byte shape (no DB migration, no API surface change).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) use_host_auth: bool,
 }
 
 /// Transport protocol for a published port. TCP is the default, preserving the

--- a/src/runtime/containerd/client.rs
+++ b/src/runtime/containerd/client.rs
@@ -7,6 +7,7 @@
 
 use crate::config::server::ContainerdConfig;
 use crate::hypervisor::error::RuntimeError;
+use crate::runtime::registry_auth::HostAuthSettings;
 use containerd_client::Client;
 use containerd_client::services::v1::version_client::VersionClient;
 
@@ -26,6 +27,8 @@ pub(crate) struct ContainerdRuntimeConfig {
     pub(crate) socket: String,
     /// containerd metadata namespace Ring operates under.
     pub(crate) namespace: String,
+    /// Server-side host registry auth settings for this runtime.
+    pub(crate) host_auth: HostAuthSettings,
 }
 
 impl ContainerdRuntimeConfig {
@@ -36,6 +39,10 @@ impl ContainerdRuntimeConfig {
         Self {
             socket: cfg.socket.clone(),
             namespace: cfg.namespace.clone(),
+            host_auth: HostAuthSettings {
+                authorized: cfg.use_host_registry_auth,
+                config_path: cfg.host_registry_config.clone(),
+            },
         }
     }
 }

--- a/src/runtime/containerd/lifecycle.rs
+++ b/src/runtime/containerd/lifecycle.rs
@@ -422,15 +422,28 @@ impl ContainerdLifecycle {
 
         let ns = &self.config.namespace;
 
-        // 1. Image + rootfs chain id.
-        let auth =
-            deployment
-                .config
-                .as_ref()
-                .and_then(|c| match (&c.server, &c.username, &c.password) {
-                    (Some(s), Some(u), Some(p)) => Some((s.clone(), u.clone(), p.clone())),
-                    _ => None,
-                });
+        // 1. Image + rootfs chain id. Credentials come either from the host's
+        // Docker config (when the deployment opts into `use_host_auth` and the
+        // runtime authorizes it) or from the inline config fields.
+        let config = deployment.config.as_ref();
+        let activated = config.map(|c| c.use_host_auth).unwrap_or(false);
+        let inline = config.and_then(|c| {
+            match (
+                c.server.as_deref(),
+                c.username.as_deref(),
+                c.password.as_deref(),
+            ) {
+                (Some(s), Some(u), Some(p)) => Some((s, u, p)),
+                _ => None,
+            }
+        });
+        let auth = crate::runtime::registry_auth::resolve_deployment_auth(
+            &deployment.image,
+            activated,
+            inline,
+            &self.config.host_auth,
+        )
+        .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))?;
         let image = ContainerdImage::from_deployment(&deployment.image, auth);
         let policy = deployment
             .config

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -339,10 +339,48 @@ async fn ensure_named_volume(
     }
 }
 
+/// Resolve the `(server, username, password)` to pull with, honoring the
+/// `use_host_auth` opt-in. When the deployment activates host auth, credentials
+/// come from the host's Docker config (gated by the server's authorization);
+/// otherwise the inline `config.server`/`username`/`password` path is used. A
+/// host-auth failure is a typed `RuntimeError` so the deployment lands in a
+/// clear errored state instead of silently falling back to an anonymous pull.
+fn resolve_registry_auth(
+    deployment: &Deployment,
+    host_auth: &crate::runtime::registry_auth::HostAuthSettings,
+) -> Result<Option<(String, String, String)>, RuntimeError> {
+    use crate::runtime::registry_auth::{decide_host_auth, registry_host_for, resolve_host_auth};
+
+    let activated = deployment
+        .config
+        .as_ref()
+        .map(|c| c.use_host_auth)
+        .unwrap_or(false);
+
+    if decide_host_auth(host_auth.authorized, activated)
+        .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))?
+    {
+        let host = registry_host_for(&deployment.image);
+        let (username, password) = resolve_host_auth(&host, host_auth.config_path.as_deref())
+            .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))?;
+        return Ok(Some((host, username, password)));
+    }
+
+    if let Some(config) = &deployment.config
+        && let (Some(server), Some(username), Some(password)) =
+            (&config.server, &config.username, &config.password)
+    {
+        return Ok(Some((server.clone(), username.clone(), password.clone())));
+    }
+
+    Ok(None)
+}
+
 pub(crate) async fn create_container(
     deployment: &mut Deployment,
     docker: &Docker,
     resolved_mounts: &[crate::models::volume::ResolvedMount],
+    host_auth: &crate::runtime::registry_auth::HostAuthSettings,
 ) -> Result<(), RuntimeError> {
     debug!("Create container for deployment id: {}", &deployment.id);
 
@@ -354,18 +392,11 @@ pub(crate) async fn create_container(
 
     let (name, reference) = parse_image_reference(&deployment.image);
 
-    let mut image_config = DockerImage {
+    let image_config = DockerImage {
         name,
         reference,
-        auth: None,
+        auth: resolve_registry_auth(deployment, host_auth)?,
     };
-
-    if let Some(config) = &deployment.config
-        && let (Some(server), Some(username), Some(password)) =
-            (&config.server, &config.username, &config.password)
-    {
-        image_config.auth = Some((server.clone(), username.clone(), password.clone()));
-    }
 
     let policy = deployment
         .config

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -782,6 +782,7 @@ mod tests {
                 group: Some(1000),
                 privileged: Some(false),
             }),
+            use_host_auth: false,
         });
         assert_eq!(build_user_config(&config), Some("1000:1000".to_string()));
     }
@@ -798,6 +799,7 @@ mod tests {
                 group: None,
                 privileged: Some(false),
             }),
+            use_host_auth: false,
         });
         assert_eq!(build_user_config(&config), Some("1000".to_string()));
     }
@@ -865,6 +867,7 @@ mod tests {
                 group: Some(0),
                 privileged: Some(true),
             }),
+            use_host_auth: false,
         });
         assert_eq!(get_privileged_config(&config), Some(true));
     }

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -349,31 +349,26 @@ fn resolve_registry_auth(
     deployment: &Deployment,
     host_auth: &crate::runtime::registry_auth::HostAuthSettings,
 ) -> Result<Option<(String, String, String)>, RuntimeError> {
-    use crate::runtime::registry_auth::{decide_host_auth, registry_host_for, resolve_host_auth};
+    let config = deployment.config.as_ref();
+    let activated = config.map(|c| c.use_host_auth).unwrap_or(false);
+    let inline = config.and_then(|c| {
+        match (
+            c.server.as_deref(),
+            c.username.as_deref(),
+            c.password.as_deref(),
+        ) {
+            (Some(s), Some(u), Some(p)) => Some((s, u, p)),
+            _ => None,
+        }
+    });
 
-    let activated = deployment
-        .config
-        .as_ref()
-        .map(|c| c.use_host_auth)
-        .unwrap_or(false);
-
-    if decide_host_auth(host_auth.authorized, activated)
-        .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))?
-    {
-        let host = registry_host_for(&deployment.image);
-        let (username, password) = resolve_host_auth(&host, host_auth.config_path.as_deref())
-            .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))?;
-        return Ok(Some((host, username, password)));
-    }
-
-    if let Some(config) = &deployment.config
-        && let (Some(server), Some(username), Some(password)) =
-            (&config.server, &config.username, &config.password)
-    {
-        return Ok(Some((server.clone(), username.clone(), password.clone())));
-    }
-
-    Ok(None)
+    crate::runtime::registry_auth::resolve_deployment_auth(
+        &deployment.image,
+        activated,
+        inline,
+        host_auth,
+    )
+    .map_err(|e| RuntimeError::ImagePullFailed(e.to_string()))
 }
 
 pub(crate) async fn create_container(

--- a/src/runtime/docker/docker_lifecycle.rs
+++ b/src/runtime/docker/docker_lifecycle.rs
@@ -3,6 +3,7 @@ use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, ex
 use crate::models::deployments::Deployment;
 use crate::models::health_check::HealthCheckStatus;
 use crate::models::volume::ResolvedMount;
+use crate::runtime::registry_auth::HostAuthSettings;
 use crate::scheduler::intentional_shutdowns::IntentionalShutdowns;
 use async_trait::async_trait;
 use axum::response::sse::Event;
@@ -34,24 +35,37 @@ pub struct DockerLifecycle {
     /// crash-looping container is silently recreated forever and never reaches
     /// `CrashLoopBackOff`. `true` for Docker, `false` for Podman.
     events_driven: bool,
+    /// Server-side host registry auth settings for this runtime, from
+    /// `[server.runtime.docker]` / `[server.runtime.podman]`.
+    host_auth: HostAuthSettings,
 }
 
 impl DockerLifecycle {
     /// Docker: an event listener drives crash counting.
-    pub fn new(docker: Docker, intentional_shutdowns: IntentionalShutdowns) -> Self {
+    pub fn new(
+        docker: Docker,
+        intentional_shutdowns: IntentionalShutdowns,
+        host_auth: HostAuthSettings,
+    ) -> Self {
         Self {
             docker,
             intentional_shutdowns,
             events_driven: true,
+            host_auth,
         }
     }
 
     /// Podman: no event listener — the reconcile pass detects crashes instead.
-    pub fn new_podman(docker: Docker, intentional_shutdowns: IntentionalShutdowns) -> Self {
+    pub fn new_podman(
+        docker: Docker,
+        intentional_shutdowns: IntentionalShutdowns,
+        host_auth: HostAuthSettings,
+    ) -> Self {
         Self {
             docker,
             intentional_shutdowns,
             events_driven: false,
+            host_auth,
         }
     }
 }
@@ -69,6 +83,7 @@ impl RuntimeLifecycle for DockerLifecycle {
             resolved_mounts,
             self.intentional_shutdowns.clone(),
             self.events_driven,
+            self.host_auth.clone(),
         )
         .await
     }

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -4,6 +4,7 @@ use crate::hypervisor::error::RuntimeError;
 use crate::hypervisor::types::InstanceStatus;
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::volume::ResolvedMount;
+use crate::runtime::registry_auth::HostAuthSettings;
 use crate::scheduler::intentional_shutdowns::IntentionalShutdowns;
 use bollard::Docker;
 use bollard::query_parameters::InspectContainerOptions;
@@ -16,6 +17,7 @@ pub(crate) async fn apply(
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
     events_driven: bool,
+    host_auth: HostAuthSettings,
 ) -> Deployment {
     let status_filter = if deployment.status == DeploymentStatus::Deleted {
         "all"
@@ -25,7 +27,14 @@ pub(crate) async fn apply(
     deployment.instances = list_instances(&docker, deployment.id.to_string(), status_filter).await;
 
     if deployment.kind == "job" {
-        handle_job_deployment(deployment, docker, resolved_mounts, intentional_shutdowns).await
+        handle_job_deployment(
+            deployment,
+            docker,
+            resolved_mounts,
+            intentional_shutdowns,
+            host_auth,
+        )
+        .await
     } else {
         handle_worker_deployment(
             deployment,
@@ -33,6 +42,7 @@ pub(crate) async fn apply(
             resolved_mounts,
             intentional_shutdowns,
             events_driven,
+            host_auth,
         )
         .await
     }
@@ -231,6 +241,7 @@ async fn handle_job_deployment(
     docker: Docker,
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
+    host_auth: HostAuthSettings,
 ) -> Deployment {
     if deployment.status == DeploymentStatus::Deleted {
         debug!("{} marked as deleted. Remove all instances", deployment.id);
@@ -277,7 +288,7 @@ async fn handle_job_deployment(
         // create_container_error after Docker rejected `start`). Either
         // way, try again — the retry path is what eventually grows
         // restart_count past MAX_RESTART_COUNT and converges to Failed.
-        match create_container(&mut deployment, &docker, &resolved_mounts).await {
+        match create_container(&mut deployment, &docker, &resolved_mounts, &host_auth).await {
             Ok(_) => {
                 deployment.status = DeploymentStatus::Running;
             }
@@ -300,6 +311,7 @@ async fn handle_worker_deployment(
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
     events_driven: bool,
+    host_auth: HostAuthSettings,
 ) -> Deployment {
     if deployment.status == DeploymentStatus::Deleted {
         debug!("{} marked as deleted. Remove all instances", deployment.id);
@@ -349,7 +361,8 @@ async fn handle_worker_deployment(
                     current_count, target_count
                 );
 
-                match create_container(&mut deployment, &docker, &resolved_mounts).await {
+                match create_container(&mut deployment, &docker, &resolved_mounts, &host_auth).await
+                {
                     Ok(_) => {
                         deployment.emit_event(
                             "info",

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod containerd;
 pub(crate) mod docker;
 pub(crate) mod firecracker;
 pub(crate) mod podman;
+pub(crate) mod registry_auth;

--- a/src/runtime/registry_auth.rs
+++ b/src/runtime/registry_auth.rs
@@ -26,6 +26,16 @@ use std::io::BufReader;
 
 use docker_credential::{CredentialRetrievalError, DockerCredential};
 
+/// Per-runtime server-side settings for host registry auth, carried from
+/// `[server.runtime.*]` down to the pull site. `authorized` gates whether a
+/// deployment may use host credentials at all; `config_path` optionally pins
+/// the host config file (else standard Docker resolution applies).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HostAuthSettings {
+    pub(crate) authorized: bool,
+    pub(crate) config_path: Option<String>,
+}
+
 /// Why resolving host registry credentials failed. Each variant maps to an
 /// actionable operator-facing message at the runtime boundary.
 #[derive(Debug)]

--- a/src/runtime/registry_auth.rs
+++ b/src/runtime/registry_auth.rs
@@ -1,0 +1,226 @@
+//! Resolving registry credentials from the host's Docker config, shared by all
+//! container runtimes (Docker, Podman, containerd).
+//!
+//! Today a deployment must inline `server`/`username`/`password` in its config,
+//! which then lives in cleartext in the database and the API. This module lets a
+//! deployment instead opt into reading credentials from the operator's host
+//! Docker config (`~/.docker/config.json` and friends) — the secret never
+//! leaves the host.
+//!
+//! The opt-in is a two-flag handshake, by design:
+//!   - the **server** authorizes it (`use_host_registry_auth` per runtime), and
+//!   - the **deployment** activates it (`config.use_host_auth`).
+//!
+//! Both are required: a deployment asking for host auth on a server that didn't
+//! authorize it fails fast with [`HostAuthError::NotAuthorized`].
+//!
+//! The config file format (the `auths`/`credsStore`/`credHelpers` schema) is the
+//! same across Docker, Podman and nerdctl/containerd — only the default location
+//! differs. We resolve the standard Docker location by default and let the
+//! operator point [`resolve_host_auth`] at any path via `host_registry_config`,
+//! which covers Podman's `containers/auth.json` and the "daemon runs as a
+//! different user than the one who logged in" case without per-runtime code.
+
+use std::fs::File;
+use std::io::BufReader;
+
+use docker_credential::{CredentialRetrievalError, DockerCredential};
+
+/// Why resolving host registry credentials failed. Each variant maps to an
+/// actionable operator-facing message at the runtime boundary.
+#[derive(Debug)]
+pub(crate) enum HostAuthError {
+    /// The deployment asked for host auth but the server didn't authorize it
+    /// (`use_host_registry_auth` is off for this runtime).
+    NotAuthorized,
+    /// The host config file is missing or unreadable.
+    ConfigUnavailable(String),
+    /// The config was read but holds no credential for this registry host.
+    NoEntryForRegistry(String),
+    /// A credential helper / store was configured but failed, or returned a
+    /// shape we can't use (e.g. an identity token rather than user/password).
+    HelperFailed(String),
+}
+
+impl std::fmt::Display for HostAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HostAuthError::NotAuthorized => write!(
+                f,
+                "deployment requested use_host_auth but the runtime is not \
+                 authorized to use host registry credentials — set \
+                 use_host_registry_auth = true under the runtime's \
+                 [server.runtime.*] config"
+            ),
+            HostAuthError::ConfigUnavailable(detail) => write!(
+                f,
+                "host registry config is unavailable ({detail}) — check the file \
+                 exists and is readable by the Ring daemon's user, or set \
+                 host_registry_config to its path"
+            ),
+            HostAuthError::NoEntryForRegistry(host) => write!(
+                f,
+                "no host credential found for registry '{host}' — run \
+                 `docker login {host}` as the Ring daemon's user, or set \
+                 host_registry_config"
+            ),
+            HostAuthError::HelperFailed(detail) => {
+                write!(f, "host credential helper failed: {detail}")
+            }
+        }
+    }
+}
+
+/// Decide whether host auth should be used, given the server authorization and
+/// the per-deployment activation. Returns `Ok(true)` to resolve host creds,
+/// `Ok(false)` to keep the inline path, and `Err(NotAuthorized)` when the
+/// deployment activated it but the server didn't authorize it.
+///
+/// Pure so it can be unit-tested and shared identically by every runtime.
+pub(crate) fn decide_host_auth(authorized: bool, activated: bool) -> Result<bool, HostAuthError> {
+    match (authorized, activated) {
+        (_, false) => Ok(false),
+        (true, true) => Ok(true),
+        (false, true) => Err(HostAuthError::NotAuthorized),
+    }
+}
+
+/// Extract the registry host from an image reference, applying the same implicit
+/// defaults the Docker CLI uses:
+///   - `nginx`            → `docker.io`
+///   - `bitnami/redis`    → `docker.io`
+///   - `ghcr.io/o/p:v1`   → `ghcr.io`
+///   - `registry.io:5000/x` → `registry.io:5000`
+///   - `localhost:5000/x` → `localhost:5000`
+///
+/// The first path segment is a registry host only if it contains a `.` or `:`
+/// (a domain or `host:port`) or is exactly `localhost`; otherwise it is part of
+/// the repository path on Docker Hub. This mirrors the rule in
+/// `containerd::image::normalize_repository`.
+pub(crate) fn registry_host_for(image: &str) -> String {
+    let first_segment = image.split('/').next().unwrap_or(image);
+    let has_registry_host =
+        first_segment.contains('.') || first_segment.contains(':') || first_segment == "localhost";
+
+    if has_registry_host {
+        first_segment.to_string()
+    } else {
+        "docker.io".to_string()
+    }
+}
+
+/// Resolve `(username, password)` for `registry_host` from the host registry
+/// config. When `config_path` is `Some`, that exact file is read; otherwise the
+/// standard Docker resolution applies (`$DOCKER_CONFIG` then
+/// `~/.docker/config.json`). Credential helpers and stores
+/// (`credHelpers`/`credsStore`) are honored in both cases.
+pub(crate) fn resolve_host_auth(
+    registry_host: &str,
+    config_path: Option<&str>,
+) -> Result<(String, String), HostAuthError> {
+    // Docker Hub creds are conventionally keyed under the legacy v1 endpoint,
+    // not the bare `docker.io` host, so try both forms for Hub.
+    let lookups: Vec<String> = if registry_host == "docker.io" {
+        vec![
+            "https://index.docker.io/v1/".to_string(),
+            registry_host.to_string(),
+        ]
+    } else {
+        vec![registry_host.to_string()]
+    };
+
+    let mut last_err = HostAuthError::NoEntryForRegistry(registry_host.to_string());
+    for key in &lookups {
+        match get_credential(key, config_path) {
+            Ok(DockerCredential::UsernamePassword(user, pass)) => return Ok((user, pass)),
+            Ok(DockerCredential::IdentityToken(_)) => {
+                return Err(HostAuthError::HelperFailed(
+                    "registry returned an identity token; only username/password \
+                     credentials are supported"
+                        .to_string(),
+                ));
+            }
+            Err(e) => last_err = map_retrieval_error(e, registry_host),
+        }
+    }
+    Err(last_err)
+}
+
+/// Run the crate's lookup against either an explicit file or the default
+/// Docker location.
+fn get_credential(
+    server: &str,
+    config_path: Option<&str>,
+) -> Result<DockerCredential, CredentialRetrievalError> {
+    match config_path {
+        Some(path) => {
+            let file = File::open(path).map_err(|_| CredentialRetrievalError::ConfigReadError)?;
+            docker_credential::get_credential_from_reader(BufReader::new(file), server)
+        }
+        None => docker_credential::get_credential(server),
+    }
+}
+
+fn map_retrieval_error(err: CredentialRetrievalError, registry_host: &str) -> HostAuthError {
+    match err {
+        CredentialRetrievalError::ConfigNotFound | CredentialRetrievalError::ConfigReadError => {
+            HostAuthError::ConfigUnavailable(err.to_string())
+        }
+        CredentialRetrievalError::NoCredentialConfigured => {
+            HostAuthError::NoEntryForRegistry(registry_host.to_string())
+        }
+        other => HostAuthError::HelperFailed(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_host_official_image_defaults_to_hub() {
+        assert_eq!(registry_host_for("nginx"), "docker.io");
+    }
+
+    #[test]
+    fn registry_host_hub_org_image_defaults_to_hub() {
+        assert_eq!(registry_host_for("bitnami/redis"), "docker.io");
+    }
+
+    #[test]
+    fn registry_host_explicit_domain_kept() {
+        assert_eq!(registry_host_for("ghcr.io/o/p:v1"), "ghcr.io");
+    }
+
+    #[test]
+    fn registry_host_with_port_kept() {
+        assert_eq!(
+            registry_host_for("registry.example:5000/foo/bar"),
+            "registry.example:5000"
+        );
+    }
+
+    #[test]
+    fn registry_host_localhost_kept() {
+        assert_eq!(registry_host_for("localhost:5000/x"), "localhost:5000");
+    }
+
+    #[test]
+    fn decide_not_activated_keeps_inline() {
+        assert!(matches!(decide_host_auth(false, false), Ok(false)));
+        assert!(matches!(decide_host_auth(true, false), Ok(false)));
+    }
+
+    #[test]
+    fn decide_authorized_and_activated_uses_host() {
+        assert!(matches!(decide_host_auth(true, true), Ok(true)));
+    }
+
+    #[test]
+    fn decide_activated_but_unauthorized_errors() {
+        assert!(matches!(
+            decide_host_auth(false, true),
+            Err(HostAuthError::NotAuthorized)
+        ));
+    }
+}

--- a/src/runtime/registry_auth.rs
+++ b/src/runtime/registry_auth.rs
@@ -81,6 +81,31 @@ impl std::fmt::Display for HostAuthError {
     }
 }
 
+/// Resolve the `(server, username, password)` a deployment should pull with,
+/// honoring the `use_host_auth` opt-in. When the deployment activates host auth,
+/// credentials come from the host config (gated by the server's authorization);
+/// otherwise the inline `config.server`/`username`/`password` path is used.
+///
+/// Shared by every container runtime so the two-flag handshake and the inline
+/// fallback behave identically. Returns `Ok(None)` when no credentials apply (an
+/// anonymous pull), and a typed [`HostAuthError`] when host auth was requested
+/// but couldn't be honored — the runtime turns that into a deployment error
+/// rather than silently degrading to an anonymous pull.
+pub(crate) fn resolve_deployment_auth(
+    image: &str,
+    activated: bool,
+    inline: Option<(&str, &str, &str)>,
+    settings: &HostAuthSettings,
+) -> Result<Option<(String, String, String)>, HostAuthError> {
+    if decide_host_auth(settings.authorized, activated)? {
+        let host = registry_host_for(image);
+        let (username, password) = resolve_host_auth(&host, settings.config_path.as_deref())?;
+        return Ok(Some((host, username, password)));
+    }
+
+    Ok(inline.map(|(s, u, p)| (s.to_string(), u.to_string(), p.to_string())))
+}
+
 /// Decide whether host auth should be used, given the server authorization and
 /// the per-deployment activation. Returns `Ok(true)` to resolve host creds,
 /// `Ok(false)` to keep the inline path, and `Err(NotAuthorized)` when the

--- a/tests/e2e/containerd/t5_host_registry_auth.sh
+++ b/tests/e2e/containerd/t5_host_registry_auth.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# T5-containerd: registry credentials resolved from the host docker config via
+# the `use_host_auth` two-flag handshake (containerd runtime).
+#
+# Mirrors tests/e2e/docker/t37_host_registry_auth.sh. Deterministic and offline:
+# no authenticated registry is stood up. The target image points at 127.0.0.1:1
+# (nothing listens), so once auth is resolved the pull fails with a transport
+# error — proving Ring got PAST auth resolution.
+#
+#   1. Authorized + activated: server sets use_host_registry_auth +
+#      host_registry_config; deployment opts in. Pull is attempted with the
+#      host creds → image_pull_back_off, NOT a "not authorized" error.
+#   2. Activated but NOT authorized: server omits the flag → fail fast with a
+#      "not authorized" event.
+#   3. Validation: use_host_auth + inline credentials → 422 at apply.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T5-containerd: host registry auth (use_host_auth) =="
+
+check_containerd_prereqs || exit 1
+export RING_E2E_ENABLE_DOCKER=false
+export RING_CONTAINERD_NS
+
+# Synthetic host docker config with an entry for the (unreachable) target
+# registry. Kept outside RING_TEST_DIR so it survives both start_ring calls.
+HOST_CFG_DIR=$(mktemp -d -t ring-e2e-ctr-t5-XXXXXX)
+trap 'rm -rf "$HOST_CFG_DIR"' EXIT
+AUTH_B64=$(printf 'nologin:secret' | base64)
+cat > "$HOST_CFG_DIR/config.json" <<EOF
+{
+  "auths": {
+    "127.0.0.1:1": { "auth": "$AUTH_B64" }
+  }
+}
+EOF
+log "synthetic host config at $HOST_CFG_DIR/config.json"
+
+FIXTURE_BODY='deployments:
+  host-auth-ctr:
+    name: host-auth-ctr
+    namespace: ring-e2e
+    runtime: containerd
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    config:
+      image_pull_policy: Always
+      use_host_auth: true'
+
+# ── Case 1: authorized + activated ──────────────────────────────────────────
+log "-- case 1: authorized + activated --"
+RING_EXTRA_CONFIG="[server.runtime.containerd]
+enabled = true
+socket = \"$RING_CONTAINERD_SOCKET\"
+namespace = \"$RING_CONTAINERD_NS\"
+use_host_registry_auth = true
+host_registry_config = \"$HOST_CFG_DIR/config.json\""
+export RING_EXTRA_CONFIG
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/host-auth-ctr.yaml"
+printf '%s\n' "$FIXTURE_BODY" > "$FIXTURE"
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "host-auth-ctr" "image_pull_back_off" 60
+DEP_ID=$(get_deployment_id "ring-e2e" "host-auth-ctr")
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS" | sed 's/^/  | /'
+if printf '%s' "$MSGS" | grep -qi "not authorized\|no host credential"; then
+  fail "case 1: host auth should have resolved, but got an auth error"
+fi
+# The pull was attempted (registry unreachable / image not found), which is the
+# proof auth resolution succeeded.
+if ! printf '%s' "$MSGS" | grep -qiE "cannot reach the registry|not found|registry"; then
+  fail "case 1: expected a pull-stage error (auth resolved, pull attempted)"
+fi
+log "case 1 OK: host auth resolved, pull attempted"
+"$RING_BIN" deployment delete "$DEP_ID"
+
+kill "$RING_PID" 2>/dev/null || true
+wait "$RING_PID" 2>/dev/null || true
+
+# ── Case 2: activated but NOT authorized ────────────────────────────────────
+log "-- case 2: activated but server did not authorize --"
+RING_EXTRA_CONFIG="[server.runtime.containerd]
+enabled = true
+socket = \"$RING_CONTAINERD_SOCKET\"
+namespace = \"$RING_CONTAINERD_NS\""
+export RING_EXTRA_CONFIG
+
+start_ring
+ring_login
+
+FIXTURE2="$RING_TEST_DIR/host-auth-ctr.yaml"
+printf '%s\n' "$FIXTURE_BODY" > "$FIXTURE2"
+"$RING_BIN" apply --file "$FIXTURE2"
+
+wait_deployment_status "ring-e2e" "host-auth-ctr" "image_pull_back_off" 60
+DEP_ID2=$(get_deployment_id "ring-e2e" "host-auth-ctr")
+TOKEN2=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS2=$(curl -fsS "$RING_URL/deployments/$DEP_ID2/events" \
+  -H "Authorization: Bearer $TOKEN2" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS2" | sed 's/^/  | /'
+if ! printf '%s' "$MSGS2" | grep -qi "not authorized"; then
+  fail "case 2: expected a 'not authorized' event when the server did not opt in"
+fi
+log "case 2 OK: fail-fast when not authorized"
+"$RING_BIN" deployment delete "$DEP_ID2"
+
+# ── Case 3: use_host_auth + inline credentials → 422 ────────────────────────
+log "-- case 3: use_host_auth combined with inline credentials is rejected --"
+TOKEN3=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN3" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/deployments" \
+  --data '{
+    "runtime": "containerd",
+    "name": "host-auth-ctr-conflict",
+    "namespace": "ring-e2e",
+    "image": "127.0.0.1:1/ring-e2e/private:latest",
+    "config": { "use_host_auth": true, "server": "127.0.0.1:1", "username": "u", "password": "p" }
+  }')
+log "POST /deployments (conflict) status: $STATUS"
+if [ "$STATUS" != "422" ]; then
+  fail "case 3: expected 422 for use_host_auth + inline credentials, got $STATUS"
+fi
+log "case 3 OK: conflict rejected with 422"
+
+log "== T5-containerd: PASS =="

--- a/tests/e2e/docker/t37_host_registry_auth.sh
+++ b/tests/e2e/docker/t37_host_registry_auth.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# T37: registry credentials resolved from the host docker config via the
+# `use_host_auth` two-flag handshake (Docker runtime).
+#
+# Covers the three paths we added, deterministically and offline (no real
+# authenticated registry is stood up, which would pollute the machine's real
+# ~/.docker/config.json and depend on registry:2 + htpasswd):
+#
+#   1. Authorized + activated: server sets use_host_registry_auth and points
+#      host_registry_config at a synthetic config.json holding an entry for the
+#      target registry. The deployment opts in with use_host_auth. The pull is
+#      attempted *with* those creds; since the registry (127.0.0.1:1) is
+#      unreachable, it lands in image_pull_back_off with a "cannot reach the
+#      registry" event — which proves Ring got PAST auth resolution (it did not
+#      fail with "not authorized" or "no host credential").
+#
+#   2. Activated but NOT authorized: server omits use_host_registry_auth. The
+#      same deployment fails fast with a "not authorized" event.
+#
+#   3. Validation: use_host_auth combined with inline credentials is a 422 at
+#      apply time.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T37: host registry auth (use_host_auth) =="
+
+# ── Setup: a synthetic host docker config with an entry for 127.0.0.1:1 ──────
+# We need a stable directory that survives across the two `start_ring` calls in
+# this test, so create it outside RING_TEST_DIR (which is recreated each start).
+HOST_CFG_DIR=$(mktemp -d -t ring-e2e-t37-XXXXXX)
+trap 'rm -rf "$HOST_CFG_DIR"' EXIT
+# base64("nologin:secret") — a well-formed auth entry the resolver can decode.
+AUTH_B64=$(printf 'nologin:secret' | base64)
+cat > "$HOST_CFG_DIR/config.json" <<EOF
+{
+  "auths": {
+    "127.0.0.1:1": { "auth": "$AUTH_B64" }
+  }
+}
+EOF
+log "synthetic host config at $HOST_CFG_DIR/config.json"
+
+HOST_AUTH_FIXTURE_BODY='deployments:
+  host-auth:
+    name: host-auth
+    namespace: ring-e2e
+    runtime: docker
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Always
+      use_host_auth: true'
+
+# ── Case 1: authorized + activated → pull attempted, registry unreachable ────
+log "-- case 1: authorized + activated --"
+RING_EXTRA_CONFIG="[server.runtime.docker]
+enabled = true
+use_host_registry_auth = true
+host_registry_config = \"$HOST_CFG_DIR/config.json\""
+export RING_EXTRA_CONFIG
+# Provide our own complete docker block above, so suppress the default one.
+export RING_E2E_ENABLE_DOCKER=false
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/host-auth.yaml"
+printf '%s\n' "$HOST_AUTH_FIXTURE_BODY" > "$FIXTURE"
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "host-auth" "image_pull_back_off" 30
+DEP_ID=$(get_deployment_id "ring-e2e" "host-auth")
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS" | sed 's/^/  | /'
+# Got past auth resolution: the failure is the unreachable registry, NOT an
+# auth/authorization error.
+if ! printf '%s' "$MSGS" | grep -qi "cannot reach the registry"; then
+  fail "case 1: expected 'cannot reach the registry' (auth resolved, pull attempted)"
+fi
+if printf '%s' "$MSGS" | grep -qi "not authorized\|no host credential"; then
+  fail "case 1: host auth should have resolved, but got an auth error"
+fi
+log "case 1 OK: host auth resolved, pull attempted against the (unreachable) registry"
+"$RING_BIN" deployment delete "$DEP_ID"
+
+# Stop the case-1 server before standing up a differently-configured one. The
+# EXIT trap (cleanup_ring) only fires at script end, so tear this one down by
+# hand here.
+kill "$RING_PID" 2>/dev/null || true
+wait "$RING_PID" 2>/dev/null || true
+
+# ── Case 2: activated but NOT authorized → fail fast ─────────────────────────
+log "-- case 2: activated but server did not authorize --"
+unset RING_EXTRA_CONFIG
+export RING_E2E_ENABLE_DOCKER=true   # default docker block, no use_host_registry_auth
+
+start_ring
+ring_login
+
+FIXTURE2="$RING_TEST_DIR/host-auth.yaml"
+printf '%s\n' "$HOST_AUTH_FIXTURE_BODY" > "$FIXTURE2"
+"$RING_BIN" apply --file "$FIXTURE2"
+
+wait_deployment_status "ring-e2e" "host-auth" "image_pull_back_off" 30
+DEP_ID2=$(get_deployment_id "ring-e2e" "host-auth")
+TOKEN2=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS2=$(curl -fsS "$RING_URL/deployments/$DEP_ID2/events" \
+  -H "Authorization: Bearer $TOKEN2" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS2" | sed 's/^/  | /'
+if ! printf '%s' "$MSGS2" | grep -qi "not authorized"; then
+  fail "case 2: expected a 'not authorized' event when the server did not opt in"
+fi
+log "case 2 OK: fail-fast when not authorized"
+"$RING_BIN" deployment delete "$DEP_ID2"
+
+# ── Case 3: use_host_auth + inline credentials → 422 at apply ────────────────
+log "-- case 3: use_host_auth combined with inline credentials is rejected --"
+TOKEN3=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN3" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/deployments" \
+  --data '{
+    "runtime": "docker",
+    "name": "host-auth-conflict",
+    "namespace": "ring-e2e",
+    "image": "127.0.0.1:1/ring-e2e/private:latest",
+    "config": { "use_host_auth": true, "server": "127.0.0.1:1", "username": "u", "password": "p" }
+  }')
+log "POST /deployments (conflict) status: $STATUS"
+if [ "$STATUS" != "422" ]; then
+  fail "case 3: expected 422 for use_host_auth + inline credentials, got $STATUS"
+fi
+log "case 3 OK: conflict rejected with 422"
+
+log "== T37: PASS =="


### PR DESCRIPTION
## What

Let a deployment pull private images using the registry credentials already configured on the **host** (e.g. via `docker login`), instead of inlining `server`/`username`/`password` in the manifest.

Today registry credentials are stored in cleartext in the `deployment.config` JSON column and returned in cleartext by the API (`GET /deployments`). With this change the secret stays on the host — it never reaches the manifest, the database, or the API.

## How

A deliberate **two-flag handshake**:

1. The **server** authorizes it per runtime: `use_host_registry_auth = true` under `[server.runtime.{docker,podman,containerd}]` (default `false`, opt-in, fail-fast — matches the existing runtime conventions).
2. The **deployment** activates it: `config.use_host_auth: true`.

Both are required. A deployment requesting host auth on a runtime that did not authorize it fails fast with an actionable error — there is no silent fallback to an anonymous pull. Combining `use_host_auth` with inline credentials is rejected at apply time (422).

```toml
# server config.toml
[server.runtime.docker]
enabled = true
use_host_registry_auth = true
```

```yaml
# deployment manifest — no secret
config:
  use_host_auth: true
```

Credential resolution uses the `docker_credential` crate and honors `credHelpers`/`credsStore`. By default it follows the standard Docker resolution (`$DOCKER_CONFIG`, then `~/.docker/config.json`); set `host_registry_config` to pin an explicit file when the Ring daemon runs as a different user than the one who logged in, or to point at a Podman `containers/auth.json`.

Supported on **Docker, Podman and containerd**. The host config format (the `auths`/`credsStore`/`credHelpers` schema) is identical across all three; only the default location differs, which the `host_registry_config` override covers without per-runtime code.

## Scope

The cleartext storage of inline `password` in the DB/API is a pre-existing issue and is **not** widened here (`use_host_auth` is a plain bool). A follow-up will wire the existing AES-256-GCM `Secret` model to registry auth (a referenced, encrypted `imagePullSecret`).

## Tests

- Unit tests for the shared resolver (`registry_host_for`, the authorized/activated decision) and for the API conflict validation.
- e2e for both Docker and containerd covering the three paths: host auth resolved + pull attempted, fail-fast when not authorized, and the inline-credentials conflict (422). The Docker e2e passes locally.
