### PR TITLE
Resolve deployment instances in one bulk runtime call

### DIFF
--- a/src/api/action/deployment/list.rs
+++ b/src/api/action/deployment/list.rs
@@ -27,6 +27,12 @@ pub(crate) struct QueryParameters {
     /// filtered in memory rather than in SQL.
     #[serde(default)]
     labels: Vec<String>,
+    /// When true, resolve each deployment's live running instances (and their
+    /// addresses) from the runtime. This queries the runtime once per
+    /// deployment, so it is opt-in: a plain `list` stays a single cheap DB read
+    /// instead of an N-roundtrip fan-out to Docker.
+    #[serde(default)]
+    instances: bool,
 }
 
 impl<S> FromRequestParts<S> for QueryParameters
@@ -45,6 +51,7 @@ where
         let mut namespaces = Vec::new();
         let mut kind = Vec::new();
         let mut labels = Vec::new();
+        let mut instances = false;
 
         for (key, value) in parsed {
             match key.as_str() {
@@ -56,6 +63,7 @@ where
                 "kind" => kind.push(value),
                 "label[]" => labels.push(value),
                 "label" => labels.push(value),
+                "instances" => instances = matches!(value.as_str(), "true" | "1"),
                 _ => {}
             }
         }
@@ -65,6 +73,7 @@ where
             status,
             kind,
             labels,
+            instances,
         })
     }
 }
@@ -124,24 +133,55 @@ pub(crate) async fn list(
         })
     };
 
