### PR TITLE
Bound Docker worker crash loops so MAX_RESTART_COUNT is honored

### DIFF
--- a/src/hypervisor/classifier.rs
+++ b/src/hypervisor/classifier.rs
@@ -1,0 +1,193 @@
+//! Shared retry-vs-give-up classifier for runtime failures.
+//!
+//! Two boundaries decide whether a failed deployment should be retried or fail
+//! fast:
+//!
+//! * the **create boundary** — a runtime rejected `create`/`start`/boot with a
+//!   [`RuntimeError`];
+//! * the **crash boundary** — a worker container started, then exited with some
+//!   exit code.
+//!
+//! Both used to funnel every failure into the same "bump `restart_count`, retry
+//! up to `MAX_RESTART_COUNT`" loop, so a permanent problem (image that doesn't
+//! exist, missing config, a binary that isn't executable) still burned five
+//! reconcile cycles before surfacing. This classifier folds the
+//! permanent-vs-transient decision into one place so a non-retryable failure
+//! lands on its terminal status immediately.
+//!
+//! It generalises the Cloud Hypervisor runtime's `classify_vm_start_error`. It is
+//! deliberately runtime-agnostic (it only reads the shared [`RuntimeError`] enum
+//! and a raw exit code) so containerd and the VM runtimes can adopt it next; for
+//! now only the Docker runtime is wired to it.
+
+use crate::hypervisor::error::RuntimeError;
+use crate::models::deployments::DeploymentStatus;
+
+/// What to do with a failed deployment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// Permanent failure: set this status and stop retrying. Retrying would only
+    /// burn reconcile cycles without changing the outcome.
+    Terminal(DeploymentStatus),
+    /// Transient failure: count it toward `restart_count` and retry, converging
+    /// to a terminal `CrashLoopBackOff`/`Failed` only if it keeps failing.
+    Retry,
+}
+
+impl Disposition {
+    pub(crate) fn is_terminal(&self) -> bool {
+        matches!(self, Disposition::Terminal(_))
+    }
+}
+
+/// Classify a create-boundary [`RuntimeError`] into terminal-or-retry while
+/// preserving the status each error maps to. The status mapping mirrors the
+/// Docker runtime's `handle_create_error`; this only adds the terminal-vs-retry
+/// verdict on top.
+///
+/// Terminal: the failure can't fix itself on a retry — the image truly doesn't
+/// exist, the config/key is absent, the container spec is rejected, firmware is
+/// missing, or the host is out of memory. Retry: registry/network hiccups, a
+/// busy port, a VM that failed to boot, and other transient/unknown errors.
+pub(crate) fn classify_create_error(err: &RuntimeError) -> Disposition {
+    match err {
+        // Permanent: the image isn't there (or policy forbids pulling it).
+        RuntimeError::ImageNotFound(_) => Disposition::Terminal(DeploymentStatus::ImagePullBackOff),
+        // Transient: a pull that failed mid-flight (registry/network) can succeed
+        // on a retry.
+        RuntimeError::ImagePullFailed(_) => Disposition::Retry,
+        // Permanent: Docker rejecting `create`/`start` almost always means a bad
+        // container spec (entrypoint, mount, options) — retrying re-submits the
+        // same rejected spec. Fail fast onto CreateContainerError.
+        RuntimeError::InstanceCreationFailed(_) => {
+            Disposition::Terminal(DeploymentStatus::CreateContainerError)
+        }
+        // Transient: network setup can race with daemon/host state.
+        RuntimeError::NetworkCreationFailed(_) => Disposition::Retry,
+        // Permanent: the referenced config (or key) is absent — a retry won't
+        // conjure it. The operator must create it.
+        RuntimeError::ConfigNotFound(_) | RuntimeError::ConfigKeyNotFound(_) => {
+            Disposition::Terminal(DeploymentStatus::ConfigError)
+        }
+        // Permanent: firmware/kernel file missing at the configured path.
+        RuntimeError::FirmwareNotFound(_) => Disposition::Terminal(DeploymentStatus::Failed),
+        // Permanent: the host is short on memory now; a retry won't free any.
+        RuntimeError::InsufficientResources(_) => {
+            Disposition::Terminal(DeploymentStatus::InsufficientResources)
+        }
+        // Transient: another process holds the port; it may be released.
+        RuntimeError::PortAlreadyInUse(_) => Disposition::Retry,
+        // Transient/unknown: worth a retry within the restart budget.
+        RuntimeError::VmStartFailed(_)
+        | RuntimeError::StatsFetchFailed(_)
+        | RuntimeError::Other(_)
+        | RuntimeError::Io(_)
+        | RuntimeError::Json(_) => Disposition::Retry,
+    }
+}
+
+/// Classify a crash-boundary exit code into terminal-or-retry.
+///
+/// A worker that exits is normally restarted (transient): the process may have
+/// hit a one-off error and a fresh start can recover. Two exit codes are the
+/// exception because they are *unambiguously* permanent under the standard shell
+/// convention, so a restart can never succeed:
+///
+/// * `127` — command not found (the entrypoint/binary doesn't exist);
+/// * `126` — found but not executable (bad perms / not a binary).
+///
+/// Both mean the container can never start its program, so we fail fast onto
+/// `CreateContainerError` rather than burning the whole restart budget. Every
+/// other code (including `0`, generic `1`, and signal-kill `128+n`) stays
+/// retryable — those can be transient, and mislabelling them terminal would
+/// wrongly give up on a recoverable worker.
+pub(crate) fn classify_exit_code(exit_code: Option<i64>) -> Disposition {
+    match exit_code {
+        Some(126) | Some(127) => Disposition::Terminal(DeploymentStatus::CreateContainerError),
+        _ => Disposition::Retry,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_not_found_is_terminal_image_pull_back_off() {
+        let d = classify_create_error(&RuntimeError::ImageNotFound("x".into()));
+        assert_eq!(d, Disposition::Terminal(DeploymentStatus::ImagePullBackOff));
+        assert!(d.is_terminal());
+    }
+
+    #[test]
+    fn image_pull_failed_is_retry() {
+        assert_eq!(
+            classify_create_error(&RuntimeError::ImagePullFailed("net".into())),
+            Disposition::Retry
+        );
+    }
+
+    #[test]
+    fn instance_creation_failed_is_terminal_create_container_error() {
+        assert_eq!(
+            classify_create_error(&RuntimeError::InstanceCreationFailed("bad".into())),
+            Disposition::Terminal(DeploymentStatus::CreateContainerError)
+        );
+    }
+
+    #[test]
+    fn config_errors_are_terminal() {
+        assert_eq!(
+            classify_create_error(&RuntimeError::ConfigNotFound("c".into())),
+            Disposition::Terminal(DeploymentStatus::ConfigError)
+        );
+        assert_eq!(
+            classify_create_error(&RuntimeError::ConfigKeyNotFound("k".into())),
+            Disposition::Terminal(DeploymentStatus::ConfigError)
+        );
+    }
+
+    #[test]
+    fn transient_runtime_errors_retry() {
+        assert_eq!(
+            classify_create_error(&RuntimeError::NetworkCreationFailed("n".into())),
+            Disposition::Retry
+        );
+        assert_eq!(
+            classify_create_error(&RuntimeError::PortAlreadyInUse(8080)),
+            Disposition::Retry
+        );
+        assert_eq!(
+            classify_create_error(&RuntimeError::Other("boom".into())),
+            Disposition::Retry
+        );
+    }
+
+    #[test]
+    fn insufficient_resources_is_terminal() {
+        assert_eq!(
+            classify_create_error(&RuntimeError::InsufficientResources("need".into())),
+            Disposition::Terminal(DeploymentStatus::InsufficientResources)
+        );
+    }
+
+    #[test]
+    fn unexecutable_and_missing_command_exit_codes_are_terminal() {
+        assert_eq!(
+            classify_exit_code(Some(126)),
+            Disposition::Terminal(DeploymentStatus::CreateContainerError)
+        );
+        assert_eq!(
+            classify_exit_code(Some(127)),
+            Disposition::Terminal(DeploymentStatus::CreateContainerError)
+        );
+    }
+
+    #[test]
+    fn other_exit_codes_retry() {
+        assert_eq!(classify_exit_code(Some(0)), Disposition::Retry);
+        assert_eq!(classify_exit_code(Some(1)), Disposition::Retry);
+        assert_eq!(classify_exit_code(Some(137)), Disposition::Retry);
+        assert_eq!(classify_exit_code(None), Disposition::Retry);
+    }
+}

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -3,6 +3,7 @@
 //! types, health probes, resource checks). Kept out of [`crate::runtime`] so
 //! that `runtime` holds only the concrete runtime implementations.
 
+pub(crate) mod classifier;
 pub(crate) mod cloud_init;
 pub(crate) mod console_logs;
 pub(crate) mod error;

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -609,13 +609,54 @@ pub(crate) async fn create(
 
 pub(crate) async fn update(pool: &SqlitePool, deployment: &Deployment) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "UPDATE deployment SET status = ?, updated_at = datetime('now'), restart_count = ?, image_digest = ?, parent_id = ? WHERE id = ?"
+        "UPDATE deployment SET status = ?, updated_at = datetime('now'), image_digest = ?, parent_id = ? WHERE id = ?"
     )
     .bind(deployment.status.to_string())
-    .bind(deployment.restart_count as i32)
     .bind(&deployment.image_digest)
     .bind(&deployment.parent_id)
     .bind(&deployment.id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Atomically add `delta` to a deployment's `restart_count` in the database and
+/// return the new value. Uses a read-modify-write *in SQL*
+/// (`restart_count = restart_count + ?`) so a concurrent writer's increment is
+/// never clobbered by a stale full-row `update` (last-writer-wins). The crash
+/// counter is the one field two code paths can touch in the same window, so it
+/// gets its own targeted statement instead of riding the blind row write.
+pub(crate) async fn increment_restart_count(
+    pool: &SqlitePool,
+    id: &str,
+    delta: u32,
+) -> Result<u32, sqlx::Error> {
+    sqlx::query(
+        "UPDATE deployment SET restart_count = restart_count + ?, updated_at = datetime('now') WHERE id = ?",
+    )
+    .bind(delta as i32)
+    .bind(id)
+    .execute(pool)
+    .await?;
+
+    let row: (i32,) = sqlx::query_as("SELECT restart_count FROM deployment WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(row.0 as u32)
+}
+
+/// Atomically reset a deployment's `restart_count` to 0 (the crash budget
+/// refill from the healthy-window logic). Targeted like
+/// [`increment_restart_count`] so it can't lose a concurrent increment to a
+/// stale full-row write.
+pub(crate) async fn reset_restart_count(pool: &SqlitePool, id: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE deployment SET restart_count = 0, updated_at = datetime('now') WHERE id = ?",
+    )
+    .bind(id)
     .execute(pool)
     .await?;
 
@@ -710,6 +751,107 @@ pub(crate) async fn delete_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn worker(id: &str, restart_count: u32) -> Deployment {
+        Deployment {
+            id: id.to_string(),
+            created_at: chrono::Utc::now().to_string(),
+            updated_at: None,
+            status: DeploymentStatus::Running,
+            restart_count,
+            namespace: "test".to_string(),
+            name: format!("w-{id}"),
+            image: "busybox".to_string(),
+            config: None,
+            runtime: "docker".to_string(),
+            kind: "worker".to_string(),
+            replicas: 1,
+            command: vec![],
+            instances: vec![],
+            labels: HashMap::new(),
+            environment: HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: vec![],
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: None,
+            network: None,
+        }
+    }
+
+    async fn count_in_db(pool: &SqlitePool, id: &str) -> u32 {
+        let row: (i32,) = sqlx::query_as("SELECT restart_count FROM deployment WHERE id = ?")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        row.0 as u32
+    }
+
+    #[tokio::test]
+    async fn increment_returns_new_value_and_persists() {
+        let pool = test_pool().await;
+        create(&pool, &worker("d1", 0)).await.unwrap();
+
+        assert_eq!(
+            increment_restart_count(&pool, "d1", 1).await.unwrap(),
+            1,
+            "increment returns the post-increment value"
+        );
+        assert_eq!(count_in_db(&pool, "d1").await, 1);
+
+        assert_eq!(increment_restart_count(&pool, "d1", 2).await.unwrap(), 3);
+        assert_eq!(count_in_db(&pool, "d1").await, 3);
+    }
+
+    #[tokio::test]
+    async fn reset_zeroes_the_counter() {
+        let pool = test_pool().await;
+        create(&pool, &worker("d1", 4)).await.unwrap();
+        reset_restart_count(&pool, "d1").await.unwrap();
+        assert_eq!(count_in_db(&pool, "d1").await, 0);
+    }
+
+    /// The core race the atomic fns guard against: a stale full-row `update`
+    /// (which no longer carries restart_count) interleaved with an increment must
+    /// NOT clobber the counter. Simulate it by loading a deployment, having a
+    /// second path increment the counter, then writing the stale row back — the
+    /// increment must survive.
+    #[tokio::test]
+    async fn stale_update_does_not_clobber_increment() {
+        let pool = test_pool().await;
+        create(&pool, &worker("d1", 0)).await.unwrap();
+
+        // Path A loads the row (restart_count == 0 in memory).
+        let stale = find(&pool, "d1").await.unwrap().unwrap();
+        assert_eq!(stale.restart_count, 0);
+
+        // Path B increments the counter atomically in the DB.
+        increment_restart_count(&pool, "d1", 1).await.unwrap();
+        assert_eq!(count_in_db(&pool, "d1").await, 1);
+
+        // Path A now writes its stale row back through the blind full-row update.
+        // Because `update` no longer carries restart_count, the increment stands.
+        update(&pool, &stale).await.unwrap();
+        assert_eq!(
+            count_in_db(&pool, "d1").await,
+            1,
+            "the concurrent increment must not be lost to a stale full-row write"
+        );
+    }
 
     #[test]
     fn mounts_named_volume_matches_volume_type() {

--- a/src/runtime/docker/docker_lifecycle.rs
+++ b/src/runtime/docker/docker_lifecycle.rs
@@ -28,20 +28,16 @@ fn filter_instances(
 pub struct DockerLifecycle {
     docker: Docker,
     intentional_shutdowns: IntentionalShutdowns,
-    /// Whether crash detection comes from a Docker event listener (`die`/`oom`/
-    /// `kill` → `restart_count`). Docker runs one; Podman does not (its event
-    /// stream only flows while `podman system service` is up), so for Podman the
-    /// reconcile pass must detect exited containers itself — otherwise a
-    /// crash-looping container is silently recreated forever and never reaches
-    /// `CrashLoopBackOff`. `true` for Docker, `false` for Podman.
-    events_driven: bool,
     /// Server-side host registry auth settings for this runtime, from
     /// `[server.runtime.docker]` / `[server.runtime.podman]`.
     host_auth: HostAuthSettings,
 }
 
 impl DockerLifecycle {
-    /// Docker: an event listener drives crash counting.
+    /// Crash counting is reconcile-driven for every runtime: the reconcile loop
+    /// owns `restart_count` and detects exited containers in-tick, so Docker and
+    /// Podman converge to `CrashLoopBackOff` the same way. The Docker event
+    /// listener is observational only (it logs crash causes, never the count).
     pub fn new(
         docker: Docker,
         intentional_shutdowns: IntentionalShutdowns,
@@ -50,23 +46,18 @@ impl DockerLifecycle {
         Self {
             docker,
             intentional_shutdowns,
-            events_driven: true,
             host_auth,
         }
     }
 
-    /// Podman: no event listener — the reconcile pass detects crashes instead.
+    /// Podman registers under its own key but shares the Docker-compatible
+    /// lifecycle; crash detection is identical, so this delegates to `new`.
     pub fn new_podman(
         docker: Docker,
         intentional_shutdowns: IntentionalShutdowns,
         host_auth: HostAuthSettings,
     ) -> Self {
-        Self {
-            docker,
-            intentional_shutdowns,
-            events_driven: false,
-            host_auth,
-        }
+        Self::new(docker, intentional_shutdowns, host_auth)
     }
 }
 
@@ -82,7 +73,6 @@ impl RuntimeLifecycle for DockerLifecycle {
             self.docker.clone(),
             resolved_mounts,
             self.intentional_shutdowns.clone(),
-            self.events_driven,
             self.host_auth.clone(),
         )
         .await

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -1,5 +1,6 @@
 use super::container::{create_container, remove_container};
 use super::instances::list_instances;
+use crate::hypervisor::classifier::Disposition;
 use crate::hypervisor::error::RuntimeError;
 use crate::hypervisor::types::InstanceStatus;
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
@@ -16,7 +17,6 @@ pub(crate) async fn apply(
     docker: Docker,
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
-    events_driven: bool,
     host_auth: HostAuthSettings,
 ) -> Deployment {
     let status_filter = if deployment.status == DeploymentStatus::Deleted {
@@ -41,38 +41,25 @@ pub(crate) async fn apply(
             docker,
             resolved_mounts,
             intentional_shutdowns,
-            events_driven,
             host_auth,
         )
         .await
     }
 }
 
-/// Detect containers that started then exited unexpectedly since the last
-/// reconcile, and bump `restart_count` for each so a crash loop eventually
-/// reaches `CrashLoopBackOff`.
+/// Count each unexpectedly-exited container toward `restart_count`, record the
+/// crash on the deployment's pending events, and flip to `CrashLoopBackOff` once
+/// the count reaches `MAX_RESTART_COUNT`. Returns `true` when reconciling should
+/// stop this tick — either because the bound was hit, or because an exit code is
+/// non-retryable (the worker can never start its program) and we fail fast onto
+/// the terminal status instead of burning the whole restart budget.
 ///
-/// Only used when the runtime has NO event listener (Podman). On Docker the
-/// `die`/`oom`/`kill` events already drive `restart_count`, so running this
-/// there too would double-count and contend over `IntentionalShutdowns`.
-///
-/// Operator-initiated stops (scale-down, delete, rolling update, health-check
-/// eviction) pre-mark the container in `IntentionalShutdowns`; those are
-/// consumed and skipped here so a scale-down is never mistaken for a crash. Each
-/// real crash is reaped (removed) so its `exited` state isn't re-counted on the
-/// next tick.
-async fn detect_and_count_crashes(
-    deployment: &mut Deployment,
-    docker: &Docker,
-    intentional_shutdowns: &IntentionalShutdowns,
-) {
-    let exited = list_instances(docker, deployment.id.to_string(), "exited").await;
-    for container_id in exited {
-        if intentional_shutdowns.take(&container_id).await {
-            // Operator-initiated stop — not a crash. Reap it quietly.
-            remove_container(docker.clone(), container_id).await;
-            continue;
-        }
+/// Each entry is `(container_id, exit_code)`; the exit code drives the
+/// fast-fail classification (`classify_exit_code`). Pure (no I/O) so the
+/// crash-loop convergence and the fast-fail can be unit-tested without a Docker
+/// daemon — see the tests in this module.
+fn apply_unexpected_exits(deployment: &mut Deployment, exited: &[(String, Option<i64>)]) -> bool {
+    for (container_id, exit_code) in exited {
         deployment.restart_count += 1;
         deployment.emit_event(
             "error",
@@ -84,14 +71,103 @@ async fn detect_and_count_crashes(
             "docker",
             Some("container_crashed"),
         );
-        // Reap the dead container so it is not counted again next tick.
-        remove_container(docker.clone(), container_id).await;
+
+        // Fast-fail on a non-retryable exit (127 command-not-found, 126
+        // not-executable): the container can never start its program, so
+        // retrying it up to MAX_RESTART_COUNT only delays the inevitable. Land
+        // on the terminal status now.
+        if let Disposition::Terminal(status) =
+            crate::hypervisor::classifier::classify_exit_code(*exit_code)
+        {
+            deployment.emit_event(
+                "error",
+                format!(
+                    "Container {} exited with a non-retryable code ({:?}); failing fast",
+                    &container_id[..container_id.len().min(12)],
+                    exit_code
+                ),
+                "docker",
+                Some("non_retryable_exit"),
+            );
+            deployment.status = status;
+            return true;
+        }
     }
+
+    if deployment.restart_count >= MAX_RESTART_COUNT {
+        deployment.status = DeploymentStatus::CrashLoopBackOff;
+        return true;
+    }
+    false
+}
+
+/// Detect containers that started then exited unexpectedly since the last
+/// reconcile, and bump `restart_count` for each so a crash loop eventually
+/// reaches `CrashLoopBackOff`.
+///
+/// Runs for every runtime, Docker included. The reconcile loop is the single
+/// writer of `restart_count` for worker exits: it reads the row at the start of
+/// a tick and writes it back at the end, so an async Docker-events listener that
+/// also bumped the counter would lose its update to that full-row write (the
+/// race that let a crash loop recreate forever). The events listener therefore
+/// no longer mutates `restart_count`; this in-tick path owns it for both Docker
+/// and Podman, which makes counting race-free by construction.
+///
+/// Operator-initiated stops (scale-down, delete, rolling update, health-check
+/// eviction) pre-mark the container in `IntentionalShutdowns`; those are
+/// consumed and skipped here so a scale-down is never mistaken for a crash. Each
+/// real crash is reaped (removed) so its `exited` state isn't re-counted on the
+/// next tick.
+async fn detect_and_count_crashes(
+    deployment: &mut Deployment,
+    docker: &Docker,
+    intentional_shutdowns: &IntentionalShutdowns,
+) -> bool {
+    let exited = list_instances(docker, deployment.id.to_string(), "exited").await;
+    let mut crashed = Vec::new();
+    for container_id in exited {
+        if intentional_shutdowns.take(&container_id).await {
+            // Operator-initiated stop — not a crash. Reap it quietly.
+            remove_container(docker.clone(), container_id).await;
+            continue;
+        }
+        // Capture the exit code before reaping so the crash boundary can decide
+        // retry-vs-fail-fast (e.g. 127 = bad entrypoint → never retryable).
+        let exit_code = inspect_exit_code(docker, &container_id).await;
+        // Reap the dead container so it is not counted again next tick.
+        remove_container(docker.clone(), container_id.clone()).await;
+        crashed.push((container_id, exit_code));
+    }
+
+    apply_unexpected_exits(deployment, &crashed)
+}
+
+/// Read a container's last exit code via `inspect`, or `None` when it can't be
+/// determined (inspect failed, or the daemon reports no code). `None` is treated
+/// as retryable by the classifier — we never fail fast on a missing code.
+async fn inspect_exit_code(docker: &Docker, container_id: &str) -> Option<i64> {
+    let info = docker
+        .inspect_container(container_id, None::<InspectContainerOptions>)
+        .await
+        .ok()?;
+    info.state?.exit_code
 }
 
 fn handle_create_error(deployment: &mut Deployment, err: RuntimeError, increment_restart: bool) {
+    // Decide retry-vs-give-up before mapping the message. A terminal error (the
+    // image truly doesn't exist, config is missing, the container spec is
+    // rejected) can't fix itself on a retry, so instead of bumping
+    // restart_count by one and burning five reconcile cycles, jump straight to
+    // the restart bound: the deployment converges to its terminal state on the
+    // next tick instead of five ticks from now. Transient errors still bump by
+    // one and retry within the budget, exactly as before.
+    let terminal = crate::hypervisor::classifier::classify_create_error(&err).is_terminal();
     if increment_restart {
-        deployment.restart_count += 1;
+        if terminal {
+            deployment.restart_count = MAX_RESTART_COUNT;
+        } else {
+            deployment.restart_count += 1;
+        }
     }
 
     let (status, reason, message) = match &err {
@@ -310,7 +386,6 @@ async fn handle_worker_deployment(
     docker: Docker,
     resolved_mounts: Vec<ResolvedMount>,
     intentional_shutdowns: IntentionalShutdowns,
-    events_driven: bool,
     host_auth: HostAuthSettings,
 ) -> Deployment {
     if deployment.status == DeploymentStatus::Deleted {
@@ -322,18 +397,15 @@ async fn handle_worker_deployment(
     } else if deployment.status == DeploymentStatus::CrashLoopBackOff {
         return deployment;
     } else {
-        // Runtimes without an event listener (Podman) can't learn of a
-        // started-then-exited container from a `die` event, so detect it here:
-        // count each unexpected exit toward restart_count before deciding how
-        // many to (re)create. Without this the deployment recreates a crashing
-        // container forever and never reaches CrashLoopBackOff. Re-check the
-        // restart bound right after, so we converge in the same tick.
-        if !events_driven {
-            detect_and_count_crashes(&mut deployment, &docker, &intentional_shutdowns).await;
-            if deployment.restart_count >= MAX_RESTART_COUNT {
-                deployment.status = DeploymentStatus::CrashLoopBackOff;
-                return deployment;
-            }
+        // Count every container that started then exited unexpectedly toward
+        // restart_count before deciding how many to (re)create. This runs for
+        // Docker and Podman alike: the reconcile loop owns restart_count for
+        // worker exits (single writer per tick), so detecting crashes here is
+        // race-free. Without it the deployment recreates a crashing container
+        // forever and never reaches CrashLoopBackOff. When the bound is hit we
+        // converge to CrashLoopBackOff in the same tick.
+        if detect_and_count_crashes(&mut deployment, &docker, &intentional_shutdowns).await {
+            return deployment;
         }
 
         let current_count: usize = deployment.instances.len();
@@ -375,10 +447,64 @@ async fn handle_worker_deployment(
                             Some("scale_up"),
                         );
 
+                        // Promote to Running only after confirming the container
+                        // is still alive. Docker returns Ok from `start` the
+                        // instant the daemon accepts it, before the entrypoint
+                        // has had a chance to crash — so a container that exits
+                        // immediately (bad command, missing file) was previously
+                        // reported Running for a full tick. Re-inspect: if it
+                        // already exited, leave the status in Creating/Pending so
+                        // the next tick's crash detection counts it toward
+                        // restart_count instead of flapping through Running.
+                        //
+                        // A *single* inspect right after `start` still races: the
+                        // daemon may report `Running` in the few milliseconds
+                        // before a fast `exit 1` propagates, so a doomed container
+                        // can be briefly (and wrongly) promoted. Settle first, then
+                        // inspect — by the time the window elapses an
+                        // instantly-dying container has reliably flipped to
+                        // exited, while a healthy one is unaffected beyond a sub-
+                        // second delay on its *first* promotion.
+                        //
+                        // When a readiness HC is declared, the scheduler's
+                        // readiness gate makes the final Running call anyway; this
+                        // check only closes the gap for deployments with no
+                        // readiness probe, and never overrides the gate (it can
+                        // only withhold Running, not force it).
                         if deployment.status == DeploymentStatus::Pending
                             || deployment.status == DeploymentStatus::Creating
                         {
-                            deployment.status = DeploymentStatus::Running;
+                            if let Some(container_id) = deployment.instances.last().cloned() {
+                                tokio::time::sleep(LIVENESS_SETTLE).await;
+                                let status =
+                                    check_container_status(docker.clone(), container_id).await;
+                                if confirmed_alive(&status) {
+                                    deployment.status = DeploymentStatus::Running;
+                                } else {
+                                    // The container exited inside the settle
+                                    // window. Drop its id from `instances` so it
+                                    // is not treated as a live replica: the
+                                    // scheduler's `handle_status_transitions`
+                                    // promotes Creating -> Running purely on
+                                    // "instances is non-empty", so leaving a dead
+                                    // id here would let it override this withheld
+                                    // Running. The container itself stays in Docker
+                                    // (still labelled), so the next tick's
+                                    // `detect_and_count_crashes` finds it via
+                                    // `list_instances("exited")`, counts it toward
+                                    // restart_count, and reaps it — the crash is
+                                    // never lost by this pop.
+                                    deployment.instances.pop();
+                                    deployment.emit_event(
+                                        "warning",
+                                        "Container exited immediately after start; not reporting Running yet".to_string(),
+                                        "docker",
+                                        Some("liveness_unconfirmed"),
+                                    );
+                                }
+                            } else {
+                                deployment.status = DeploymentStatus::Running;
+                            }
                         }
                     }
                     Err(err) => {
@@ -432,6 +558,25 @@ async fn handle_worker_deployment(
     deployment
 }
 
+/// How long to let a just-started container settle before the liveness inspect
+/// that gates the `Running` promotion. A single inspect issued the instant
+/// `start_container` returns races the entrypoint: the daemon can still report
+/// `Running` in the few milliseconds before a fast `exit 1` propagates, so a
+/// doomed container gets briefly (and wrongly) promoted. 750ms reliably beats
+/// that race (an instantly-dying container has flipped to exited by then)
+/// without noticeably slowing healthy promotions — it costs at most this once,
+/// on a worker's *first* promotion, and only when no readiness HC is declared
+/// (the readiness gate owns the Running call otherwise).
+const LIVENESS_SETTLE: std::time::Duration = std::time::Duration::from_millis(750);
+
+/// Whether a just-started container's inspected state confirms it is alive and
+/// may be promoted to `Running`. Only `Running` qualifies: `Completed` (exit 0)
+/// and `Failed` (non-zero / no state) both mean the entrypoint already exited,
+/// so reporting `Running` would be a lie the next reconcile tick has to undo.
+fn confirmed_alive(status: &InstanceStatus) -> bool {
+    matches!(status, InstanceStatus::Running)
+}
+
 async fn check_container_status(docker: Docker, container_id: String) -> InstanceStatus {
     let inspect_options = InspectContainerOptions { size: true };
     match docker
@@ -455,5 +600,174 @@ async fn check_container_status(docker: Docker, container_id: String) -> Instanc
             debug!("Failed to inspect container {}: {}", container_id, e);
             InstanceStatus::Failed
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn worker_running() -> Deployment {
+        Deployment {
+            id: "crash-loop".to_string(),
+            created_at: chrono::Utc::now().to_string(),
+            updated_at: None,
+            status: DeploymentStatus::Running,
+            restart_count: 0,
+            namespace: "test".to_string(),
+            name: "crasher".to_string(),
+            image: "busybox".to_string(),
+            config: None,
+            runtime: "docker".to_string(),
+            kind: "worker".to_string(),
+            replicas: 1,
+            command: vec![],
+            instances: vec![],
+            labels: HashMap::new(),
+            environment: HashMap::new(),
+            volumes: "[]".to_string(),
+            health_checks: vec![],
+            resources: None,
+            image_digest: None,
+            ports: vec![],
+            pending_events: vec![],
+            parent_id: None,
+            network: None,
+        }
+    }
+
+    /// The bug: on the Docker (`events_driven == true`) path the in-tick crash
+    /// counter was gated off (`if !events_driven`), so a worker whose container
+    /// exited every tick was recreated forever and `restart_count` never climbed
+    /// to `MAX_RESTART_COUNT`. `apply_unexpected_exits` is exactly the per-tick
+    /// counting `detect_and_count_crashes` now runs for Docker too. Drive it once
+    /// per reconcile tick with one unexpected exit and assert the deployment
+    /// reaches `CrashLoopBackOff` within `MAX_RESTART_COUNT` ticks.
+    ///
+    /// Before the fix this convergence could not happen on Docker at all (the
+    /// branch was never entered), which is the regression this guards.
+    #[test]
+    fn worker_crash_loop_reaches_crashloopbackoff_within_bound() {
+        let mut deployment = worker_running();
+
+        let mut converged_at = None;
+        for tick in 1..=(MAX_RESTART_COUNT as usize) {
+            // One container started then exited unexpectedly this tick, with a
+            // retryable exit code (None) so convergence is driven by the count,
+            // not the fast-fail path.
+            let exited = vec![(format!("container-{tick:03}"), None)];
+            let hit_bound = apply_unexpected_exits(&mut deployment, &exited);
+
+            assert_eq!(
+                deployment.restart_count, tick as u32,
+                "each unexpected exit must bump restart_count exactly once"
+            );
+
+            if hit_bound {
+                converged_at = Some(tick);
+                break;
+            }
+        }
+
+        assert_eq!(
+            converged_at,
+            Some(MAX_RESTART_COUNT as usize),
+            "must converge on the tick that reaches MAX_RESTART_COUNT, not before or never"
+        );
+        assert_eq!(deployment.restart_count, MAX_RESTART_COUNT);
+        assert_eq!(deployment.status, DeploymentStatus::CrashLoopBackOff);
+    }
+
+    /// A tick with no unexpected exits (e.g. only operator-initiated stops, which
+    /// `detect_and_count_crashes` filters out before calling this) must never
+    /// bump the counter or flip the status — otherwise a scale-down would be
+    /// mistaken for a crash.
+    #[test]
+    fn no_unexpected_exit_never_counts() {
+        let mut deployment = worker_running();
+        let hit_bound = apply_unexpected_exits(&mut deployment, &[]);
+        assert!(!hit_bound);
+        assert_eq!(deployment.restart_count, 0);
+        assert_eq!(deployment.status, DeploymentStatus::Running);
+    }
+
+    /// Counting must be idempotent across the bound: once `CrashLoopBackOff` is
+    /// reached the deployment is terminal for the worker path (the early return
+    /// in `handle_worker_deployment` stops calling this), but a single tick that
+    /// observes several exits at once must still land exactly on the count and
+    /// flip, never under-count.
+    #[test]
+    fn multiple_exits_in_one_tick_count_each() {
+        let mut deployment = worker_running();
+        let exited: Vec<(String, Option<i64>)> = (0..MAX_RESTART_COUNT)
+            .map(|i| (format!("container-{i}"), None))
+            .collect();
+        let hit_bound = apply_unexpected_exits(&mut deployment, &exited);
+        assert!(hit_bound);
+        assert_eq!(deployment.restart_count, MAX_RESTART_COUNT);
+        assert_eq!(deployment.status, DeploymentStatus::CrashLoopBackOff);
+    }
+
+    /// Fast-fail: a single exit with a non-retryable code (127 = command not
+    /// found) must land on the terminal CreateContainerError immediately, not
+    /// burn the whole restart budget. restart_count is bumped once (this was a
+    /// real exit) but convergence is driven by the classifier, not the bound.
+    #[test]
+    fn non_retryable_exit_code_fails_fast() {
+        let mut deployment = worker_running();
+        let exited = vec![("container-bad".to_string(), Some(127))];
+        let hit_bound = apply_unexpected_exits(&mut deployment, &exited);
+        assert!(hit_bound, "a non-retryable exit must stop reconciling");
+        assert_eq!(
+            deployment.status,
+            DeploymentStatus::CreateContainerError,
+            "127 fails fast onto the terminal create-container status, not CrashLoopBackOff"
+        );
+        assert_eq!(
+            deployment.restart_count, 1,
+            "the single real exit is counted, but we don't loop to MAX"
+        );
+    }
+
+    /// A retryable exit code (generic 1) on the first tick must NOT fail fast:
+    /// it counts toward the budget and keeps the deployment in a non-terminal
+    /// state so the next tick can retry.
+    #[test]
+    fn retryable_exit_code_keeps_retrying() {
+        let mut deployment = worker_running();
+        let exited = vec![("container-1".to_string(), Some(1))];
+        let hit_bound = apply_unexpected_exits(&mut deployment, &exited);
+        assert!(!hit_bound);
+        assert_eq!(deployment.restart_count, 1);
+        assert_eq!(deployment.status, DeploymentStatus::Running);
+    }
+
+    /// Liveness gate: a container still running right after start may be
+    /// promoted to Running...
+    #[test]
+    fn confirmed_alive_only_for_running() {
+        assert!(confirmed_alive(&InstanceStatus::Running));
+    }
+
+    /// ...but one that already exited (cleanly or not) must NOT be reported
+    /// Running — that's the immediate-exit window Phase 4 closes. The
+    /// `LIVENESS_SETTLE` delay before the inspect is what guarantees a
+    /// fast-exiting container is observed in one of these states (Completed for
+    /// exit 0, Failed for non-zero / no state) rather than a transient Running.
+    #[test]
+    fn not_alive_when_already_exited() {
+        assert!(!confirmed_alive(&InstanceStatus::Completed));
+        assert!(!confirmed_alive(&InstanceStatus::Failed));
+    }
+
+    /// The settle window must be long enough to beat the start/exit race yet
+    /// short enough not to drag healthy first-promotions. Guards against an
+    /// accidental edit to 0 (no settle → race returns) or a multi-second value
+    /// that would visibly slow healthy workers.
+    #[test]
+    fn liveness_settle_is_within_a_sane_range() {
+        assert!(LIVENESS_SETTLE >= std::time::Duration::from_millis(500));
+        assert!(LIVENESS_SETTLE <= std::time::Duration::from_millis(1000));
     }
 }

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -973,8 +973,22 @@ impl FirecrackerLifecycle {
         }
 
         deployment.instances = self.scan_instances(&deployment.id);
-        if deployment.status != DeploymentStatus::CreateContainerError {
-            deployment.status = DeploymentStatus::Running;
+
+        // Promote to Running only after confirming at least one instance is
+        // genuinely alive (API socket on disk AND a live firecracker process).
+        // `start_vm` returning Ok means the boot was *accepted*, not that the
+        // guest stayed up — a VM that crashes right after boot leaves a stale
+        // socket, which `scan_instances` alone would mistake for a healthy
+        // instance and wrongly report Running. Gating on `instance_alive` closes
+        // that window; if nothing is alive we leave the prior status (typically
+        // Creating) so the deployment reconciles again next tick instead of
+        // flapping through a false Running.
+        let any_alive = deployment
+            .instances
+            .iter()
+            .any(|id| self.instance_alive(id));
+        if let Some(status) = liveness_confirmed_status(&deployment.status, any_alive) {
+            deployment.status = status;
         }
         deployment
     }
@@ -1111,6 +1125,24 @@ fn classify_vm_start_error(e: &RuntimeError) -> (Option<DeploymentStatus>, &'sta
         ),
         _ => (None, "VmStartFailed"),
     }
+}
+
+/// Decide the post-scale worker status from the current status and whether any
+/// instance is genuinely alive. Returns `Some(Running)` only when liveness is
+/// confirmed; `None` leaves the status untouched (so a VM that booted then died
+/// is not falsely reported Running, and an existing status — including a prior
+/// `CreateContainerError` from a failed `start_vm` — is preserved).
+///
+/// `start_vm` returning Ok means the boot was *accepted*, not that the guest
+/// stayed up; this gate is what makes "Running" mean "actually running".
+fn liveness_confirmed_status(
+    current: &DeploymentStatus,
+    any_alive: bool,
+) -> Option<DeploymentStatus> {
+    if *current == DeploymentStatus::CreateContainerError {
+        return None;
+    }
+    any_alive.then_some(DeploymentStatus::Running)
 }
 
 /// Find the PID of the `firecracker` process bound to `socket_path`, by scanning
@@ -1515,6 +1547,35 @@ impl FirecrackerLifecycle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A confirmed-alive instance promotes a fresh deployment to Running.
+    #[test]
+    fn liveness_confirmed_promotes_to_running() {
+        assert_eq!(
+            liveness_confirmed_status(&DeploymentStatus::Creating, true),
+            Some(DeploymentStatus::Running)
+        );
+    }
+
+    /// A VM that booted then died (nothing alive) must NOT be reported Running:
+    /// the status is left untouched so the deployment reconciles again.
+    #[test]
+    fn no_live_instance_does_not_promote() {
+        assert_eq!(
+            liveness_confirmed_status(&DeploymentStatus::Creating, false),
+            None
+        );
+    }
+
+    /// A failed `start_vm` (CreateContainerError) is never overwritten by the
+    /// liveness gate, even if a stale socket made `any_alive` look true.
+    #[test]
+    fn create_error_is_preserved() {
+        assert_eq!(
+            liveness_confirmed_status(&DeploymentStatus::CreateContainerError, true),
+            None
+        );
+    }
 
     #[test]
     fn scan_instances_reads_disk_not_memory() {

--- a/src/scheduler/healthy_window.rs
+++ b/src/scheduler/healthy_window.rs
@@ -1,0 +1,180 @@
+//! Windowed reset of a deployment's `restart_count`.
+//!
+//! `restart_count` is otherwise monotonic for the life of a deployment: a worker
+//! that crashed a few times early on, then ran healthy for weeks, keeps the old
+//! count, so the next single crash trips `CrashLoopBackOff`. That turns the
+//! intended "5 crashes within a window" semantics into "5 crashes ever".
+//!
+//! This tracker watches how long a worker has been continuously `Running` with a
+//! non-zero `restart_count`. Once it has stayed healthy for at least the
+//! anti-flap window (`min_healthy_time`, same window the rollout readiness gate
+//! uses), the count is reset to 0 — the crash budget refills.
+//!
+//! State is in-memory and non-persistent, like [`super::backoff::RetryBackoff`]:
+//! at process restart the clock starts over, which is safe (a still-crashing
+//! worker re-crashes and never accrues the window; a healthy one simply takes
+//! one window longer to have its old count forgiven).
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Per-deployment "continuously running since" clock, scoped to deployments
+/// whose `restart_count` is non-zero (a zero count needs no reset).
+#[derive(Default)]
+pub(crate) struct HealthyWindow {
+    /// `deployment_id -> (running_since, restart_count_observed_at_that_time)`.
+    running_since: HashMap<String, (Instant, u32)>,
+}
+
+impl HealthyWindow {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record this tick's observation and decide whether `restart_count` should
+    /// be reset to 0. Returns `true` exactly once, on the tick where the worker
+    /// has been continuously `Running` (with an unchanged non-zero count) for at
+    /// least `window`; the caller is then responsible for persisting the reset.
+    ///
+    /// The clock restarts whenever the worker is not `Running` or its
+    /// `restart_count` changed since the last observation (a fresh crash), so
+    /// only an uninterrupted healthy stretch counts toward the window.
+    pub(crate) fn observe(
+        &mut self,
+        deployment_id: &str,
+        is_running: bool,
+        restart_count: u32,
+        window: Duration,
+    ) -> bool {
+        // Nothing to forgive, and not healthy-running: drop any clock and move on.
+        if restart_count == 0 || !is_running {
+            self.running_since.remove(deployment_id);
+            return false;
+        }
+
+        let now = Instant::now();
+        match self.running_since.get(deployment_id).copied() {
+            // Same count, still running: the window keeps accruing.
+            Some((since, observed)) if observed == restart_count => {
+                if now.duration_since(since) >= window {
+                    self.running_since.remove(deployment_id);
+                    return true;
+                }
+                false
+            }
+            // First healthy observation, or the count moved (a fresh crash):
+            // (re)start the clock from now.
+            _ => {
+                self.running_since
+                    .insert(deployment_id.to_string(), (now, restart_count));
+                false
+            }
+        }
+    }
+
+    /// Forget a deployment (deleted, or its count was reset elsewhere).
+    pub(crate) fn clear(&mut self, deployment_id: &str) {
+        self.running_since.remove(deployment_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WINDOW: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn zero_count_never_resets() {
+        let mut w = HealthyWindow::new();
+        assert!(!w.observe("d1", true, 0, WINDOW));
+    }
+
+    #[test]
+    fn not_running_clears_the_clock() {
+        let mut w = HealthyWindow::new();
+        // Start the clock while running with a non-zero count.
+        assert!(!w.observe("d1", true, 4, WINDOW));
+        // A non-running tick must drop the clock so a later running stretch
+        // starts fresh, not from the original timestamp.
+        assert!(!w.observe("d1", false, 4, WINDOW));
+        assert!(!w.running_since.contains_key("d1"));
+    }
+
+    #[test]
+    fn resets_after_window_with_stable_count() {
+        let mut w = HealthyWindow::new();
+        // First observation arms the clock in the past so the window has elapsed.
+        w.running_since
+            .insert("d1".to_string(), (Instant::now() - WINDOW, 4));
+        assert!(w.observe("d1", true, 4, WINDOW));
+        // And it only fires once: the entry is gone afterwards.
+        assert!(!w.running_since.contains_key("d1"));
+    }
+
+    #[test]
+    fn does_not_reset_before_window() {
+        let mut w = HealthyWindow::new();
+        // Clock just armed: well within the window, no reset yet.
+        assert!(!w.observe("d1", true, 4, WINDOW));
+        assert!(!w.observe("d1", true, 4, WINDOW));
+    }
+
+    #[test]
+    fn a_fresh_crash_restarts_the_clock() {
+        let mut w = HealthyWindow::new();
+        // Healthy for a full window with count=4 would normally reset...
+        w.running_since
+            .insert("d1".to_string(), (Instant::now() - WINDOW, 4));
+        // ...but the count moved to 5 this tick (a new crash): the window must
+        // restart from now, so this tick does NOT reset.
+        assert!(!w.observe("d1", true, 5, WINDOW));
+        let (_, observed) = *w.running_since.get("d1").unwrap();
+        assert_eq!(observed, 5);
+    }
+
+    /// End-to-end Phase 1 semantics: a worker crashes its way up to count=4,
+    /// then runs healthy. Within the window no reset fires; once it has been
+    /// continuously healthy past the window the count is forgiven (reset → true).
+    #[test]
+    fn crash_four_times_then_healthy_past_window_resets() {
+        let mut w = HealthyWindow::new();
+
+        // Four crashes: each is a fresh count, so the clock keeps restarting and
+        // never resets while the worker is still crashing.
+        for count in 1..=4 {
+            assert!(!w.observe("d1", true, count, WINDOW));
+        }
+
+        // Healthy stretch begins at count=4. Just inside the window: no reset.
+        assert!(!w.observe("d1", true, 4, WINDOW));
+
+        // Backdate the clock so the window has fully elapsed with a stable count.
+        let (_, observed) = *w.running_since.get("d1").unwrap();
+        w.running_since
+            .insert("d1".to_string(), (Instant::now() - WINDOW, observed));
+
+        // Now healthy past the window: the budget refills.
+        assert!(w.observe("d1", true, 4, WINDOW));
+    }
+
+    /// Crashes that keep arriving inside the window never reset, so the count is
+    /// free to climb to the CrashLoopBackOff bound — the reset can't mask a loop.
+    #[test]
+    fn crashes_within_window_never_reset() {
+        let mut w = HealthyWindow::new();
+        for count in 1..=5 {
+            // Even if a stale clock from a prior count had elapsed, a changed
+            // count restarts it, so no reset ever fires mid-loop.
+            assert!(!w.observe("d1", true, count, WINDOW));
+        }
+    }
+
+    #[test]
+    fn clear_drops_the_entry() {
+        let mut w = HealthyWindow::new();
+        w.observe("d1", true, 3, WINDOW);
+        w.clear("d1");
+        assert!(!w.running_since.contains_key("d1"));
+    }
+}

--- a/src/scheduler/intentional_shutdowns.rs
+++ b/src/scheduler/intentional_shutdowns.rs
@@ -3,21 +3,23 @@
 //!
 //! # Why
 //!
-//! Docker emits a `die` event whenever a container stops, regardless of cause:
-//! a crash, an OOM kill, but also a graceful `docker stop` we sent ourselves.
-//! The scheduler reacts to `die` by bumping `restart_count` on the deployment;
-//! once `restart_count` reaches `MAX_RESTART_COUNT` it flips to
+//! A container that stops shows up two ways: Docker emits a `die` event, and the
+//! reconcile pass sees it as an `exited` instance. Either can stem from a crash,
+//! an OOM kill, or a graceful `docker stop` we sent ourselves. The reconcile
+//! pass (`detect_and_count_crashes`) counts each unexpected exit toward
+//! `restart_count`; once it reaches `MAX_RESTART_COUNT` the deployment flips to
 //! `CrashLoopBackOff`. Without this filter, every scale-down, delete, rolling
-//! update step or health-check eviction would count as a crash and could push
-//! a perfectly healthy deployment into `CrashLoopBackOff`.
+//! update step or health-check eviction would be counted as a crash and could
+//! push a perfectly healthy deployment into `CrashLoopBackOff`.
 //!
 //! # How it works
 //!
 //! Before the runtime stops a container on purpose, it calls
-//! [`IntentionalShutdowns::mark`] with the container id. When the matching
-//! `die` event reaches `apply_docker_event`, the scheduler calls
-//! [`IntentionalShutdowns::take`]: if the id was marked, the event is skipped
-//! and the entry is consumed.
+//! [`IntentionalShutdowns::mark`] with the container id. Two consumers call
+//! [`IntentionalShutdowns::take`]: `detect_and_count_crashes` skips the exited
+//! container so it is reaped without bumping `restart_count`, and
+//! `apply_docker_event` skips the matching `die` event so it is not logged as a
+//! crash. The first to observe the stop consumes the entry.
 //!
 //! # Where to mark
 //!
@@ -28,7 +30,8 @@
 //!   (`runtime/docker/docker_lifecycle.rs`)
 //!
 //! Do NOT mark a container when the *container itself* failed (a real crash,
-//! an OOM, an exit). Those must reach `bump_restart_count`.
+//! an OOM, an exit). Those must reach `detect_and_count_crashes` so they count
+//! toward `restart_count`.
 //!
 //! # TTL
 //!

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod backoff;
 pub(crate) mod docker_events;
 pub(crate) mod event_worker;
 pub(crate) mod health_checker;
+pub(crate) mod healthy_window;
 pub(crate) mod intentional_shutdowns;
 pub(crate) mod scheduler;
 pub(crate) mod stats_cache;

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -11,6 +11,7 @@ use crate::models::volume::ResolvedMount;
 use crate::scheduler::backoff::RetryBackoff;
 use crate::scheduler::docker_events::DockerEvent;
 use crate::scheduler::health_checker::HealthChecker;
+use crate::scheduler::healthy_window::HealthyWindow;
 use crate::scheduler::intentional_shutdowns::IntentionalShutdowns;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -1030,9 +1031,8 @@ async fn apply_docker_event(
         } => {
             // Operator-initiated shutdowns (scale-down, delete, rolling update,
             // health-check kill) are pre-marked in `IntentionalShutdowns` by the
-            // runtime before it issues the stop. The matching `die` event must
-            // therefore NOT bump `restart_count` — otherwise we'd flip a healthy
-            // deployment into CrashLoopBackOff just for being scaled down.
+            // runtime before it issues the stop. The matching `die` event for
+            // those is consumed here so it never reaches the crash trace below.
             if intentional_shutdowns.take(&container_id).await {
                 debug!(
                     "Ignoring die event for {} (intentional shutdown)",
@@ -1040,9 +1040,18 @@ async fn apply_docker_event(
                 );
                 return;
             }
-            bump_restart_count(
+            // The reconcile loop owns `restart_count` for worker exits: it reads
+            // the deployment at the start of a tick and writes the full row back
+            // at the end, so a bump issued here would be lost to that write (the
+            // race that let crash loops recreate forever and never reach
+            // CrashLoopBackOff). `detect_and_count_crashes` now counts the same
+            // exited container in-tick for both Docker and Podman. This branch is
+            // therefore log-only — it records the crash cause for traceability
+            // without mutating the counter.
+            if let Err(e) = deployment_event::log_event(
                 pool,
-                &deployment_id,
+                deployment_id,
+                "warning",
                 format!(
                     "Container {} died (exit_code={})",
                     container_id,
@@ -1050,9 +1059,13 @@ async fn apply_docker_event(
                         .map(|c| c.to_string())
                         .unwrap_or_else(|| "?".to_string()),
                 ),
-                "ContainerDied",
+                "docker-events",
+                Some("container_died"),
             )
-            .await;
+            .await
+            {
+                warn!("Failed to log die event: {}", e);
+            }
         }
         DockerEvent::ContainerOom {
             deployment_id,
@@ -1105,52 +1118,6 @@ async fn apply_docker_event(
     }
 }
 
-async fn bump_restart_count(pool: &SqlitePool, deployment_id: &str, message: String, reason: &str) {
-    let mut deployment = match deployments::find(pool, deployment_id).await {
-        Ok(Some(d)) => d,
-        Ok(None) => {
-            // Container belonged to a deployment that has since been deleted — ignore.
-            debug!("Ignoring event for unknown deployment {}", deployment_id);
-            return;
-        }
-        Err(e) => {
-            error!(
-                "Failed to load deployment {} on event: {}",
-                deployment_id, e
-            );
-            return;
-        }
-    };
-
-    // Don't keep counting once we've already given up — saves DB writes when a
-    // doomed deployment keeps emitting events.
-    if deployment.status == DeploymentStatus::CrashLoopBackOff {
-        return;
-    }
-
-    deployment.restart_count += 1;
-    if let Err(e) = deployments::update(pool, &deployment).await {
-        error!(
-            "Failed to persist restart_count for deployment {}: {}",
-            deployment_id, e
-        );
-        return;
-    }
-
-    if let Err(e) = deployment_event::log_event(
-        pool,
-        deployment_id.to_string(),
-        "warning",
-        format!("{} — restart_count={}", message, deployment.restart_count),
-        "docker-events",
-        Some(reason),
-    )
-    .await
-    {
-        warn!("Failed to log crash event for {}: {}", deployment_id, e);
-    }
-}
-
 pub(crate) async fn schedule(
     pool: SqlitePool,
     config: crate::config::config::Config,
@@ -1183,6 +1150,11 @@ pub(crate) async fn schedule(
     // (Docker, Cloud Hypervisor, future Firecracker, ...) automatically gets
     // exponential backoff on transient failures without duplicating the logic.
     let mut backoff = RetryBackoff::new();
+
+    // Per-deployment "continuously healthy since" clock. Resets a worker's
+    // restart_count once it has run uninterrupted for the anti-flap window, so
+    // the crash budget is "N crashes within a window", not "N crashes for life".
+    let mut healthy_window = HealthyWindow::new();
 
     info!(
         "Starting scheduler with interval: {}s, apply timeout: {}s",
@@ -1270,6 +1242,7 @@ pub(crate) async fn schedule(
             // deployment and go straight to cleanup.
             if deployment.status == DeploymentStatus::Deleted {
                 backoff.clear(&deployment.id);
+                healthy_window.clear(&deployment.id);
                 let mut result = match apply_runtime(
                     &pool,
                     &deployment,
@@ -1422,6 +1395,25 @@ pub(crate) async fn schedule(
                 None => continue,
             };
 
+            // Persist any restart_count bump the runtime made through a targeted
+            // atomic `+= delta` rather than the blind full-row `update` below.
+            // The blind write reads the row at tick start and rewrites it whole,
+            // so two paths touching the counter would clobber each other
+            // (last-writer-wins). The atomic statement folds the delta into the
+            // DB's current value, so no increment is ever lost. The in-memory
+            // count is then realigned to the persisted truth for the backoff and
+            // healthy-window decisions below.
+            if result.restart_count > restart_count_before {
+                let delta = result.restart_count - restart_count_before;
+                match deployments::increment_restart_count(&pool, &result.id, delta).await {
+                    Ok(persisted) => result.restart_count = persisted,
+                    Err(e) => error!(
+                        "Failed to increment restart_count for deployment {}: {}",
+                        result.id, e
+                    ),
+                }
+            }
+
             // Translate the runtime's outcome into a backoff decision.
             // A bumped restart_count means the runtime hit a transient
             // failure — arm the next retry. Otherwise (success, terminal
@@ -1471,6 +1463,45 @@ pub(crate) async fn schedule(
             // Log the creating -> running transition only now that the status
             // for this cycle is settled (the gate above may have reverted it).
             log_running_transition(&pool, &old_status, &result).await;
+
+            // Refill the crash budget: once a worker has run continuously
+            // healthy for the anti-flap window, forgive its accrued
+            // restart_count. Without this the count is monotonic for life, so a
+            // worker that crashed a few times months ago trips CrashLoopBackOff
+            // on its next single crash. Crashes *within* the window still bump
+            // the count and converge (the window restarts on every fresh crash),
+            // so this never masks a real crash loop. Scoped to workers — jobs
+            // converge to Failed, not a windowed budget.
+            if result.kind == "worker"
+                && healthy_window.observe(
+                    &result.id,
+                    result.status == DeploymentStatus::Running,
+                    result.restart_count,
+                    min_healthy_time_for(&result),
+                )
+            {
+                info!(
+                    "Deployment {} healthy for the anti-flap window; resetting restart_count from {} to 0",
+                    result.id, result.restart_count
+                );
+                // Targeted reset, same reasoning as the atomic increment above:
+                // never let a stale full-row write resurrect the old count.
+                if let Err(e) = deployments::reset_restart_count(&pool, &result.id).await {
+                    error!(
+                        "Failed to reset restart_count for deployment {}: {}",
+                        result.id, e
+                    );
+                } else {
+                    result.restart_count = 0;
+                    result.emit_event(
+                        "info",
+                        "restart_count reset to 0 after staying healthy".to_string(),
+                        "scheduler",
+                        Some("restart_count_reset"),
+                    );
+                    persist_pending_events(&pool, &mut result).await;
+                }
+            }
 
             if let Err(e) = deployments::update(&pool, &result).await {
                 error!("Failed to update deployment {}: {}", result.id, e);

--- a/tests/e2e/docker/t39_git_auth_crashloop_converges.sh
+++ b/tests/e2e/docker/t39_git_auth_crashloop_converges.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# T39: THE production case. A container whose entrypoint fails like a git clone
+# auth failure (writes "fatal: Authentication failed" and exits 128) must
+# converge to CrashLoopBackOff and STOP being recreated — not loop forever.
+#
+# This is the exact shape of the bug that bit us in prod: exit 128 is the real
+# git auth exit code, and per the classifier 128 is RETRYABLE, so this can only
+# converge via the restart-count path (it is NOT short-circuited by the
+# fast-fail terminal classification). If the in-tick crash counter regresses,
+# restart_count stays low, the scheduler recreates the container every tick, and
+# containers pile up without bound. This test would have caught that.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T39: git-auth-style crash loop must converge to CrashLoopBackOff =="
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/git-auth-crashloop.yaml"
+
+# Give the scheduler time to react. With a 1s scheduler interval, 90s leaves
+# comfortable headroom for restart_count to climb past MAX_RESTART_COUNT (5)
+# through the restart-count path (128 is retryable, not fast-failed).
+log "waiting 90s for the scheduler to react to repeated exit-128 crashes..."
+sleep 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "git-auth-crashloop")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+# Count every container ever created for this deployment (running + exited).
+TOTAL_CONTAINERS=$(docker ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+RESTART_COUNT=$(get_restart_count "ring-e2e" "git-auth-crashloop")
+STATUS=$("$RING_BIN" deployment list --output json \
+  | jq -r --arg ns "ring-e2e" --arg n "git-auth-crashloop" \
+      '.[] | select(.namespace==$ns and .name==$n) | .status' \
+  | head -n1)
+
+log "observed: total_containers=$TOTAL_CONTAINERS restart_count=$RESTART_COUNT status=$STATUS"
+
+# 1) restart_count must reach MAX_RESTART_COUNT (5) — it is counted via the
+#    retryable restart-count path, exactly like prod.
+if [ "${RESTART_COUNT:-0}" -lt 5 ]; then
+  fail "expected restart_count >= 5, got $RESTART_COUNT (exit-128 crashes are not being counted)"
+fi
+
+# 2) The deployment must converge to CrashLoopBackOff and STOP recreating.
+if [ "$STATUS" != "crash_loop_back_off" ]; then
+  fail "expected status crash_loop_back_off, got '$STATUS'"
+fi
+
+# 3) Total containers ever spawned must stay bounded. Without the cap this grows
+#    linearly with time (one new container per tick = ~90 over this window).
+if [ "$TOTAL_CONTAINERS" -gt 10 ]; then
+  fail "too many containers spawned ($TOTAL_CONTAINERS) — restart loop is not bounded (prod bug)"
+fi
+
+log "== T39: PASS =="

--- a/tests/e2e/docker/t40_windowed_restart_count_reset.sh
+++ b/tests/e2e/docker/t40_windowed_restart_count_reset.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# T40: Phase 1 windowed restart_count reset. A worker that crashes a few times
+# (N < MAX_RESTART_COUNT) and then runs healthy past the anti-flap window must
+# have its restart_count forgiven (reset to 0), so an isolated later crash
+# doesn't trip CrashLoopBackOff.
+#
+# Docker re-runs the SAME command on every (re)spawn, so the "crash then heal"
+# behaviour is driven by state on a host bind mount: each start increments a
+# counter; while count <= 3 the container exits 1 (counted as a crash); on the
+# 4th start it stays up and sleeps forever. We key the crash phase off
+# restart_count (NOT the status) on purpose: a container that exits immediately
+# can momentarily be reported `running` before the exit propagates, so status is
+# an unreliable signal during the crash phase. restart_count is the durable
+# truth — it climbs to 3, the worker then stays up, and after the healthy window
+# the scheduler resets restart_count back to 0.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T40: restart_count is forgiven after a healthy window =="
+
+# Host-side state directory the container increments a counter in. Start clean
+# so the counter begins at 0 even across re-runs of this test.
+STATE_DIR="/tmp/ring-e2e-t40"
+rm -rf "$STATE_DIR"
+mkdir -p "$STATE_DIR"
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/crash-then-heal.yaml"
+
+# Phase 1: the container crashes 3 times. Wait for restart_count to reach 3,
+# which proves the crash phase registered. It must stop at 3 (the 4th start
+# stays up), well short of MAX_RESTART_COUNT (5) — otherwise we couldn't test a
+# *windowed* reset, only a CrashLoopBackOff.
+log "waiting for the crash phase to accrue restart_count=3..."
+REACHED=0
+for _ in $(seq 1 60); do
+  RC=$(get_restart_count "ring-e2e" "crash-then-heal")
+  if [ "${RC:-0}" -ge 3 ]; then
+    REACHED=1
+    break
+  fi
+  sleep 1
+done
+if [ "$REACHED" -ne 1 ]; then
+  fail "restart_count never reached 3 during the crash phase (last: ${RC:-0})"
+fi
+log "crash phase registered: restart_count=$RC"
+
+# It must not have blown past the CrashLoopBackOff bound; if it did, the windowed
+# reset can't be exercised.
+if [ "${RC:-0}" -ge 5 ]; then
+  fail "restart_count reached the CrashLoopBackOff bound ($RC); cannot test the windowed reset"
+fi
+
+# Phase 2: the 4th container stays up (sleep 3600). Wait for it to be Running
+# and STAY Running, then let the anti-flap window (DEFAULT_MIN_HEALTHY_TIME=10s)
+# elapse so the scheduler forgives the accrued count. 40s is generous headroom.
+log "waiting 40s for the worker to stay healthy past the window and forgive restart_count..."
+sleep 40
+
+RESTART_AFTER_WINDOW=$(get_restart_count "ring-e2e" "crash-then-heal")
+STATUS=$("$RING_BIN" deployment list --output json \
+  | jq -r --arg ns "ring-e2e" --arg n "crash-then-heal" \
+      '.[] | select(.namespace==$ns and .name==$n) | .status' \
+  | head -n1)
+
+log "observed: restart_count_after_window=$RESTART_AFTER_WINDOW status=$STATUS"
+
+# Must be Running now (the 4th container slept; it didn't crash again).
+if [ "$STATUS" != "running" ]; then
+  fail "expected status running after the healthy window, got '$STATUS'"
+fi
+
+# The crash budget must have refilled: restart_count forgiven back to 0.
+if [ "${RESTART_AFTER_WINDOW:-99}" -ne 0 ]; then
+  fail "expected restart_count reset to 0 after the healthy window, got $RESTART_AFTER_WINDOW (Phase 1 reset did not fire)"
+fi
+
+log "== T40: PASS =="

--- a/tests/e2e/docker/t41_fast_fail_exit_127.sh
+++ b/tests/e2e/docker/t41_fast_fail_exit_127.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# T41: Phase 3 fast-fail on a non-retryable exit code. A container that RUNS but
+# exec's a binary that doesn't exist exits 127 (command not found). 127 is
+# Terminal in the classifier, so the deployment must fail FAST — jump straight
+# to a terminal status without burning all MAX_RESTART_COUNT (5) restart cycles.
+#
+# This is distinct from t23: there Docker `start` itself fails (a create/start
+# boundary error). Here `create`/`start` succeed and the container actually runs;
+# it is the EXIT CODE at the crash boundary (127) that is non-retryable. We
+# assert convergence happens in noticeably FEWER cycles than the full
+# crash-loop path: very few containers spawned, and restart_count does not have
+# to climb tick-by-tick to 5.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T41: exit 127 must fail fast, not burn the whole restart budget =="
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/command-not-found.yaml"
+
+# Fast-fail should land on a terminal status within a handful of ticks. 30s is
+# far short of the ~5+ ticks the slow restart-count path needs but is generous
+# for the fast path; it also lets us assert "few containers spawned" before a
+# slow loop could have created many.
+log "waiting 30s for the fast-fail terminal convergence..."
+sleep 30
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "command-not-found")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+TOTAL_CONTAINERS=$(docker ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+RESTART_COUNT=$(get_restart_count "ring-e2e" "command-not-found")
+STATUS=$("$RING_BIN" deployment list --output json \
+  | jq -r --arg ns "ring-e2e" --arg n "command-not-found" \
+      '.[] | select(.namespace==$ns and .name==$n) | .status' \
+  | head -n1)
+
+log "observed: total_containers=$TOTAL_CONTAINERS restart_count=$RESTART_COUNT status=$STATUS"
+
+# 1) Must have reached a terminal status quickly. The classifier maps a 127 exit
+#    to CreateContainerError; CrashLoopBackOff is also acceptable as a terminal
+#    convergence, but the point is it must be terminal, not still trying.
+case "$STATUS" in
+  create_container_error|crash_loop_back_off) ;;
+  *) fail "expected a terminal status (create_container_error / crash_loop_back_off) via fast-fail, got '$STATUS'" ;;
+esac
+
+# 2) Fast-fail means FEWER containers spawned than the slow path. The slow path
+#    (counting one crash per tick to 5) would spawn at least ~5 containers over
+#    several ticks; the fast path lands terminal almost immediately. Require the
+#    count to stay small.
+if [ "$TOTAL_CONTAINERS" -gt 3 ]; then
+  fail "too many containers spawned ($TOTAL_CONTAINERS) — exit 127 is NOT failing fast (burning restart cycles)"
+fi
+
+log "== T41: PASS =="

--- a/tests/e2e/docker/t42_liveness_never_running.sh
+++ b/tests/e2e/docker/t42_liveness_never_running.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# T42: Phase 4 liveness-confirmed Running. A container that dies ~immediately
+# after start must NEVER be reported `running`.
+#
+# Docker returns Ok from `start` the instant the daemon accepts the container,
+# before its entrypoint has had a chance to crash. Without the liveness
+# re-inspect, a container that exits immediately (here `sh -c "exit 1"`) was
+# promoted to Running for a full reconcile tick before flipping — a lie the next
+# tick had to undo. With the fix the scheduler re-inspects after start and only
+# reports Running once the container is confirmed alive, so this deployment is
+# only ever observed as creating/pending (or, once it has crashed enough,
+# crash_loop_back_off) — never `running`.
+#
+# We poll the status tightly right after apply and record every distinct value
+# observed. The assertion is that `running` is never among them.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T42: an instantly-dying container must never be reported Running =="
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/instant-exit.yaml"
+
+# Poll the status tightly for ~40s. The scheduler interval is 1s and the
+# container exits within milliseconds of each start, so if the early-success
+# Running window were still open we'd catch a `running` reading on essentially
+# every tick. Sub-second polling makes the catch reliable, not racy: the bug
+# would expose a Running snapshot for a whole tick (~1s), far longer than our
+# poll period.
+OBSERVED=""
+SAW_RUNNING=0
+DEADLINE=$(( $(date +%s) + 40 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  STATUS=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg ns "ring-e2e" --arg n "instant-exit" \
+        '.[] | select(.namespace==$ns and .name==$n) | .status' \
+    | head -n1)
+  if [ -n "$STATUS" ]; then
+    case " $OBSERVED " in
+      *" $STATUS "*) ;;
+      *) OBSERVED="$OBSERVED $STATUS"; log "observed status: $STATUS" ;;
+    esac
+    if [ "$STATUS" = "running" ]; then
+      SAW_RUNNING=1
+      break
+    fi
+    # Once it has converged to crash_loop_back_off it will never go Running, so
+    # we can stop early.
+    if [ "$STATUS" = "crash_loop_back_off" ]; then
+      break
+    fi
+  fi
+  sleep 0.2
+done
+
+log "distinct statuses observed:${OBSERVED:- <none>}"
+
+# 1) Running must never have been observed for an instantly-dying container.
+if [ "$SAW_RUNNING" -eq 1 ]; then
+  fail "deployment was reported 'running' despite the container dying immediately — Phase 4 liveness gate is open"
+fi
+
+# 2) Sanity: it must converge to crash_loop_back_off (it keeps crashing). Give
+#    it the remaining time to reach the bound if it hasn't already.
+wait_deployment_status "ring-e2e" "instant-exit" "crash_loop_back_off" 90
+
+log "== T42: PASS =="

--- a/tests/e2e/fixtures/command-not-found.yaml
+++ b/tests/e2e/fixtures/command-not-found.yaml
@@ -1,0 +1,15 @@
+deployments:
+  command-not-found:
+    name: command-not-found
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Phase 3 fast-fail. The image and the `sh` entrypoint exist, so Docker
+    # `create` and `start` both succeed and the container actually RUNS — but
+    # the program it tries to exec does not exist, so the container EXITS with
+    # code 127 (command not found) at the crash boundary. 127 is Terminal in the
+    # classifier, so this must fail fast onto a terminal status without burning
+    # all MAX_RESTART_COUNT restart cycles. This is distinct from t23, where
+    # Docker `start` itself fails (a create/start-boundary error, not an exit).
+    command: ["sh", "-c", "exec this-binary-truly-does-not-exist"]
+    replicas: 1

--- a/tests/e2e/fixtures/crash-then-heal.yaml
+++ b/tests/e2e/fixtures/crash-then-heal.yaml
@@ -1,0 +1,25 @@
+deployments:
+  crash-then-heal:
+    name: crash-then-heal
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Phase 1 windowed restart_count reset. Docker re-runs the SAME command on
+    # every (re)spawn, so the "crash a few times then stay healthy" behaviour is
+    # driven by state on a host bind mount: each start increments a counter in
+    # /state/count. While count <= 3 the container exits 1 (a crash Ring counts
+    # toward restart_count); on the 4th start it stops crashing and sleeps
+    # forever (stays Running). Once it has been continuously Running past the
+    # anti-flap window (DEFAULT_MIN_HEALTHY_TIME = 10s), the scheduler forgives
+    # the accrued restart_count and resets it to 0.
+    command:
+      - "sh"
+      - "-c"
+      - 'n=$(cat /state/count 2>/dev/null || echo 0); n=$((n+1)); echo $n > /state/count; if [ "$n" -le 3 ]; then echo "crash #$n" >&2; exit 1; fi; echo "healthy after $n starts"; exec sleep 3600'
+    replicas: 1
+    volumes:
+      - type: bind
+        source: /tmp/ring-e2e-t40
+        destination: /state
+        driver: local
+        permission: rw

--- a/tests/e2e/fixtures/git-auth-crashloop.yaml
+++ b/tests/e2e/fixtures/git-auth-crashloop.yaml
@@ -1,0 +1,14 @@
+deployments:
+  git-auth-crashloop:
+    name: git-auth-crashloop
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Reproduces the production case: an entrypoint that fails like a git clone
+    # against a repo it can't authenticate to. `git` exits 128 on an auth
+    # failure, and 128 is RETRYABLE per the exit-code classifier, so the only
+    # way this converges is the restart-count path — exactly the prod bug:
+    # the container must reach CrashLoopBackOff after MAX_RESTART_COUNT and
+    # STOP being recreated, not loop forever.
+    command: ["sh", "-c", "echo 'fatal: Authentication failed for https://example.com/private.git' >&2; exit 128"]
+    replicas: 1

--- a/tests/e2e/fixtures/instant-exit.yaml
+++ b/tests/e2e/fixtures/instant-exit.yaml
@@ -1,0 +1,15 @@
+deployments:
+  instant-exit:
+    name: instant-exit
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Phase 4 liveness-confirmed Running. The container starts and exits almost
+    # immediately (exit 1). Docker returns Ok from `start` the instant the
+    # daemon accepts the container, before the entrypoint has had a chance to
+    # crash — so without the liveness re-inspect this deployment was reported
+    # `running` for a full tick before flipping. The deployment must NEVER be
+    # observed as `running`: it should only ever be creating/pending or, once it
+    # has crashed enough, crash_loop_back_off.
+    command: ["sh", "-c", "exit 1"]
+    replicas: 1

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -108,10 +108,13 @@ cleanup_ring() {
   fi
 
   # Remove any Docker container created by this Ring instance. Ring labels all
-  # containers with "ring_deployment=<uuid>", so filter by the ring_namespace
-  # we used for the test (set by fixtures via the "ring" namespace).
+  # containers with "ring_deployment=<uuid>" and names them
+  # "<namespace>_<name>_<id>"; the fixtures all use the "ring-e2e" namespace, so
+  # scope the cleanup to that name prefix. (The previous filter used
+  # "^ring_e2e_" with an underscore, which never matched the hyphenated
+  # "ring-e2e_" prefix and leaked containers between runs.)
   if command -v docker > /dev/null 2>&1; then
-    docker ps -aq --filter "label=ring_deployment" --filter "name=^ring_e2e_" 2>/dev/null \
+    docker ps -aq --filter "label=ring_deployment" --filter "name=^ring-e2e_" 2>/dev/null \
       | xargs -r docker rm -f > /dev/null 2>&1 || true
   fi
 


### PR DESCRIPTION
## Why

On the Docker runtime, a worker container that exits non-zero shortly after start was recreated forever and never reached `CrashLoopBackOff` — `MAX_RESTART_COUNT` was not respected. Root cause: `restart_count` was only bumped by the async Docker events listener, and that increment was clobbered by the reconcile loop's blind full-row update (lost-update race); the convergent inline counter was gated to Podman only. Reproduced in production (a git-auth failure crash-looped indefinitely).

## What

- Count crashes inline in the reconcile tick for Docker too; the events listener is now log-only (single writer, race removed).
- Atomic `restart_count` writes (`increment`/`reset` in SQL) so concurrent updates can't clobber the counter; `restart_count` removed from the full-row update.
- Windowed `restart_count` reset: forgive the count after a worker stays healthy for `min_healthy_time`, so an isolated later crash no longer trips the bound.
- Shared retry-vs-give-up classifier: non-retryable create errors and exit codes 126/127 fail fast instead of burning all retries.
- Liveness-confirmed `Running` on Docker (settle + recheck) and fix Firecracker's unconditional `Running` promotion.

## Tests

- `cargo test --bin ring` green, `cargo clippy` clean.
- New e2e (real Ring + Docker): t39 git-auth crash loop converges to CrashLoopBackOff, t40 windowed reset, t41 fast-fail on exit 127, t42 liveness never reports Running for an instant-exit container.

Deployed and verified in production.