### PR TITLE
Expose unhealthy deployments by namespace and status

### DIFF
--- a/src/api/action/metrics.rs
+++ b/src/api/action/metrics.rs
@@ -23,6 +23,7 @@
 //! use `/deployments/{id}/metrics`.
 
 use crate::api::server::AppState;
+use crate::models::deployments;
 use crate::models::deployments::DeploymentStatus;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
@@ -93,6 +94,12 @@ struct Snapshot {
     deployments: u64,
     deployments_by_status: BTreeMap<String, u64>,
     deployments_by_runtime: BTreeMap<String, u64>,
+    /// Deployments stuck in a non-healthy state, broken down by
+    /// `(namespace, status)`. Only unhealthy statuses are emitted (running /
+    /// completed / deleted are excluded), so the series count tracks the number
+    /// of deployments actually in trouble rather than namespaces × statuses.
+    /// Lets an operator see *which* tenant is affected, not just the total.
+    unhealthy_deployments_by_namespace: Vec<NamespaceStatusCount>,
     namespaces: u64,
     secrets: u64,
     volumes: u64,
@@ -112,6 +119,33 @@ struct Snapshot {
     /// deployment reports stats.
     deployment_runtime: Vec<RuntimeSeries>,
 }
+
+/// One `(namespace, status)` bucket with its deployment count, ready to render
+/// as a two-label Prometheus series.
+#[derive(Debug, Serialize)]
+struct NamespaceStatusCount {
+    namespace: String,
+    status: String,
+    count: u64,
+}
+
+/// Statuses considered "in trouble": a deployment in one of these is not
+/// serving and needs attention. `running`/`completed`/`deleted` are healthy or
+/// terminal and intentionally excluded so the per-namespace breakdown stays
+/// small and alert-friendly. Listed explicitly (not "everything else") so a new
+/// status is a deliberate decision, not silently bucketed.
+const UNHEALTHY_STATUSES: [&str; 10] = [
+    "pending",
+    "failed",
+    "crash_loop_back_off",
+    "image_pull_back_off",
+    "create_container_error",
+    "network_error",
+    "config_error",
+    "file_system_error",
+    "insufficient_resources",
+    "error",
+];
 
 /// Serializable, render-ready copy of one deployment's cached runtime stats.
 /// Mirrors `stats_cache::DeploymentRuntimeStats` but lives here so the cache
@@ -170,6 +204,8 @@ impl Snapshot {
             status_keys.iter().map(String::as_str),
         );
         snap.deployments_by_runtime = group_count(pool, "deployment", "runtime").await;
+        snap.unhealthy_deployments_by_namespace =
+            unhealthy_by_namespace(pool, &UNHEALTHY_STATUSES).await;
         snap.deployments = snap
             .deployments_by_status
             .iter()
@@ -230,6 +266,34 @@ async fn group_count(pool: &sqlx::SqlitePool, table: &str, column: &str) -> BTre
     }
 }
 
+/// Render-ready breakdown of deployments in trouble, per `(namespace, status)`.
+/// Thin adapter over [`deployments::count_by_namespace_and_status`]: maps the
+/// raw rows into [`NamespaceStatusCount`] and, like the other metrics helpers,
+/// is fail-soft — a query error logs and yields an empty list rather than
+/// taking the whole scrape down.
+async fn unhealthy_by_namespace(
+    pool: &sqlx::SqlitePool,
+    statuses: &[&str],
+) -> Vec<NamespaceStatusCount> {
+    match deployments::count_by_namespace_and_status(pool, statuses).await {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(namespace, status, count)| NamespaceStatusCount {
+                namespace,
+                status,
+                count: count.max(0) as u64,
+            })
+            .collect(),
+        Err(e) => {
+            error!(
+                "metrics: grouping deployment by namespace/status failed: {}",
+                e
+            );
+            Vec::new()
+        }
+    }
+}
+
 /// Ensure every expected label value is present, defaulting to 0, without
 /// dropping any extra keys the DB returned. Keeps zero-valued series alive
 /// across scrapes (Prometheus alerts break when a series disappears) while
