### PR TITLE
feat: pull private images using an encrypted image_pull_secret

### DIFF
--- a/documentation/how-to/deploy-with-secrets.md
+++ b/documentation/how-to/deploy-with-secrets.md
@@ -61,6 +61,28 @@ Inside the container, `secretRef` values are indistinguishable from plain values
 
 **If a referenced secret does not exist in the namespace:** Ring emits an `error` event with `reason: SecretResolutionError`, the scheduler skips the deployment on that tick, and the deployment stays in `creating`. Inspect with `ring deployment events <id> --level error`.
 
+## Pull a private image with a secret
+
+To pull from a private registry without inlining the credentials in your manifest, store them in a Secret and reference it with `config.image_pull_secret`. The Secret's value is a Docker `config.json` payload (the same format `docker login` writes):
+
+```bash
+ring secret create scaleway-registry -n production \
+  -v '{"auths":{"rg.fr-par.scw.cloud":{"auth":"'"$(printf 'nologin:%s' "$SCW_SECRET_KEY" | base64 -w0)"'"}}}'
+```
+
+```yaml
+deployments:
+  api:
+    name: api
+    namespace: production
+    runtime: docker
+    image: rg.fr-par.scw.cloud/my-namespace/api:v1
+    config:
+      image_pull_secret: scaleway-registry
+```
+
+The scheduler decrypts the Secret and pulls with it; the credentials never reach the deployment row or the API. It must live in the same namespace as the deployment, and is mutually exclusive with inline `server`/`username`/`password` and with `use_host_auth`. See the [`image_pull_secret` reference](/documentation/reference/manifest#image_pull_secret-credentials-from-an-encrypted-secret).
+
 ## Mount a secret as a file
 
 Some apps will not read credentials from an environment variable — they want a file path. Prometheus is a typical example: its `authorization.credentials_file` only takes a path, not the credential itself. For those cases, declare the secret as a `volume` of `type: secret`:

--- a/documentation/how-to/deploy-with-secrets.md
+++ b/documentation/how-to/deploy-with-secrets.md
@@ -63,11 +63,12 @@ Inside the container, `secretRef` values are indistinguishable from plain values
 
 ## Pull a private image with a secret
 
-To pull from a private registry without inlining the credentials in your manifest, store them in a Secret and reference it with `config.image_pull_secret`. The Secret's value is a Docker `config.json` payload (the same format `docker login` writes):
+To pull from a private registry without inlining the credentials in your manifest, store them in a Secret and reference it with `config.image_pull_secret`. The Secret's value is a Docker `config.json` — log in once, then store the file:
 
 ```bash
+docker login rg.fr-par.scw.cloud
 ring secret create scaleway-registry -n production \
-  -v '{"auths":{"rg.fr-par.scw.cloud":{"auth":"'"$(printf 'nologin:%s' "$SCW_SECRET_KEY" | base64 -w0)"'"}}}'
+  --value "$(cat ~/.docker/config.json)"
 ```
 
 ```yaml
@@ -81,7 +82,9 @@ deployments:
       image_pull_secret: scaleway-registry
 ```
 
-The scheduler decrypts the Secret and pulls with it; the credentials never reach the deployment row or the API. It must live in the same namespace as the deployment, and is mutually exclusive with inline `server`/`username`/`password` and with `use_host_auth`. See the [`image_pull_secret` reference](/documentation/reference/manifest#image_pull_secret-credentials-from-an-encrypted-secret).
+The scheduler decrypts the Secret and pulls with it; the credentials never reach the deployment row or the API. It must live in the same namespace as the deployment, and is mutually exclusive with inline `server`/`username`/`password` and with `use_host_auth`.
+
+> If your `docker login` uses a credential helper (`credsStore`), `config.json` won't contain the credential — see the [`image_pull_secret` reference](/documentation/reference/manifest#image_pull_secret-credentials-from-an-encrypted-secret) for the alternatives. The simplest path when you're already logged in on the host is [`use_host_auth`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host), which needs no Secret at all.
 
 ## Mount a secret as a file
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -363,6 +363,7 @@ config:
 | `server` | Private-registry hostname (only for non-Docker-Hub registries). |
 | `username`, `password` | Registry credentials. Sent to the runtime on `pull`. |
 | `use_host_auth` | `true` to resolve registry credentials from the **host's** Docker config instead of inlining them. Mutually exclusive with `server`/`username`/`password`. See below. |
+| `image_pull_secret` | Name of a `Secret` (same namespace) holding registry credentials as a `dockerconfigjson` payload. Resolved and decrypted server-side before the pull. Mutually exclusive with inline credentials and `use_host_auth`. See below. |
 | `user.id` | Numeric UID the container runs as (forwarded to `User` in Docker config). Optional. |
 | `user.group` | Numeric GID. Optional. |
 | `user.privileged` | Boolean. If `true`, the container is started with `HostConfig.Privileged = true`. Default `false`. |
@@ -387,6 +388,29 @@ It is a **two-flag handshake**:
 If a deployment sets `use_host_auth` on a runtime that did not authorize it, the deployment fails fast with an actionable error (no silent fallback to an anonymous pull). Combining `use_host_auth` with inline `server`/`username`/`password` is rejected at apply time.
 
 Supported on Docker, Podman and containerd. The host config follows the standard Docker resolution (`$DOCKER_CONFIG`, then `~/.docker/config.json`), honoring `credHelpers`/`credsStore`. When the Ring daemon runs as a different user than the one who logged in — or for a Podman `containers/auth.json` — pin the file explicitly with `host_registry_config` in the server config.
+
+### `image_pull_secret` — credentials from an encrypted Secret
+
+The portable, declarative alternative to `use_host_auth`: store the registry credentials in an **encrypted `Secret`** (AES-256-GCM at rest) and reference it by name. The credentials never appear in the manifest, the database row, or the API response — only the secret's name does.
+
+The Secret's value is a Docker `config.json` payload (`dockerconfigjson`), the same format `docker login` writes and `kubectl create secret docker-registry` produces:
+
+```bash
+# one-time: store the credentials as an encrypted Secret
+ring secret create scaleway-registry -n production \
+  -v '{"auths":{"rg.fr-par.scw.cloud":{"auth":"'"$(printf 'nologin:%s' "$SCW_SECRET_KEY" | base64 -w0)"'"}}}'
+```
+
+```yaml
+# deployment — references the Secret by name, no credentials inline
+config:
+  image_pull_policy: "Always"
+  image_pull_secret: "scaleway-registry"
+```
+
+At deploy time the scheduler decrypts the Secret, picks the `auths` entry matching the image's registry host, and pulls with it. If the Secret is missing or has no entry for the registry, the deployment fails fast with an `image_pull_secret_resolution_error` event (the value is never logged). It must reference a Secret in the **same namespace** as the deployment, and is mutually exclusive with inline `server`/`username`/`password` and with `use_host_auth`.
+
+Supported on Docker, Podman and containerd.
 
 ## Full example
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -393,12 +393,12 @@ Supported on Docker, Podman and containerd. The host config follows the standard
 
 The portable, declarative alternative to `use_host_auth`: store the registry credentials in an **encrypted `Secret`** (AES-256-GCM at rest) and reference it by name. The credentials never appear in the manifest, the database row, or the API response — only the secret's name does.
 
-The Secret's value is a Docker `config.json` payload (`dockerconfigjson`), the same format `docker login` writes and `kubectl create secret docker-registry` produces:
+The Secret's value is a Docker `config.json` payload (`dockerconfigjson`) — the exact format `docker login` writes. The simplest way to create it is to log in once and store the resulting file:
 
 ```bash
-# one-time: store the credentials as an encrypted Secret
+docker login rg.fr-par.scw.cloud
 ring secret create scaleway-registry -n production \
-  -v '{"auths":{"rg.fr-par.scw.cloud":{"auth":"'"$(printf 'nologin:%s' "$SCW_SECRET_KEY" | base64 -w0)"'"}}}'
+  --value "$(cat ~/.docker/config.json)"
 ```
 
 ```yaml
@@ -407,6 +407,8 @@ config:
   image_pull_policy: "Always"
   image_pull_secret: "scaleway-registry"
 ```
+
+> **Credential helpers.** This works when `docker login` stores the credential **inline** in `config.json` (an `"auth": "..."` entry — the common case on Linux servers). If Docker is configured with a credential helper (`credsStore`/`credHelpers`, e.g. Docker Desktop), the file holds no usable credential — it's in the OS keychain instead. In that case either write the `auths` entry by hand, or use [`use_host_auth`](#use_host_auth-credentials-from-the-host), which resolves helpers on the host.
 
 At deploy time the scheduler decrypts the Secret, picks the `auths` entry matching the image's registry host, and pulls with it. If the Secret is missing or has no entry for the registry, the deployment fails fast with an `image_pull_secret_resolution_error` event (the value is never logged). It must reference a Secret in the **same namespace** as the deployment, and is mutually exclusive with inline `server`/`username`/`password` and with `use_host_auth`.
 

--- a/documentation/runtimes/containerd.md
+++ b/documentation/runtimes/containerd.md
@@ -50,7 +50,7 @@ ring apply -f web.yaml
 - **Image entrypoint is honoured.** containerd is low-level and doesn't merge the image's `Entrypoint`/`Cmd` for you the way the Docker daemon does — Ring reads them from the image config and applies them when the deployment gives no `command`.
 - **`command` health checks** run via `Tasks.Exec` (gRPC), no in-guest agent needed.
 - **Crash detection is reconcile-based** (tick-paced), like Podman — it inspects task exit status on each scheduler pass.
-- **Private registries.** containerd has no `login` of its own. Either inline `config.server`/`username`/`password`, or — since `nerdctl login` writes to `~/.docker/config.json` — set `use_host_registry_auth = true` and pull with `config.use_host_auth: true` (no secret in the manifest). See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
+- **Private registries.** containerd has no `login` of its own. Inline `config.server`/`username`/`password`; or set `use_host_registry_auth = true` and pull with `config.use_host_auth: true` (since `nerdctl login` writes to `~/.docker/config.json`); or store credentials in an encrypted `Secret` and reference it with `config.image_pull_secret`. See [manifest `config`](/documentation/reference/manifest#config) and [deploy with secrets](/documentation/how-to/deploy-with-secrets#pull-a-private-image-with-a-secret).
 
 ## See also
 

--- a/documentation/runtimes/docker.md
+++ b/documentation/runtimes/docker.md
@@ -53,6 +53,7 @@ ring apply -f web.yaml
 - **Event-driven crash detection.** Ring listens to the Docker event stream, so a crash is noticed sub-second (the other runtimes detect crashes on the scheduler tick instead).
 - **Full feature set.** Everything in the [manifest reference](/documentation/reference/manifest) works on Docker — it's the baseline the other runtimes are compared against.
 - **Registry auth from the host.** Already `docker login`-ed on the host? Set `use_host_registry_auth = true` here, then `config.use_host_auth: true` on the deployment, to pull private images without putting the secret in the manifest. See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
+- **Registry auth from an encrypted Secret.** The portable alternative: store credentials in a `Secret` and reference it with `config.image_pull_secret`. See [deploy with secrets](/documentation/how-to/deploy-with-secrets#pull-a-private-image-with-a-secret).
 
 ## See also
 

--- a/documentation/runtimes/podman.md
+++ b/documentation/runtimes/podman.md
@@ -50,6 +50,7 @@ ring apply -f web.yaml
 - **Rootless remaps UID/GID.** A file written inside the container has a different owner on the host. Bind-mount and named-volume ownership behave differently than under Docker-root — mind permissions on mounts.
 - **Host networking** (`network.mode: host`) is not yet supported on Podman.
 - **Registry auth from the host.** `podman login` writes to `containers/auth.json`. Authorize it with `use_host_registry_auth = true` (point `host_registry_config` at the auth file) and pull with `config.use_host_auth: true` — no secret in the manifest. See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
+- **Registry auth from an encrypted Secret.** Or store credentials in a `Secret` and reference it with `config.image_pull_secret`. See [deploy with secrets](/documentation/how-to/deploy-with-secrets#pull-a-private-image-with-a-secret).
 - Otherwise the feature set matches Docker — same images, same health checks, same labels.
 
 ## See also

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -172,6 +172,23 @@ fn validate_config(input: &DeploymentInput, errors: &mut ViolationList) {
             "deployment.config.use_host_auth.conflict",
         ));
     }
+
+    // `image_pull_secret` is a third, mutually exclusive credential source: the
+    // scheduler resolves it into server/username/password before the pull, so
+    // combining it with inline credentials or `use_host_auth` is contradictory.
+    if config.image_pull_secret.is_some()
+        && (config.server.is_some()
+            || config.username.is_some()
+            || config.password.is_some()
+            || config.use_host_auth)
+    {
+        errors.push(Violation::new(
+            "config.image_pull_secret",
+            "image_pull_secret cannot be combined with inline server/username/password \
+             or use_host_auth — pick a single credential source",
+            "deployment.config.image_pull_secret.conflict",
+        ));
+    }
 }
 
 /// Per-port rules. The `DeploymentPort` struct already constrains
@@ -3238,6 +3255,103 @@ mod tests {
                 "namespace": "ring",
                 "image": "private.io/nginx:latest",
                 "config": { "use_host_auth": true }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_image_pull_secret_with_inline_credentials() {
+        // image_pull_secret is resolved into credentials by the scheduler, so
+        // combining it with inline server/username/password is contradictory.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx-pull-secret-conflict",
+                "namespace": "ring",
+                "image": "private.io/nginx:latest",
+                "config": {
+                    "image_pull_secret": "dockercfg",
+                    "username": "u",
+                    "password": "p"
+                }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.config.image_pull_secret.conflict".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_image_pull_secret_with_use_host_auth() {
+        // image_pull_secret and use_host_auth are two mutually exclusive
+        // credential sources.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx-two-sources",
+                "namespace": "ring",
+                "image": "private.io/nginx:latest",
+                "config": { "image_pull_secret": "dockercfg", "use_host_auth": true }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value = response.json();
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x["code"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            codes.contains(&"deployment.config.image_pull_secret.conflict".to_string()),
+            "got {:?}",
+            codes
+        );
+    }
+
+    #[tokio::test]
+    async fn create_accepts_image_pull_secret_alone() {
+        // image_pull_secret on its own (no inline creds, no host auth) is the
+        // supported shape.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "docker",
+                "name": "nginx-pull-secret",
+                "namespace": "ring",
+                "image": "private.io/nginx:latest",
+                "config": { "image_pull_secret": "dockercfg" }
             }))
             .await;
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -112,6 +112,11 @@ struct DeploymentConfig {
     /// inlining `server`/`username`/`password`. Mutually exclusive with them.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     use_host_auth: bool,
+
+    /// Name of a Secret holding registry credentials (`dockerconfigjson`).
+    /// Mutually exclusive with inline credentials and `use_host_auth`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    image_pull_secret: Option<String>,
 }
 
 /// Numeric uid/gid the container runs as (forwarded to Docker's `User`).

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -158,6 +158,13 @@ pub(crate) struct DeploymentConfig {
     /// their byte-for-byte shape (no DB migration, no API surface change).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub(crate) use_host_auth: bool,
+    /// Name of a `Secret` (same namespace) holding registry credentials as a
+    /// Docker `config.json` payload (`dockerconfigjson`). The scheduler decrypts
+    /// it and fills `server`/`username`/`password` before the runtime pulls, so
+    /// the secret is never inlined in the manifest, the database, or the API.
+    /// Mutually exclusive with inline credentials and `use_host_auth`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) image_pull_secret: Option<String>,
 }
 
 /// Transport protocol for a published port. TCP is the default, preserving the

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -809,6 +809,7 @@ mod tests {
                 privileged: Some(false),
             }),
             use_host_auth: false,
