### PR TITLE
Add a liveness grace window so a just-ready worker survives a probe flap

### DIFF
--- a/src/models/health_check.rs
+++ b/src/models/health_check.rs
@@ -36,6 +36,14 @@ pub(crate) enum HealthCheck {
         /// to the scheduler's built-in window when unset.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         min_healthy_time: Option<String>,
+        /// Grace period before the Docker-native `HEALTHCHECK` starts counting
+        /// failures against the container (Docker `HealthConfig.start_period`).
+        /// Lets a slow-to-boot app (e.g. an in-container build behind a proxy)
+        /// avoid being marked `unhealthy` while it is still starting up. Parsed
+        /// by `parse_duration` (e.g. `"180s"`). Only affects the Docker-native
+        /// healthcheck — Ring's scheduler-side gating is unaffected.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_period: Option<String>,
     },
     #[serde(rename = "http")]
     Http {
@@ -49,6 +57,8 @@ pub(crate) enum HealthCheck {
         readiness: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         min_healthy_time: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_period: Option<String>,
     },
     #[serde(rename = "command")]
     Command {
@@ -62,6 +72,8 @@ pub(crate) enum HealthCheck {
         readiness: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         min_healthy_time: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_period: Option<String>,
     },
 }
 
@@ -174,6 +186,17 @@ impl HealthCheck {
             } => min_healthy_time.as_deref(),
         }
     }
+
+    /// Grace period for the Docker-native `HEALTHCHECK` (`start_period`), if
+    /// configured. Only meaningful for the translated `command` readiness check
+    /// — see `runtime::docker::container::build_health_config`.
+    pub(crate) fn start_period(&self) -> Option<&str> {
+        match self {
+            HealthCheck::Tcp { start_period, .. }
+            | HealthCheck::Http { start_period, .. }
+            | HealthCheck::Command { start_period, .. } => start_period.as_deref(),
+        }
+    }
 }
 
 impl Default for HealthCheck {
@@ -186,6 +209,7 @@ impl Default for HealthCheck {
             on_failure: FailureAction::Restart,
             readiness: false,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 }
@@ -294,6 +318,35 @@ mod tests {
         let result = HealthCheck::parse_duration("500ms");
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_millis(), 500);
+    }
+
+    #[test]
+    fn start_period_serde_round_trips() {
+        // The optional `start_period` rides inside the existing JSON (no DB
+        // column / migration) and must survive a serialize → deserialize round
+        // trip on each variant, defaulting to None when absent.
+        let with = HealthCheck::Command {
+            command: "test -f /ready".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Restart,
+            readiness: true,
+            min_healthy_time: None,
+            start_period: Some("180s".to_string()),
+        };
+        let json = serde_json::to_string(&with).unwrap();
+        assert!(json.contains("\"start_period\":\"180s\""));
+        let back: HealthCheck = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.start_period(), Some("180s"));
+
+        // Absent in the JSON → deserializes to None (serde default), and is
+        // skipped on serialize.
+        let without_json = r#"{"type":"command","command":"true","interval":"10s","timeout":"5s","on_failure":"restart"}"#;
+        let parsed: HealthCheck = serde_json::from_str(without_json).unwrap();
+        assert_eq!(parsed.start_period(), None);
+        let reserialized = serde_json::to_string(&parsed).unwrap();
+        assert!(!reserialized.contains("start_period"));
     }
 
     #[test]

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -110,7 +110,11 @@ fn build_health_config(health_checks: &[HealthCheck]) -> Option<HealthConfig> {
         interval: Some(to_nanos(hc.interval())),
         timeout: Some(to_nanos(hc.timeout())),
         retries: Some(hc.threshold() as i64),
-        start_period: None,
+        // Grace period before Docker counts failures, so a slow-to-boot app
+        // (e.g. an in-container build) isn't mis-marked `unhealthy` while it is
+        // still starting. Same nanosecond encoding as the other fields; absent
+        // or malformed leaves it unset (Docker's own default applies).
+        start_period: hc.start_period().map(to_nanos),
         start_interval: None,
     })
 }
@@ -993,6 +997,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: false,
             min_healthy_time: None,
+            start_period: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -1009,6 +1014,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -1023,6 +1029,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }];
         assert!(build_health_config(&hcs).is_none());
     }