@@ -268,6 +332,7 @@ fn render_prom(snap: &Snapshot) -> String {
         "runtime",
         &snap.deployments_by_runtime,
     );
+    write_namespace_status_gauge(&mut out, snap);
 
     write_gauge(
         &mut out,
@@ -440,6 +505,27 @@ fn write_labelled_gauge(
             out,
             "{name}{{{label}=\"{}\"}} {count}",
             escape_label_value(key)
+        );
+    }
+}
+
+/// Render the unhealthy-deployments breakdown as a two-label gauge
+/// (`namespace`, `status`). The HELP/TYPE pair is always emitted so the metric
+/// is discoverable even when nothing is broken and there are no series.
+fn write_namespace_status_gauge(out: &mut String, snap: &Snapshot) {
+    let name = "ring_unhealthy_deployments";
+    let _ = writeln!(
+        out,
+        "# HELP {name} Deployments in a non-healthy status, by namespace and status."
+    );
+    let _ = writeln!(out, "# TYPE {name} gauge");
+    for row in &snap.unhealthy_deployments_by_namespace {
+        let _ = writeln!(
+            out,
+            "{name}{{namespace=\"{}\",status=\"{}\"}} {}",
+            escape_label_value(&row.namespace),
+            escape_label_value(&row.status),
+            row.count
         );
     }
 }