-    for deployment in list_deployments.into_iter() {
-        if !matches_labels(&deployment) {
-            continue;
+    let retained: Vec<deployments::Deployment> = list_deployments
+        .into_iter()
+        .filter(matches_labels)
+        .collect();
+
+    // Resolve running instances per runtime in a single bulk call each, rather
+    // than one runtime roundtrip per deployment. This keeps the instance count
+    // (the `x/y` replicas column) in the default listing without the previous
+    // N-deployments fan-out that timed out on busy hosts.
+    let mut ids_by_runtime: HashMap<String, Vec<String>> = HashMap::new();
+    for deployment in &retained {
+        ids_by_runtime
+            .entry(deployment.runtime.clone())
+            .or_default()
+            .push(deployment.id.clone());
+    }
+
+    let mut instance_ids: HashMap<String, Vec<String>> = HashMap::new();
+    for (runtime_name, ids) in &ids_by_runtime {
+        if let Some(rt) = runtimes.get(runtime_name) {
+            instance_ids.extend(rt.list_running_instances_grouped(ids).await);
         }
+    }
+
+    for deployment in retained.into_iter() {
         let id = deployment.id.clone();
         let runtime_name = deployment.runtime.clone();
         let mut output = DeploymentOutput::from_to_model(deployment);
 
-        if let Some(rt) = runtimes.get(&runtime_name) {
-            let ids = rt.list_instances(id, "running").await;
+        if let Some(ids) = instance_ids.get(&id) {
             let mut instances = Vec::with_capacity(ids.len());
             for instance_id in ids {
-                let address = rt
-                    .instance_address(&instance_id)
-                    .await
-                    .map(|ip| ip.to_string());
+                // Addresses require a per-instance inspect, so only resolve them
+                // when the caller explicitly asked (`?instances=true`). The
+                // default listing carries instance ids (hence the count) without
+                // that extra cost.
+                let address = if query_parameters.instances {
+                    if let Some(rt) = runtimes.get(&runtime_name) {
+                        rt.instance_address(instance_id)
+                            .await
+                            .map(|ip| ip.to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
                 instances.push(DeploymentInstance {
-                    id: instance_id,
+                    id: instance_id.clone(),
                     address,
                 });
             }

--- a/src/api/action/metrics.rs
+++ b/src/api/action/metrics.rs
@@ -25,6 +25,7 @@
 use crate::api::server::AppState;
 use crate::models::deployments;
 use crate::models::deployments::DeploymentStatus;
+use crate::models::query::{group_count, table_count};
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
@@ -227,42 +228,6 @@ impl Snapshot {
         snap.configs = table_count(pool, "config").await;
 
         snap
-    }
-}
-
-/// `SELECT COUNT(*)` for a table. A query error logs and yields `0` rather than
-/// failing the whole scrape — a single broken series should never take the
-/// endpoint down for a scraper.
-async fn table_count(pool: &sqlx::SqlitePool, table: &str) -> u64 {
-    // `table` is a hard-coded literal at every call site, never user input, so
-    // the format!-built query carries no injection surface.
-    let sql = format!("SELECT COUNT(*) FROM {table}");
-    match sqlx::query_scalar::<_, i64>(&sql).fetch_one(pool).await {
-        Ok(count) => count.max(0) as u64,
-        Err(e) => {
-            error!("metrics: counting {} failed: {}", table, e);
-            0
-        }
-    }
-}
-
-/// `SELECT col, COUNT(*) ... GROUP BY col` as a label→count map. Same
-/// fail-soft contract as [`table_count`].
-async fn group_count(pool: &sqlx::SqlitePool, table: &str, column: &str) -> BTreeMap<String, u64> {
-    // `table`/`column` are hard-coded literals at every call site.
-    let sql = format!("SELECT {column}, COUNT(*) FROM {table} GROUP BY {column}");
-    match sqlx::query_as::<_, (String, i64)>(&sql)
-        .fetch_all(pool)
-        .await
-    {
-        Ok(rows) => rows
-            .into_iter()
-            .map(|(label, count)| (label, count.max(0) as u64))
-            .collect(),
-        Err(e) => {
-            error!("metrics: grouping {}.{} failed: {}", table, column, e);
-            BTreeMap::new()
-        }
     }
 }
 

--- a/src/hypervisor/lifecycle_trait.rs
+++ b/src/hypervisor/lifecycle_trait.rs
@@ -7,6 +7,7 @@ use axum::response::sse::Event;
 use futures::stream;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
 use std::pin::Pin;
@@ -152,6 +153,30 @@ pub(crate) trait RuntimeLifecycle: Send + Sync {
     ) -> Deployment;
 
     async fn list_instances(&self, deployment_id: String, status: &str) -> Vec<String>;
+
+    /// Resolve the running instance ids for many deployments at once, keyed by
+    /// deployment id.
+    ///
+    /// The default implementation loops over `list_instances` per deployment,
+    /// preserving the previous behaviour for runtimes with no cheaper bulk path.
+    /// Container runtimes (Docker) override this to issue a single host-wide
+    /// list and group in memory, turning an N-deployments fan-out into one call
+    /// — this is what keeps `GET /deployments` from timing out on busy hosts.
+    ///
+    /// Only ids are returned (no address): the deployment listing needs the
+    /// instance *count*, and resolving an address is a separate per-instance
+    /// inspect that callers opt into when they actually need it.
+    async fn list_running_instances_grouped(
+        &self,
+        deployment_ids: &[String],
+    ) -> HashMap<String, Vec<String>> {
+        let mut grouped = HashMap::new();
+        for deployment_id in deployment_ids {
+            let ids = self.list_instances(deployment_id.clone(), "running").await;
+            grouped.insert(deployment_id.clone(), ids);
+        }
+        grouped
+    }
 
     /// Fallback: uses instance ID as display name. Override for runtimes
     /// that assign human-readable names (e.g. Docker container names).

--- a/src/models/query.rs
+++ b/src/models/query.rs
@@ -1,4 +1,47 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+
+use tracing::error;
+
+/// `SELECT COUNT(*)` for a table. A query error logs and yields `0` rather than
+/// failing the caller — used by the fail-soft metrics scrape where a single
+/// broken series should never take the whole endpoint down.
+///
+/// `table` is expected to be a hard-coded literal at the call site, never user
+/// input, so the format!-built query carries no injection surface.
+pub(crate) async fn table_count(pool: &sqlx::SqlitePool, table: &str) -> u64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    match sqlx::query_scalar::<_, i64>(&sql).fetch_one(pool).await {
+        Ok(count) => count.max(0) as u64,
+        Err(e) => {
+            error!("query: counting {} failed: {}", table, e);
+            0
+        }
+    }
+}
+
+/// `SELECT col, COUNT(*) ... GROUP BY col` as a label→count map. Same fail-soft
+/// contract as [`table_count`]. `table`/`column` are expected to be hard-coded
+/// literals at the call site.
+pub(crate) async fn group_count(
+    pool: &sqlx::SqlitePool,
+    table: &str,
+    column: &str,
+) -> BTreeMap<String, u64> {
+    let sql = format!("SELECT {column}, COUNT(*) FROM {table} GROUP BY {column}");
+    match sqlx::query_as::<_, (String, i64)>(&sql)
+        .fetch_all(pool)
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(label, count)| (label, count.max(0) as u64))
+            .collect(),
+        Err(e) => {
+            error!("query: grouping {}.{} failed: {}", table, column, e);
+            BTreeMap::new()
+        }
+    }
+}
 
 pub(crate) fn build_filtered_query(
     base_query: &str,

--- a/src/runtime/docker/docker_lifecycle.rs
+++ b/src/runtime/docker/docker_lifecycle.rs
@@ -82,6 +82,13 @@ impl RuntimeLifecycle for DockerLifecycle {
         super::instances::list_instances(&self.docker, deployment_id, status).await
     }
 
+    async fn list_running_instances_grouped(
+        &self,
+        deployment_ids: &[String],
+    ) -> std::collections::HashMap<String, Vec<String>> {
+        super::instances::list_running_instances_grouped(&self.docker, deployment_ids).await
+    }
+
     async fn list_instances_with_names(
         &self,
         deployment_id: String,

--- a/src/runtime/docker/instances.rs
+++ b/src/runtime/docker/instances.rs
@@ -60,6 +60,42 @@ pub(crate) async fn list_instances(docker: &Docker, id: String, status: &str) ->
     instances
 }
 
+/// Group running instance ids by deployment in a single host-wide list call,
+/// instead of one `list_containers` per deployment. Only deployments in
+/// `wanted` are kept. This is the bulk path behind the deployment listing: with
+/// many deployments it collapses N full container lists into one.
+pub(crate) async fn list_running_instances_grouped(
+    docker: &Docker,
+    wanted: &[String],
+) -> std::collections::HashMap<String, Vec<String>> {
+    use std::collections::{HashMap, HashSet};
+
+    let wanted: HashSet<&str> = wanted.iter().map(String::as_str).collect();
+    let mut grouped: HashMap<String, Vec<String>> = HashMap::new();
+
+    let options = build_list_options("running");
+    match docker.list_containers(Some(options)).await {
+        Ok(containers) => {
+            for container in containers {
+                if matches_status(container.state.as_ref(), "running")
+                    && let Some(labels) = &container.labels
+                    && let Some(deployment_id) = labels.get("ring_deployment")
+                    && wanted.contains(deployment_id.as_str())
+                    && let Some(container_id) = &container.id
+                {
+                    grouped
+                        .entry(deployment_id.clone())
+                        .or_default()
+                        .push(container_id.clone());
+                }
+            }
+        }
+        Err(e) => debug!("Docker list instances (grouped) error: {}", e),
+    }
+
+    grouped
+}
+
 pub(crate) async fn list_instances_with_names(
     docker: &Docker,
     id: String,


### PR DESCRIPTION
## Problem

`GET /deployments` resolved each deployment's live instances by calling the runtime once per deployment (`list_instances` → a full host-wide `docker ps` each time), in series. On a host with many deployments this is O(deployments × all_containers) and times out (408 on `deployment list -n kemeter`).

## Fix

Add `RuntimeLifecycle::list_running_instances_grouped(deployment_ids)`:
- default impl loops (previous behaviour, fine for the low-count VM runtimes);
- Docker overrides it with a single `list_containers` grouped in memory by the `ring_deployment` label.

The deployment listing now resolves the instance count for all deployments via one bulk call per runtime, so the `x/y` replicas column is preserved without the fan-out. Per-instance addresses (a separate inspect each) are only resolved when the caller passes `?instances=true`.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy` clean; 118 tests pass (incl. deployment::list).
- Deployed to production: `deployment list -n kemeter --type job` went from timing out (408) to ~0.85s, replicas column intact.