@@ -1037,6 +1044,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }];
         let cfg = build_health_config(&hcs).expect("should translate");
         assert_eq!(
@@ -1062,6 +1070,7 @@ mod tests {
                 on_failure: FailureAction::Alert,
                 readiness: true,
                 min_healthy_time: None,
+                start_period: None,
             },
             HealthCheck::Command {
                 command: "/usr/local/bin/ready.sh".to_string(),
@@ -1071,10 +1080,48 @@ mod tests {
                 on_failure: FailureAction::Alert,
                 readiness: true,
                 min_healthy_time: None,
+                start_period: None,
             },
         ];
         let cfg = build_health_config(&hcs).expect("should translate the command HC");
         assert_eq!(cfg.test.as_ref().unwrap()[1], "/usr/local/bin/ready.sh");
+    }
+
+    #[test]
+    fn build_health_config_carries_start_period_to_docker() {
+        // A `start_period` on the command readiness HC must reach the Docker
+        // `HealthConfig` as nanoseconds, so the container isn't mis-marked
+        // `unhealthy` while a slow startup (e.g. an in-container build) runs.
+        let hcs = vec![HealthCheck::Command {
+            command: "test -f /var/run/kemeter/ready".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+            min_healthy_time: None,
+            start_period: Some("180s".to_string()),
+        }];
+        let cfg = build_health_config(&hcs).expect("should translate");
+        assert_eq!(cfg.start_period, Some(180_000_000_000));
+    }
+
+    #[test]
+    fn build_health_config_leaves_start_period_unset_when_absent() {
+        // No `start_period` configured → leave it unset so Docker's own default
+        // applies (rather than pinning it to 0).
+        let hcs = vec![HealthCheck::Command {
+            command: "test -f /var/run/kemeter/ready".to_string(),
+            interval: "10s".to_string(),
+            timeout: "5s".to_string(),
+            threshold: 3,
+            on_failure: FailureAction::Alert,
+            readiness: true,
+            min_healthy_time: None,
+            start_period: None,
+        }];
+        let cfg = build_health_config(&hcs).expect("should translate");
+        assert_eq!(cfg.start_period, None);
     }
 
     // --- prefer_local_cache: without credentials, the non-Always policies