@@ -643,6 +729,83 @@ mod tests {
         assert_eq!(
             after.deployments_by_runtime.get("docker").copied(),
             Some(docker_before + 2)
+        );
+    }
+
+    async fn insert_deployment(
+        pool: &sqlx::SqlitePool,
+        id: &str,
+        namespace: &str,
+        name: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO deployment (id, created_at, status, namespace, runtime, kind, name) \
+             VALUES (?, '2024-01-01', ?, ?, 'docker', 'worker', ?)",
+        )
+        .bind(id)
+        .bind(status)
+        .bind(namespace)
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn unhealthy_by_namespace_buckets_only_unhealthy_statuses() {
+        let (pool, _app) = new_test_app_with_pool().await;
+
+        // Two tenants, a mix of states. Only the unhealthy ones must surface,
+        // each tagged with its own namespace so an operator can tell who is hit.
+        // Use synthetic namespaces so the fixtures' own deployments don't bleed
+        // into the assertion.
+        insert_deployment(&pool, "k1", "ns-trouble-a", "proxysql", "running").await;
+        insert_deployment(&pool, "k2", "ns-trouble-a", "pgbouncer", "config_error").await;
+        insert_deployment(&pool, "c1", "ns-trouble-b", "web", "crash_loop_back_off").await;
+        insert_deployment(&pool, "c2", "ns-trouble-b", "old", "completed").await;
+        insert_deployment(&pool, "c3", "ns-trouble-b", "img", "image_pull_back_off").await;
+
+        let rows = unhealthy_by_namespace(&pool, &UNHEALTHY_STATUSES).await;
+        // Restrict to the namespaces we created — the fixtures seed their own
+        // deployments, so assert on our delta rather than the whole set.
+        let got: Vec<(&str, &str, u64)> = rows
+            .iter()
+            .filter(|r| r.namespace == "ns-trouble-a" || r.namespace == "ns-trouble-b")
+            .map(|r| (r.namespace.as_str(), r.status.as_str(), r.count))
+            .collect();
+
+        // running + completed are excluded; the three unhealthy ones remain,
+        // ordered by (namespace, status).
+        assert_eq!(
+            got,
+            vec![
+                ("ns-trouble-a", "config_error", 1),
+                ("ns-trouble-b", "crash_loop_back_off", 1),
+                ("ns-trouble-b", "image_pull_back_off", 1),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn unhealthy_deployments_render_with_namespace_and_status_labels() {
+        let (pool, _app) = new_test_app_with_pool().await;
+        insert_deployment(&pool, "k2", "ns-trouble-a", "pgbouncer", "config_error").await;
+        insert_deployment(&pool, "k1", "ns-trouble-a", "proxysql", "running").await;
+
+        let snap = Snapshot::collect(&pool).await;
+        let body = render_prom(&snap);
+
+        assert!(body.contains("# TYPE ring_unhealthy_deployments gauge"));
+        assert!(body.contains(
+            "ring_unhealthy_deployments{namespace=\"ns-trouble-a\",status=\"config_error\"} 1"
+        ));
+        // A healthy deployment never appears in *this* metric (the substring is
+        // scoped to ring_unhealthy_deployments, not the global by-status gauge).
+        assert!(
+            !body.contains(
+                "ring_unhealthy_deployments{namespace=\"ns-trouble-a\",status=\"running\""
+            )
         );
     }
 }

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -684,6 +684,29 @@ pub(crate) async fn find_referencing_secret(
     Ok(rows.into_iter().map(Deployment::from).collect())
 }
 
+/// Count deployments grouped by `(namespace, status)`, restricted to the given
+/// statuses. One row per non-empty bucket, ordered by `(namespace, status)`.
+/// Returns raw `(namespace, status, count)` tuples; callers decide how to
+/// present them. `statuses` must be non-empty.
+pub(crate) async fn count_by_namespace_and_status(
+    pool: &SqlitePool,
+    statuses: &[&str],
+) -> Result<Vec<(String, String, i64)>, sqlx::Error> {
+    // Bind each status as a parameter (they are caller-provided literals today,
+    // but parameterising keeps the query injection-free regardless).
+    let placeholders = vec!["?"; statuses.len()].join(", ");
+    let sql = format!(
+        "SELECT namespace, status, COUNT(*) FROM deployment \
+         WHERE status IN ({placeholders}) \
+         GROUP BY namespace, status ORDER BY namespace, status"
+    );
+    let mut query = sqlx::query_as::<_, (String, String, i64)>(&sql);
+    for status in statuses {
+        query = query.bind(*status);
+    }
+    query.fetch_all(pool).await
+}
+
 /// True when `volumes_json` (a deployment's `volumes` column) contains a mount
 /// of `type == "volume"` whose `source` is `volume_name`. Distinguishes a real
 /// named-volume reference from a bind/config/secret that merely shares the name,


### PR DESCRIPTION
## What

Adds a new Prometheus metric exposed on `/metrics`:

```
ring_unhealthy_deployments{namespace="...", status="..."} <count>
```

It breaks down deployments that are **not** in a healthy state by `(namespace, status)`, so an operator can see *which* tenant is affected, not just the global total that `ring_deployments_by_status` already provides.

## Why

`ring_deployments_by_status` is a global aggregate with no namespace label. There was no way to tell *who* owns the deployments currently stuck in `crash_loop_back_off`, `config_error`, `image_pull_back_off`, etc. This metric fills that gap for any multi-tenant Ring operator.

## Design

- Only unhealthy statuses are emitted. `running`, `completed` and `deleted` are excluded, so the series count stays proportional to the number of deployments actually in trouble rather than namespaces x statuses. The unhealthy set is an explicit list, so adding a status is a deliberate decision.
- The SQL lives in the model layer (`models::deployments::count_by_namespace_and_status`), returning raw `(namespace, status, count)` tuples. The metrics action is a thin, fail-soft adapter that maps and renders them; a query error logs and yields no series rather than failing the whole scrape.
- No namespace or tenant name is hardcoded: the metric is neutral. Consumers (dashboards, alerts) decide what to filter on.

## Tests

- `count_by_namespace_and_status` buckets only unhealthy statuses, ordered by `(namespace, status)`.
- The rendered exposition contains the two-label series and never includes healthy deployments.
- `cargo fmt`, `cargo clippy --bins --tests` and the metrics + deployments test suites are green.