+            image_pull_secret: None,
         });
         assert_eq!(build_user_config(&config), Some("1000:1000".to_string()));
     }
@@ -826,6 +827,7 @@ mod tests {
                 privileged: Some(false),
             }),
             use_host_auth: false,
+            image_pull_secret: None,
         });
         assert_eq!(build_user_config(&config), Some("1000".to_string()));
     }
@@ -894,6 +896,7 @@ mod tests {
                 privileged: Some(true),
             }),
             use_host_auth: false,
+            image_pull_secret: None,
         });
         assert_eq!(get_privileged_config(&config), Some(true));
     }

--- a/src/runtime/registry_auth.rs
+++ b/src/runtime/registry_auth.rs
@@ -153,6 +153,29 @@ pub(crate) fn resolve_host_auth(
     registry_host: &str,
     config_path: Option<&str>,
 ) -> Result<(String, String), HostAuthError> {
+    resolve_with(registry_host, |server| get_credential(server, config_path))
+}
+
+/// Resolve `(username, password)` for `registry_host` from an in-memory Docker
+/// `config.json` payload (e.g. the decrypted contents of an image-pull Secret),
+/// rather than a file on disk. Same Hub-key handling and error mapping as
+/// [`resolve_host_auth`].
+pub(crate) fn resolve_auth_from_payload(
+    registry_host: &str,
+    payload: &str,
+) -> Result<(String, String), HostAuthError> {
+    resolve_with(registry_host, |server| {
+        docker_credential::get_credential_from_reader(std::io::Cursor::new(payload), server)
+    })
+}
+
+/// Shared lookup core: try the registry host (plus the legacy Hub key for
+/// `docker.io`), turn an identity token into an error, and map crate errors to
+/// [`HostAuthError`]. `lookup` performs one credential read for a given key.
+fn resolve_with<F>(registry_host: &str, lookup: F) -> Result<(String, String), HostAuthError>
+where
+    F: Fn(&str) -> Result<DockerCredential, CredentialRetrievalError>,
+{
     // Docker Hub creds are conventionally keyed under the legacy v1 endpoint,
     // not the bare `docker.io` host, so try both forms for Hub.
     let lookups: Vec<String> = if registry_host == "docker.io" {
@@ -166,7 +189,7 @@ pub(crate) fn resolve_host_auth(
 
     let mut last_err = HostAuthError::NoEntryForRegistry(registry_host.to_string());
     for key in &lookups {
-        match get_credential(key, config_path) {
+        match lookup(key) {
             Ok(DockerCredential::UsernamePassword(user, pass)) => return Ok((user, pass)),
             Ok(DockerCredential::IdentityToken(_)) => {
                 return Err(HostAuthError::HelperFailed(
@@ -256,6 +279,39 @@ mod tests {
         assert!(matches!(
             decide_host_auth(false, true),
             Err(HostAuthError::NotAuthorized)
+        ));
+    }
+
+    #[test]
+    fn payload_auth_decodes_dockerconfigjson_for_private_registry() {
+        use base64::Engine as _;
+        let auth = base64::engine::general_purpose::STANDARD.encode("alice:s3cr3t");
+        let payload = format!(r#"{{"auths":{{"registry.example:5000":{{"auth":"{auth}"}}}}}}"#);
+        let (user, pass) =
+            resolve_auth_from_payload("registry.example:5000", &payload).expect("should resolve");
+        assert_eq!(user, "alice");
+        assert_eq!(pass, "s3cr3t");
+    }
+
+    #[test]
+    fn payload_auth_uses_legacy_hub_key_for_docker_io() {
+        use base64::Engine as _;
+        let auth = base64::engine::general_purpose::STANDARD.encode("bob:hunter2");
+        // Hub creds are keyed under the legacy v1 endpoint, not bare docker.io.
+        let payload =
+            format!(r#"{{"auths":{{"https://index.docker.io/v1/":{{"auth":"{auth}"}}}}}}"#);
+        let (user, pass) =
+            resolve_auth_from_payload("docker.io", &payload).expect("should resolve");
+        assert_eq!(user, "bob");
+        assert_eq!(pass, "hunter2");
+    }
+
+    #[test]
+    fn payload_auth_errors_when_no_entry_for_registry() {
+        let payload = r#"{"auths":{"other.io":{"auth":"eA=="}}}"#;
+        assert!(matches!(
+            resolve_auth_from_payload("registry.example:5000", payload),
+            Err(HostAuthError::NoEntryForRegistry(_))
         ));
     }
 }

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -57,6 +57,76 @@ async fn resolve_environment(deployment: &mut Deployment, pool: &SqlitePool) -> 
     Ok(())
 }
 
+/// Resolve `config.image_pull_secret` into inline registry credentials before
+/// the runtime pulls. The named `Secret` (same namespace) holds a Docker
+/// `config.json` payload (`dockerconfigjson`); we decrypt it, pick the entry for
+/// the image's registry host, and fill `config.server`/`username`/`password` on
+/// the deployment. The runtime's existing inline-credentials path then consumes
+/// them — so no runtime change and no DB access at pull time, mirroring how
+/// `resolve_environment` resolves env `secretRef`s here in the scheduler.
+///
+/// A no-op when `image_pull_secret` is unset. Errors (secret missing, decrypt
+/// failure, no entry for the registry) are returned as a message — never the
+/// decrypted value — so the caller can surface them as a deployment event.
+async fn resolve_image_pull_secret(
+    deployment: &mut Deployment,
+    pool: &SqlitePool,
+) -> Result<(), String> {
+    let Some(secret_name) = deployment
+        .config
+        .as_ref()
+        .and_then(|c| c.image_pull_secret.clone())
+    else {
+        return Ok(());
+    };
+
+    let payload = match SecretModel::find_by_namespace_name(
+        pool,
+        &deployment.namespace,
+        &secret_name,
+    )
+    .await
+    {
+        Ok(Some(secret)) => secret.get_decrypted_value().map_err(|e| {
+            format!(
+                "Failed to decrypt image_pull_secret '{}': {}",
+                secret_name, e
+            )
+        })?,
+        Ok(None) => {
+            return Err(format!(
+                "image_pull_secret '{}' not found in namespace '{}'",
+                secret_name, deployment.namespace
+            ));
+        }
+        Err(e) => {
+            return Err(format!(
+                "Failed to fetch image_pull_secret '{}': {}",
+                secret_name, e
+            ));
+        }
+    };
+
+    // The payload is a Docker config.json. Reuse the same lookup the host-auth
+    // path uses, reading from memory instead of a file on disk.
+    let host = crate::runtime::registry_auth::registry_host_for(&deployment.image);
+    let (username, password) =
+        crate::runtime::registry_auth::resolve_auth_from_payload(&host, &payload).map_err(|e| {
+            format!(
+                "image_pull_secret '{}' has no usable credential for registry '{}': {}",
+                secret_name, host, e
+            )
+        })?;
+
+    if let Some(config) = deployment.config.as_mut() {
+        config.server = Some(host);
+        config.username = Some(username);
+        config.password = Some(password);
+    }
+
+    Ok(())
+}
+
 async fn load_configs(
     pool: &SqlitePool,
     deployment: &Deployment,
@@ -1244,10 +1314,37 @@ pub(crate) async fn schedule(
                 None => continue,
             };
 
-            let resolved = match prepare_deployment(&pool, &deployment).await {
+            let mut resolved = match prepare_deployment(&pool, &deployment).await {
                 Some(d) => d,
                 None => continue,
             };
+
+            // Resolve config.image_pull_secret into inline credentials before
+            // the runtime pulls. Like volume/env secret resolution above, a
+            // failure skips this tick and surfaces a deployment event (naming
+            // only the secret, never its value), so the operator can fix it.
+            if let Err(e) = resolve_image_pull_secret(&mut resolved, &pool).await {
+                error!(
+                    "Failed to resolve image_pull_secret for deployment {}: {}",
+                    deployment.id, e
+                );
+                if let Err(log_err) = deployment_event::log_event(
+                    &pool,
+                    deployment.id.clone(),
+                    "error",
+                    e,
+                    "scheduler",
+                    Some("image_pull_secret_resolution_error"),
+                )
+                .await
+                {
+                    warn!(
+                        "Failed to log image_pull_secret resolution error event: {}",
+                        log_err
+                    );
+                }
+                continue;
+            }
 
             let resolved_mounts = match crate::models::volume::resolve_volumes(
                 &deployment.volumes,

--- a/tests/e2e/containerd/t6_image_pull_secret.sh
+++ b/tests/e2e/containerd/t6_image_pull_secret.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# T6-containerd: registry credentials resolved from an encrypted Secret via
+# `config.image_pull_secret` (containerd runtime).
+#
+# Mirrors tests/e2e/docker/t38_image_pull_secret.sh. Deterministic and offline:
+# the image points at 127.0.0.1:1, so once the secret is decrypted the pull
+# fails — proving Ring got PAST secret resolution.
+#
+#   1. Valid secret → pull attempted (NOT a resolution error).
+#   2. Missing secret → image_pull_secret_resolution_error event.
+#   3. Validation: image_pull_secret + inline credentials → 422.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T6-containerd: image_pull_secret (encrypted registry credentials) =="
+
+setup_containerd
+
+start_ring
+ring_login
+
+"$RING_BIN" namespace create ring-e2e 2>&1 \
+  | grep -qiE "created|already exists" \
+  || fail "ring namespace create did not succeed"
+
+AUTH_B64=$(printf 'nologin:secret' | base64)
+DOCKERCFG="{\"auths\":{\"127.0.0.1:1\":{\"auth\":\"$AUTH_B64\"}}}"
+"$RING_BIN" secret create dockercfg -n ring-e2e -v "$DOCKERCFG" 2>&1 \
+  | grep -qF "created" \
+  || fail "ring secret create did not succeed"
+log "secret 'dockercfg' created"
+
+# ── Case 1: valid secret → pull attempted ───────────────────────────────────
+log "-- case 1: valid image_pull_secret --"
+FIXTURE="$RING_TEST_DIR/pull-secret-ctr.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  pull-secret-ctr:
+    name: pull-secret-ctr
+    namespace: ring-e2e
+    runtime: containerd
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    config:
+      image_pull_policy: Always
+      image_pull_secret: dockercfg
+EOF
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "pull-secret-ctr" "image_pull_back_off" 60
+DEP_ID=$(get_deployment_id "ring-e2e" "pull-secret-ctr")
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS" | sed 's/^/  | /'
+if printf '%s' "$MSGS" | grep -qi "image_pull_secret\|decrypt"; then
+  fail "case 1: secret should have resolved, but got a resolution error"
+fi
+if ! printf '%s' "$MSGS" | grep -qiE "cannot reach the registry|not found|registry"; then
+  fail "case 1: expected a pull-stage error (secret resolved, pull attempted)"
+fi
+log "case 1 OK: secret decrypted, pull attempted"
+"$RING_BIN" deployment delete "$DEP_ID"
+
+# ── Case 2: missing secret → resolution error ───────────────────────────────
+log "-- case 2: image_pull_secret points at a non-existent secret --"
+FIXTURE2="$RING_TEST_DIR/pull-secret-ctr-missing.yaml"
+cat > "$FIXTURE2" <<'EOF'
+deployments:
+  pull-secret-ctr-missing:
+    name: pull-secret-ctr-missing
+    namespace: ring-e2e
+    runtime: containerd
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    config:
+      image_pull_policy: Always
+      image_pull_secret: does-not-exist
+EOF
+"$RING_BIN" apply --file "$FIXTURE2"
+
+DEP_ID2=$(get_deployment_id "ring-e2e" "pull-secret-ctr-missing")
+TOKEN2=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+FOUND=""
+for _ in $(seq 1 30); do
+  MSGS2=$(curl -fsS "$RING_URL/deployments/$DEP_ID2/events" \
+    -H "Authorization: Bearer $TOKEN2" | jq -r '.[].message' || true)
+  if printf '%s' "$MSGS2" | grep -qi "image_pull_secret 'does-not-exist' not found"; then
+    FOUND=1
+    break
+  fi
+  sleep 1
+done
+log "events:"; printf '%s\n' "${MSGS2:-}" | sed 's/^/  | /'
+[ -n "$FOUND" ] || fail "case 2: expected a resolution error naming the missing secret"
+log "case 2 OK: missing secret surfaces a resolution error"
+"$RING_BIN" deployment delete "$DEP_ID2"
+
+# ── Case 3: image_pull_secret + inline credentials → 422 ────────────────────
+log "-- case 3: image_pull_secret combined with inline credentials is rejected --"
+TOKEN3=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN3" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/deployments" \
+  --data '{
+    "runtime": "containerd",
+    "name": "pull-secret-ctr-conflict",
+    "namespace": "ring-e2e",
+    "image": "127.0.0.1:1/ring-e2e/private:latest",
+    "config": { "image_pull_secret": "dockercfg", "username": "u", "password": "p" }
+  }')
+log "POST /deployments (conflict) status: $STATUS"
+if [ "$STATUS" != "422" ]; then
+  fail "case 3: expected 422 for image_pull_secret + inline credentials, got $STATUS"
+fi
+log "case 3 OK: conflict rejected with 422"
+
+log "== T6-containerd: PASS =="

--- a/tests/e2e/docker/t38_image_pull_secret.sh
+++ b/tests/e2e/docker/t38_image_pull_secret.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# T38: registry credentials resolved from an encrypted Secret via
+# `config.image_pull_secret` (Docker runtime).
+#
+# Deterministic and offline (like t37): the target image points at 127.0.0.1:1,
+# which nothing listens on, so once the secret is decrypted and the auth
+# resolved, the pull fails with a transport error — proving Ring got PAST secret
+# resolution.
+#
+#   1. Valid secret: a Secret holding a dockerconfigjson with an entry for the
+#      target registry. The deployment references it via image_pull_secret. The
+#      pull is attempted with those creds → image_pull_back_off with a "cannot
+#      reach the registry" event (NOT a resolution error).
+#   2. Missing secret: image_pull_secret pointing at a non-existent Secret →
+#      image_pull_secret_resolution_error event.
+#   3. Validation: image_pull_secret + inline credentials → 422 at apply.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T38: image_pull_secret (encrypted registry credentials) =="
+
+start_ring
+ring_login
+
+# Secrets need the namespace to exist first.
+"$RING_BIN" namespace create ring-e2e 2>&1 \
+  | grep -qiE "created|already exists" \
+  || fail "ring namespace create did not succeed"
+
+# A Secret whose value is a dockerconfigjson with an entry for 127.0.0.1:1.
+AUTH_B64=$(printf 'nologin:secret' | base64)
+DOCKERCFG="{\"auths\":{\"127.0.0.1:1\":{\"auth\":\"$AUTH_B64\"}}}"
+"$RING_BIN" secret create dockercfg -n ring-e2e -v "$DOCKERCFG" 2>&1 \
+  | grep -qF "created" \
+  || fail "ring secret create did not succeed"
+log "secret 'dockercfg' created"
+
+# ── Case 1: valid secret → pull attempted, registry unreachable ─────────────
+log "-- case 1: valid image_pull_secret --"
+FIXTURE="$RING_TEST_DIR/pull-secret.yaml"
+cat > "$FIXTURE" <<'EOF'
+deployments:
+  pull-secret:
+    name: pull-secret
+    namespace: ring-e2e
+    runtime: docker
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Always
+      image_pull_secret: dockercfg
+EOF
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_deployment_status "ring-e2e" "pull-secret" "image_pull_back_off" 30
+DEP_ID=$(get_deployment_id "ring-e2e" "pull-secret")
+TOKEN=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+MSGS=$(curl -fsS "$RING_URL/deployments/$DEP_ID/events" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[].message')
+log "events:"; printf '%s\n' "$MSGS" | sed 's/^/  | /'
+if printf '%s' "$MSGS" | grep -qi "image_pull_secret\|not found\|decrypt"; then
+  fail "case 1: secret should have resolved, but got a resolution error"
+fi
+if ! printf '%s' "$MSGS" | grep -qi "cannot reach the registry"; then
+  fail "case 1: expected 'cannot reach the registry' (secret resolved, pull attempted)"
+fi
+log "case 1 OK: secret decrypted, pull attempted against the (unreachable) registry"
+"$RING_BIN" deployment delete "$DEP_ID"
+
+# ── Case 2: missing secret → resolution error ───────────────────────────────
+log "-- case 2: image_pull_secret points at a non-existent secret --"
+FIXTURE2="$RING_TEST_DIR/pull-secret-missing.yaml"
+cat > "$FIXTURE2" <<'EOF'
+deployments:
+  pull-secret-missing:
+    name: pull-secret-missing
+    namespace: ring-e2e
+    runtime: docker
+    image: 127.0.0.1:1/ring-e2e/private:latest
+    replicas: 1
+    command: ["sleep", "600"]
+    config:
+      image_pull_policy: Always
+      image_pull_secret: does-not-exist
+EOF
+"$RING_BIN" apply --file "$FIXTURE2"
+
+# The scheduler skips the tick and logs an error event; the deployment never
+# leaves its pre-apply state. Poll the events directly rather than a status.
+DEP_ID2=$(get_deployment_id "ring-e2e" "pull-secret-missing")
+TOKEN2=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+FOUND=""
+for _ in $(seq 1 30); do
+  MSGS2=$(curl -fsS "$RING_URL/deployments/$DEP_ID2/events" \
+    -H "Authorization: Bearer $TOKEN2" | jq -r '.[].message' || true)
+  if printf '%s' "$MSGS2" | grep -qi "image_pull_secret 'does-not-exist' not found"; then
+    FOUND=1
+    break
+  fi
+  sleep 1
+done
+log "events:"; printf '%s\n' "${MSGS2:-}" | sed 's/^/  | /'
+[ -n "$FOUND" ] || fail "case 2: expected a resolution error naming the missing secret"
+log "case 2 OK: missing secret surfaces a resolution error"
+"$RING_BIN" deployment delete "$DEP_ID2"
+
+# ── Case 3: image_pull_secret + inline credentials → 422 ────────────────────
+log "-- case 3: image_pull_secret combined with inline credentials is rejected --"
+TOKEN3=$(jq -r '.default.token' "$RING_TEST_DIR/auth.json")
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN3" \
+  -H "Content-Type: application/json" \
+  -X POST "$RING_URL/deployments" \
+  --data '{
+    "runtime": "docker",
+    "name": "pull-secret-conflict",
+    "namespace": "ring-e2e",
+    "image": "127.0.0.1:1/ring-e2e/private:latest",
+    "config": { "image_pull_secret": "dockercfg", "username": "u", "password": "p" }
+  }')
+log "POST /deployments (conflict) status: $STATUS"
+if [ "$STATUS" != "422" ]; then
+  fail "case 3: expected 422 for image_pull_secret + inline credentials, got $STATUS"
+fi
+log "case 3 OK: conflict rejected with 422"
+
+log "== T38: PASS =="


### PR DESCRIPTION
Pull private images using credentials stored in an **encrypted Secret**, referenced by name — the Kubernetes `imagePullSecrets` model.

The credentials never appear in the manifest, the `deployment.config` DB row, or the API response — only the Secret's name does. This is the declarative counterpart to `use_host_auth` (#173): the secret lives in Ring (encrypted, AES-256-GCM) instead of on the host.

```bash
docker login rg.fr-par.scw.cloud
ring secret create scaleway -n prod --value "$(cat ~/.docker/config.json)"
```

```yaml
config:
  image_pull_secret: scaleway   # no credentials inline
```

The Secret's value is a Docker `config.json` (`dockerconfigjson`).

**How it works**
- Resolution happens in the scheduler, before the pull — the same place env `secretRef` and `type: secret` volumes are already resolved. No runtime changes, no DB access at pull time.
- It reuses the `registry_auth` resolver from #173 (refactored to read an in-memory payload as well as a file), fills `config.server`/`username`/`password` on the resolved deployment, and the existing inline-credentials path takes over.
- Missing/undecryptable secret → `image_pull_secret_resolution_error` event (value never logged).
- Mutually exclusive with inline credentials and `use_host_auth` — rejected at apply (422).
- Works on Docker, Podman and containerd.

**Tests** — unit tests for the in-memory resolver and the API conflict; e2e for Docker and containerd (valid secret → pull attempted, missing secret → error event, conflict → 422). Docker e2e passes locally.

Builds on #173, already merged to `main`.