--- a/src/scheduler/health_checker.rs
+++ b/src/scheduler/health_checker.rs
@@ -48,6 +48,7 @@ impl HealthChecker {
         deployment: &Deployment,
         old_status: &DeploymentStatus,
         runtime: &dyn crate::hypervisor::lifecycle_trait::RuntimeLifecycle,
+        suppress_liveness_action: bool,
     ) -> HealthCheckOutcome {
         let mut outcome = HealthCheckOutcome {
             results: Vec::new(),
@@ -104,9 +105,29 @@ impl HealthChecker {
                     )
                     .await;
 
-                // In the creating phase we only persist the result for the
-                // gate to read; no failure counting, no `on_failure` action.
-                if !creating_phase {
+                // Liveness grace window: right after a deployment first becomes
+                // `Running`, suppress the liveness `on_failure` action for a
+                // settle period. A single brief probe flap in that window would
+                // otherwise fire `on_failure: restart`, tearing down an instance
+                // that is merely still settling (e.g. a slow in-container build
+                // behind a proxy) and looping the whole startup until the
+                // rollout deadline marks it failed. We still run the probe and
+                // record its result; we just hold back the action and reset the
+                // failure counter so the post-grace threshold starts from a
+                // settled baseline. Readiness checks are unaffected (they never
+                // drive `on_failure` here), and a container that actually EXITS
+                // is recreated by the exit-based crash path, which this grace
+                // never touches — so real crashes are not masked.
+                let suppress_this = suppress_liveness_action && !health_check.is_readiness();
+
+                // In the creating phase we only persist the result for the gate
+                // to read; no failure counting, no `on_failure` action. In the
+                // running phase, a suppressed liveness check records its result
+                // and clears its counter, but fires no action this tick.
+                if !creating_phase && suppress_this {
+                    let key = format!("{}:{}:{}", deployment.id, instance_id, hc_index);
+                    self.reset_failure_count(&key).await;
+                } else if !creating_phase {
                     let key = format!("{}:{}:{}", deployment.id, instance_id, hc_index);
                     if matches!(
                         result.status,
@@ -414,11 +435,12 @@ mod tests {
                 on_failure: FailureAction::Restart,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -447,11 +469,12 @@ mod tests {
                 on_failure: FailureAction::Restart,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -491,11 +514,12 @@ mod tests {
                 on_failure: FailureAction::Restart,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -523,11 +547,12 @@ mod tests {
                 on_failure: FailureAction::Restart,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -555,26 +580,27 @@ mod tests {
                 on_failure: FailureAction::Restart,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         // Call 1: failure count = 1/3, no action
         let outcome1 = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
         assert!(outcome1.instances_to_remove.is_empty());
         assert!(outcome1.events.is_empty());
 
         // Call 2: failure count = 2/3, no action
         let outcome2 = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
         assert!(outcome2.instances_to_remove.is_empty());
         assert!(outcome2.events.is_empty());
 
         // Call 3: failure count = 3/3, triggers restart
         let outcome3 = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
         assert_eq!(outcome3.instances_to_remove, vec!["instance-1".to_string()]);
         assert!(
@@ -602,11 +628,12 @@ mod tests {
                 on_failure: FailureAction::Stop,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.proposed_status, Some(DeploymentStatus::Deleted));
@@ -636,11 +663,12 @@ mod tests {
                 on_failure: FailureAction::Alert,
                 readiness: false,
                 min_healthy_time: None,
+                start_period: None,
             }],
         );
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert!(outcome.proposed_status.is_none());
@@ -697,6 +725,7 @@ mod tests {
             on_failure: FailureAction::Restart,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 
@@ -709,6 +738,7 @@ mod tests {
             on_failure: FailureAction::Restart,
             readiness: false,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 
@@ -728,7 +758,7 @@ mod tests {
         deployment.status = DeploymentStatus::Creating;
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -755,7 +785,7 @@ mod tests {
         deployment.status = DeploymentStatus::Creating;
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         // Only the readiness check ran (one result), the liveness was skipped.
@@ -786,7 +816,7 @@ mod tests {
         let old_status = DeploymentStatus::Creating;
 
         let outcome = checker
-            .execute_checks(&deployment, &old_status, &runtime)
+            .execute_checks(&deployment, &old_status, &runtime, false)
             .await;
 
         // Treated as the creating phase: only readiness ran, liveness skipped,
@@ -812,7 +842,7 @@ mod tests {
         deployment.status = DeploymentStatus::Creating;
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert_eq!(outcome.results.len(), 1);
@@ -831,6 +861,152 @@ mod tests {
         assert!(outcome.proposed_status.is_none());
     }
 
+    // ---- liveness grace window ----
+
+    #[tokio::test]
+    async fn liveness_failure_suppressed_within_grace() {
+        // A worker just promoted to Running (old_status == Running) with a
+        // failing liveness probe must NOT be restarted while inside the grace
+        // window. The probe still runs and its result is recorded; only the
+        // restart action is held back.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::unhealthy("connection refused");
+
+        let deployment = make_deployment(
+            "grace-suppress",
+            vec!["instance-1".to_string()],
+            vec![HealthCheck::Tcp {
+                port: 9999,
+                interval: "5s".to_string(),
+                timeout: "5s".to_string(),
+                threshold: 1,
+                on_failure: FailureAction::Restart,
+                readiness: false,
+                min_healthy_time: None,
+                start_period: None,
+            }],
+        );
+
+        // suppress_liveness_action = true (still inside the grace window).
+        let outcome = checker
+            .execute_checks(&deployment, &DeploymentStatus::Running, &runtime, true)
+            .await;
+
+        // The probe ran and recorded a failure...
+        assert_eq!(outcome.results.len(), 1);
+        assert!(matches!(
+            outcome.results[0].status,
+            HealthCheckStatus::Failed
+        ));
+        // ...but no restart was queued and no failure action fired.
+        assert!(
+            outcome.instances_to_remove.is_empty(),
+            "liveness restart must be suppressed during the grace window"
+        );
+        assert!(outcome.health_check_failures.is_empty());
+        assert!(outcome.events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn liveness_failure_restarts_after_grace() {
+        // The SAME failing liveness probe, once the grace window has elapsed
+        // (suppress_liveness_action == false), DOES restart the instance.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::unhealthy("connection refused");
+
+        let deployment = make_deployment(
+            "grace-elapsed",
+            vec!["instance-1".to_string()],
+            vec![HealthCheck::Tcp {
+                port: 9999,
+                interval: "5s".to_string(),
+                timeout: "5s".to_string(),
+                threshold: 1,
+                on_failure: FailureAction::Restart,
+                readiness: false,
+                min_healthy_time: None,
+                start_period: None,
+            }],
+        );
+
+        let outcome = checker
+            .execute_checks(&deployment, &DeploymentStatus::Running, &runtime, false)
+            .await;
+
+        assert_eq!(outcome.instances_to_remove, vec!["instance-1".to_string()]);
+        assert_eq!(outcome.health_check_failures.len(), 1);
+        assert_eq!(outcome.health_check_failures[0].action, "restart");
+    }
+
+    #[tokio::test]
+    async fn grace_does_not_suppress_readiness_results() {
+        // The grace only gates the *liveness action*; readiness probes still
+        // run and record (they never fire on_failure here anyway), so the
+        // readiness gate keeps the data it needs even during the grace window.
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::healthy();
+
+        let deployment = make_deployment(
+            "grace-readiness",
+            vec!["instance-1".to_string()],
+            vec![readiness_tcp(), liveness_tcp()],
+        );
+
+        // Running phase, suppression on.
+        let outcome = checker
+            .execute_checks(&deployment, &DeploymentStatus::Running, &runtime, true)
+            .await;
+
+        // Both checks ran and recorded results (readiness + liveness probe),
+        // and with a healthy runtime nothing is removed.
+        assert_eq!(outcome.results.len(), 2);
+        assert!(outcome.instances_to_remove.is_empty());
+    }
+
+    #[tokio::test]
+    async fn grace_does_not_mask_an_exited_container() {
+        // Real-crash guarantee at the health-check layer: the grace suppresses
+        // only the *probe-driven* liveness action. An instance that has exited
+        // is removed from `deployment.instances` by the exit-based crash path
+        // *before* health checks run, so there's no instance left to probe —
+        // execute_checks simply has nothing to suppress, and the crash path has
+        // already queued the recreation. We model that here: with the dead
+        // instance already gone, even an in-grace running-phase check produces
+        // no results and removes nothing (the recreation is the crash path's
+        // job, untouched by the grace).
+        let pool = new_test_pool().await;
+        let checker = HealthChecker::new(pool);
+        let runtime = MockRuntime::unhealthy("connection refused");
+
+        // No instances: the dead one was already reaped by the exit path.
+        let deployment = make_deployment(
+            "grace-exited",
+            vec![],
+            vec![HealthCheck::Tcp {
+                port: 9999,
+                interval: "5s".to_string(),
+                timeout: "5s".to_string(),
+                threshold: 1,
+                on_failure: FailureAction::Restart,
+                readiness: false,
+                min_healthy_time: None,
+                start_period: None,
+            }],
+        );
+
+        let outcome = checker
+            .execute_checks(&deployment, &DeploymentStatus::Running, &runtime, true)
+            .await;
+
+        // The grace never touched the exit path: no probe ran, nothing removed
+        // here — recreation is driven separately by the crash path.
+        assert!(outcome.results.is_empty());
+        assert!(outcome.instances_to_remove.is_empty());
+    }
+
     #[tokio::test]
     async fn jobs_skip_health_checks_during_creating() {
         // Jobs never gate on readiness; they go straight to completed/failed.
@@ -847,7 +1023,7 @@ mod tests {
         deployment.kind = "job".to_string();
 
         let outcome = checker
-            .execute_checks(&deployment, &deployment.status, &runtime)
+            .execute_checks(&deployment, &deployment.status, &runtime, false)
             .await;
 
         assert!(outcome.results.is_empty(), "jobs run no checks in creating");

--- a/src/scheduler/liveness_grace.rs
+++ b/src/scheduler/liveness_grace.rs
@@ -1,0 +1,181 @@
+//! Per-deployment liveness grace window.
+//!
+//! When a deployment first enters `Running` (the readiness gate has finally let
+//! the optimistic `Creating → Running` flip stand), the liveness health checks
+//! start acting on `old_status == Running`. With zero settle margin, a single
+//! brief flap of the liveness probe right after promotion can fire its
+//! `on_failure: restart` and tear the instance down — which, for a runtime that
+//! runs a slow in-container build at startup (e.g. `bun run build` behind
+//! Caddy), restarts the whole build from scratch and loops until the rollout
+//! deadline marks the deployment `failed`.
+//!
+//! This tracker remembers *when* a deployment first became `Running` and lets
+//! the scheduler suppress the liveness `on_failure` actions until it has been
+//! `Running` for at least the grace window. The probe still runs and its result
+//! is still recorded; only the restart/stop/alert action is held back during
+//! the settle period.
+//!
+//! Crucially this only gates the liveness *health-check* action path. A
+//! container that genuinely EXITS (Docker `die` event → crash path /
+//! liveness-confirmed Running re-inspect) is handled elsewhere and is NOT
+//! suppressed by this grace: a real crash is still recreated immediately. The
+//! grace only filters a *probe* that flaps while the app is settling, never an
+//! exit.
+//!
+//! State is in-memory and non-persistent, like [`super::backoff::RetryBackoff`]
+//! and [`super::healthy_window::HealthyWindow`]: at process restart the clock
+//! starts over, which is safe — a deployment that is already `Running` simply
+//! gets one fresh grace window, and a genuinely-dead container is still caught
+//! by the exit-based path that this tracker never touches.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Built-in liveness grace window. Ordered deliberately below the sauron
+/// `ready` probe timeout (300s) and the rollout deadline (600s) and above a
+/// typical in-container build (33-60s): `grace (120) < ready_timeout (300) <
+/// rollout_deadline (600)`. Overridable via `RING_LIVENESS_GRACE` (seconds).
+pub(crate) const DEFAULT_LIVENESS_GRACE: Duration = Duration::from_secs(120);
+
+/// Resolve the liveness grace from the environment, falling back to
+/// [`DEFAULT_LIVENESS_GRACE`]. A value of `0` disables the grace (useful for
+/// deterministic tests and for operators who explicitly opt out).
+pub(crate) fn liveness_grace_from_env() -> Duration {
+    match std::env::var("RING_LIVENESS_GRACE") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => DEFAULT_LIVENESS_GRACE,
+        },
+        Err(_) => DEFAULT_LIVENESS_GRACE,
+    }
+}
+
+/// Per-deployment "running since" clock used to suppress liveness actions
+/// during the settle window after a deployment first becomes `Running`.
+#[derive(Default)]
+pub(crate) struct LivenessGrace {
+    /// `deployment_id -> Instant the deployment was first observed Running`.
+    running_since: HashMap<String, Instant>,
+}
+
+impl LivenessGrace {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record this tick's observation and decide whether the deployment is
+    /// still inside its liveness grace window (so liveness `on_failure` actions
+    /// must be held back).
+    ///
+    /// - The clock is armed the first tick a deployment is observed `Running`.
+    /// - While not `Running` the clock is dropped, so a later `Running` stretch
+    ///   (a recreate, or a gate that reverted to `Creating`) starts a fresh
+    ///   grace window rather than counting from a stale timestamp.
+    ///
+    /// Returns `true` while the deployment has been `Running` for less than
+    /// `grace` — i.e. liveness restarts should be suppressed this tick.
+    pub(crate) fn in_grace(
+        &mut self,
+        deployment_id: &str,
+        is_running: bool,
+        grace: Duration,
+    ) -> bool {
+        if !is_running {
+            self.running_since.remove(deployment_id);
+            return false;
+        }
+
+        let now = Instant::now();
+        let since = *self
+            .running_since
+            .entry(deployment_id.to_string())
+            .or_insert(now);
+
+        now.duration_since(since) < grace
+    }
+
+    /// Forget a deployment (deleted, or being recreated). The next `Running`
+    /// observation re-arms a fresh grace window.
+    pub(crate) fn clear(&mut self, deployment_id: &str) {
+        self.running_since.remove(deployment_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GRACE: Duration = Duration::from_secs(120);
+
+    #[test]
+    fn not_running_is_never_in_grace() {
+        let mut g = LivenessGrace::new();
+        assert!(!g.in_grace("d1", false, GRACE));
+        assert!(!g.running_since.contains_key("d1"));
+    }
+
+    #[test]
+    fn first_running_tick_is_in_grace() {
+        let mut g = LivenessGrace::new();
+        // Just became Running: well inside the window, suppress liveness.
+        assert!(g.in_grace("d1", true, GRACE));
+    }
+
+    #[test]
+    fn no_longer_in_grace_after_window_elapses() {
+        let mut g = LivenessGrace::new();
+        // Arm the clock in the past so the window has fully elapsed.
+        g.running_since
+            .insert("d1".to_string(), Instant::now() - GRACE);
+        assert!(!g.in_grace("d1", true, GRACE));
+    }
+
+    #[test]
+    fn leaving_running_resets_the_clock() {
+        let mut g = LivenessGrace::new();
+        // Arm an elapsed clock, then a non-Running tick must drop it...
+        g.running_since
+            .insert("d1".to_string(), Instant::now() - GRACE);
+        assert!(!g.in_grace("d1", false, GRACE));
+        // ...so the next Running tick starts a *fresh* grace window.
+        assert!(g.in_grace("d1", true, GRACE));
+    }
+
+    #[test]
+    fn zero_grace_never_suppresses() {
+        let mut g = LivenessGrace::new();
+        assert!(!g.in_grace("d1", true, Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn clear_drops_the_entry() {
+        let mut g = LivenessGrace::new();
+        assert!(g.in_grace("d1", true, GRACE));
+        g.clear("d1");
+        assert!(!g.running_since.contains_key("d1"));
+    }
+
+    #[test]
+    fn env_override_parses_seconds() {
+        // Default when unset.
+        unsafe {
+            std::env::remove_var("RING_LIVENESS_GRACE");
+        }
+        assert_eq!(liveness_grace_from_env(), DEFAULT_LIVENESS_GRACE);
+
+        unsafe {
+            std::env::set_var("RING_LIVENESS_GRACE", "5");
+        }
+        assert_eq!(liveness_grace_from_env(), Duration::from_secs(5));
+
+        // Malformed falls back to the default rather than panicking.
+        unsafe {
+            std::env::set_var("RING_LIVENESS_GRACE", "not-a-number");
+        }
+        assert_eq!(liveness_grace_from_env(), DEFAULT_LIVENESS_GRACE);
+
+        unsafe {
+            std::env::remove_var("RING_LIVENESS_GRACE");
+        }
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -4,5 +4,6 @@ pub(crate) mod event_worker;
 pub(crate) mod health_checker;
 pub(crate) mod healthy_window;
 pub(crate) mod intentional_shutdowns;
+pub(crate) mod liveness_grace;
 pub(crate) mod scheduler;
 pub(crate) mod stats_cache;

--- a/src/scheduler/scheduler.rs
+++ b/src/scheduler/scheduler.rs
@@ -13,6 +13,7 @@ use crate::scheduler::docker_events::DockerEvent;
 use crate::scheduler::health_checker::HealthChecker;
 use crate::scheduler::healthy_window::HealthyWindow;
 use crate::scheduler::intentional_shutdowns::IntentionalShutdowns;
+use crate::scheduler::liveness_grace::{LivenessGrace, liveness_grace_from_env};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::env;
@@ -421,6 +422,7 @@ async fn run_health_checks(
     old_status: &DeploymentStatus,
     health_checker: &HealthChecker,
     runtime: &dyn RuntimeLifecycle,
+    suppress_liveness_action: bool,
 ) {
     // Health checks run in `Running` (full set, drives `on_failure`) and, for
     // readiness gating, in `Creating` (readiness-only, record-only — see
@@ -440,7 +442,7 @@ async fn run_health_checks(
     debug!("Executing health checks for deployment {}", deployment.id);
 
     let outcome = health_checker
-        .execute_checks(deployment, old_status, runtime)
+        .execute_checks(deployment, old_status, runtime, suppress_liveness_action)
         .await;
 
     for result in &outcome.results {
@@ -1156,6 +1158,13 @@ pub(crate) async fn schedule(
     // the crash budget is "N crashes within a window", not "N crashes for life".
     let mut healthy_window = HealthyWindow::new();
 
+    // Per-deployment liveness grace clock. Suppresses liveness `on_failure`
+    // actions for a settle window after a deployment first becomes Running, so
+    // a brief probe flap right after promotion can't restart-loop a slow-to-
+    // settle startup. Exit-based crash detection is unaffected.
+    let mut liveness_grace = LivenessGrace::new();
+    let liveness_grace_window = liveness_grace_from_env();
+
     info!(
         "Starting scheduler with interval: {}s, apply timeout: {}s",
         interval_seconds, apply_timeout_secs
@@ -1243,6 +1252,7 @@ pub(crate) async fn schedule(
             if deployment.status == DeploymentStatus::Deleted {
                 backoff.clear(&deployment.id);
                 healthy_window.clear(&deployment.id);
+                liveness_grace.clear(&deployment.id);
                 let mut result = match apply_runtime(
                     &pool,
                     &deployment,
@@ -1449,12 +1459,34 @@ pub(crate) async fn schedule(
             // `publish_status_change` uses it to detect a real status change.
             let old_status = deployment.status.clone();
             handle_status_transitions(&pool, &mut result, &mut deleted).await;
+
+            // Liveness grace window. Liveness `on_failure` actions act only in
+            // the established-Running phase (keyed on `old_status == Running`,
+            // the same condition `execute_checks` uses to leave the
+            // creating/readiness-only phase). We arm a settle clock the first
+            // tick a deployment is established-Running and suppress the liveness
+            // *action* until it has been Running for at least `liveness_grace`.
+            // This stops a brief probe flap right after promotion from firing a
+            // restart and looping a slow-to-settle startup (e.g. an in-container
+            // build behind a proxy) until the rollout deadline fails it. The
+            // probe still runs and is recorded; only the restart/stop/alert
+            // action is held. A container that genuinely EXITS is recreated by
+            // the exit-based crash path, untouched by this grace, so real
+            // crashes are never masked. The clock resets whenever the deployment
+            // leaves Running (recreate / gate revert to Creating).
+            let suppress_liveness_action = liveness_grace.in_grace(
+                &result.id,
+                old_status == DeploymentStatus::Running,
+                liveness_grace_window,
+            );
+
             run_health_checks(
                 &pool,
                 &mut result,
                 &old_status,
                 &health_checker,
                 runtime.as_ref(),
+                suppress_liveness_action,
             )
             .await;
             gate_running_on_readiness(&pool, &old_status, &mut result).await;
@@ -1685,6 +1717,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 
@@ -1697,6 +1730,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: true,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 
@@ -1709,6 +1743,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: false,
             min_healthy_time: None,
+            start_period: None,
         }
     }
 
@@ -1723,6 +1758,7 @@ mod tests {
                 on_failure: FailureAction::Alert,
                 readiness,
                 min_healthy_time: raw.map(|s| s.to_string()),
+                start_period: None,
             })
             .collect();
         child_with_health_checks(id, hcs)
@@ -1860,6 +1896,7 @@ mod tests {
             on_failure: FailureAction::Alert,
             readiness: false, // not a readiness HC
             min_healthy_time: None,
+            start_period: None,
         });
         let child = child_with_health_checks("child-7", hcs);
         insert_hc_result(&pool, "child-7", "command", "success", 30).await;

--- a/tests/e2e/docker/t43_liveness_grace_slow_ready.sh
+++ b/tests/e2e/docker/t43_liveness_grace_slow_ready.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# T43: liveness grace window. A slow-to-ready app whose ready-file briefly flaps
+# right after promotion to `running` must NOT be restart-looped to `failed`.
+#
+# Reproduces the bun+Caddy production bug (simplified to one self-contained
+# container — see fixtures/slow-ready-liveness-grace.yaml):
+#   - the app sleeps ~12s before creating its ready-file (the "build" window),
+#     so the deployment is correctly held in `creating` until then;
+#   - once promoted to `running`, the ready-file flaps off a few times in the
+#     first seconds — the exact condition that, with zero settle margin, fired
+#     the liveness `on_failure: restart`, tore the instance down and restarted
+#     the whole build from scratch, looping until the rollout deadline marked it
+#     `failed`.
+#
+# With the liveness grace window suppressing the liveness action during the
+# settle period, the deployment must reach `running` and STAY there:
+#   - it never reaches `failed`,
+#   - restart_count stays 0 (no liveness-driven restart),
+#   - it is observed `running` and remains running through the flap window.
+#
+# Env knobs (inherited by the ring server we spawn):
+#   - RING_LIVENESS_GRACE=30  : covers the post-promotion flap window.
+#   - RING_ROLLOUT_DEADLINE=60 : a *broken* Ring (no grace) would restart-loop
+#     the 12s "build" and hit this deadline within the test, converging to
+#     `failed` — so the assertion below actually distinguishes fixed from broken.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T43: slow-ready app with a post-promotion flap must not be killed by liveness =="
+
+# Suppress the liveness action for 30s after first Running (covers the flap),
+# and keep the rollout deadline short so a broken build-loop would actually fail
+# within the test rather than the test timing out.
+export RING_LIVENESS_GRACE=30
+export RING_ROLLOUT_DEADLINE=60
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/slow-ready-liveness-grace.yaml"
+
+# 1) It must reach `running`. The app is ready at ~12s; allow generous headroom
+#    for the scheduler interval and the anti-flap min_healthy_time window.
+wait_deployment_status "ring-e2e" "slow-ready" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "slow-ready")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+# The single running instance, captured right after promotion. The liveness
+# `on_failure: restart` tears the instance DOWN (removes the container) — the
+# concrete symptom of the bug, which then restarts the whole "build". We assert
+# this exact container survives the flap: it is never removed, and no new
+# container is ever spawned to replace it.
+INITIAL_CID=$(docker ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+if [ -z "$INITIAL_CID" ]; then
+  fail "no running container found for the deployment after it reached running"
+fi
+log "running container at promotion: $INITIAL_CID"
+
+# 2) It must STAY running through the flap window and never be restart-looped.
+#    The sustained ready-file flap lands ~8s after promotion and lasts ~8s
+#    (3 consecutive liveness failures). Sample past it (still inside the 30s
+#    grace window) and assert:
+#      - status never leaves `running` / never reaches `failed`;
+#      - the promotion container is never removed (>=1 running container, and
+#        the running container id never changes — no restart-and-recreate).
+log "watching the deployment survive the flap window..."
+DEADLINE=$(( $(date +%s) + 40 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  STATUS=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg ns "ring-e2e" --arg n "slow-ready" \
+        '.[] | select(.namespace==$ns and .name==$n) | .status' \
+    | head -n1)
+  RUNNING_CIDS=$(docker ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID")
+  RUNNING_COUNT=$(printf '%s\n' "$RUNNING_CIDS" | grep -c . || true)
+
+  if [ "$STATUS" = "failed" ]; then
+    fail "deployment reached 'failed' — the liveness restart loop was NOT suppressed by the grace window"
+  fi
+  if [ "$STATUS" != "running" ]; then
+    fail "deployment left 'running' (now '$STATUS') during the flap window — liveness action fired inside the grace"
+  fi
+  if [ "${RUNNING_COUNT:-0}" -lt 1 ]; then
+    fail "the running container was torn down during the flap window — liveness restart was not suppressed"
+  fi
+  case "$RUNNING_CIDS" in
+    *"$INITIAL_CID"*) ;;
+    *) fail "the promotion container ($INITIAL_CID) was replaced (now: $RUNNING_CIDS) — liveness restart-recreated the instance inside the grace" ;;
+  esac
+
+  sleep 2
+done
+
+# 3) Final sanity: still running, restart_count never climbed, and it is the
+#    same original container — proving no liveness restart ever fired.
+wait_deployment_status "ring-e2e" "slow-ready" "running" 5
+FINAL_RC=$(get_restart_count "ring-e2e" "slow-ready")
+if [ "${FINAL_RC:-0}" -ne 0 ]; then
+  fail "final restart_count is $FINAL_RC, expected 0"
+fi
+FINAL_CID=$(docker ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+if [ "$FINAL_CID" != "$INITIAL_CID" ]; then
+  fail "running container changed from $INITIAL_CID to $FINAL_CID — the instance was restarted"
+fi
+
+log "deployment stayed running on the same container ($INITIAL_CID) through the flap; restart_count=0"
+log "== T43: PASS =="

--- a/tests/e2e/fixtures/slow-ready-liveness-grace.yaml
+++ b/tests/e2e/fixtures/slow-ready-liveness-grace.yaml
@@ -1,0 +1,64 @@
+deployments:
+  slow-ready:
+    name: slow-ready
+    namespace: ring-e2e
+    runtime: docker
+    image: alpine:3.19
+    # Faithful reproduction of the bun+Caddy slow-ready bug, simplified to a
+    # single self-contained container (no registry, no real build):
+    #
+    #   1. The app is slow to become ready: it sleeps ~12s before creating the
+    #      ready-file (longer than the readiness threshold*interval = 6s, so the
+    #      deployment is correctly held in `creating` during the "build").
+    #   2. The ready-file appears; after the anti-flap window the deployment is
+    #      promoted `creating -> running` (~t+22s).
+    #   3. Shortly AFTER promotion the ready-file FLAPS off for a sustained ~8s
+    #      (4 liveness intervals, longer than threshold*interval = 6s, so it
+    #      forces 3 consecutive liveness failures) — the exact condition that,
+    #      with zero settle margin, fired the liveness `on_failure: restart`,
+    #      tore the instance down and restarted the whole "build" from scratch,
+    #      looping to `failed` at the rollout deadline.
+    #   4. The ready-file is restored and the app sleeps forever.
+    #
+    # With the liveness grace window (RING_LIVENESS_GRACE) covering the flap,
+    # the deployment must reach `running` and STAY there — restart_count stays 0
+    # and it never reaches `failed`. With the grace disabled, the same flap
+    # restart-loops it (the negative control).
+    command:
+      - "sh"
+      - "-c"
+      - |
+        sleep 12
+        touch /tmp/ready
+        # Let the deployment promote to `running` and settle (anti-flap window
+        # ~10s + scheduler ticks), then flap the ready-file off for a sustained
+        # window long enough to trip the liveness threshold (3 consecutive
+        # fails). This lands inside the post-promotion grace window.
+        sleep 18
+        rm -f /tmp/ready
+        sleep 8
+        touch /tmp/ready
+        # Stable from here on.
+        exec sleep 3600
+    replicas: 1
+    health_checks:
+      # Readiness: holds the deployment in `creating` until the ready-file
+      # exists. on_failure: alert — a not-yet-ready app during the slow start
+      # must not be restarted.
+      - type: command
+        command: "test -f /tmp/ready"
+        readiness: true
+        interval: 2s
+        timeout: 2s
+        threshold: 3
+        on_failure: alert
+      # Liveness: once running, restart an instance whose app has died. This is
+      # the check whose post-promotion flap caused the restart loop; the grace
+      # window must suppress it until the deployment has settled.
+      - type: command
+        command: "test -f /tmp/ready"
+        readiness: false
+        interval: 2s
+        timeout: 2s
+        threshold: 3
+        on_failure: restart


### PR DESCRIPTION
## Why

A slow-to-ready worker (e.g. a `bun run build` served by Caddy) goes `Creating -> Running` the moment its ready-file appears, then the liveness check (`on_failure: restart`) could fire on the very next ticks. A brief ready-file flap right after promotion tore the container down and restarted the whole ~30s+ build, looping to a failed rollout. Reproduced in production.

## What

- New `LivenessGrace` tracker (in-memory, like `HealthyWindow`/`RetryBackoff`): suppress the liveness `on_failure: restart` action for a grace window after a worker first becomes established-Running. Probe results are still recorded; only the restart action is withheld. Default 120s, overridable via `RING_LIVENESS_GRACE`.
- The grace gates only the probe-driven liveness restart; a container that actually exits is still recreated immediately by the exit-based crash path, so real crashes are never masked.
- Optional `start_period` on the health-check model, set on the Docker-native healthcheck so a slow in-container build isn't mis-marked unhealthy.

## Tests

- `cargo test --bin ring` green, `cargo clippy` clean.
- New e2e t43: a slow-to-ready worker that flaps its ready-file is not killed during the grace window. Negative control (`RING_LIVENESS_GRACE=0`) fails, proving the assertion discriminates fixed vs broken.

Deployed and verified in production.

> Based on #177 (crash-loop bounding); review/merge that one first.