### PR TITLE
Mark a worker that exits 0 as Completed instead of recreating it forever

### DIFF
--- a/src/hypervisor/classifier.rs
+++ b/src/hypervisor/classifier.rs
@@ -93,16 +93,23 @@ pub(crate) fn classify_create_error(err: &RuntimeError) -> Disposition {
 /// exception because they are *unambiguously* permanent under the standard shell
 /// convention, so a restart can never succeed:
 ///
+/// * `0` — the process ran to completion successfully. A worker that exits 0
+///   has *finished*, not crashed: it must converge to `Completed`, never be
+///   recreated. Treating it as retryable recreates the container every tick
+///   forever (re-pulling the image each time under the default `Always`
+///   policy) — a one-shot/`pg_dump`-style container declared as a worker would
+///   otherwise loop endlessly and starve the reconcile cycle.
 /// * `127` — command not found (the entrypoint/binary doesn't exist);
 /// * `126` — found but not executable (bad perms / not a binary).
 ///
-/// Both mean the container can never start its program, so we fail fast onto
+/// 126/127 mean the container can never start its program, so we fail fast onto
 /// `CreateContainerError` rather than burning the whole restart budget. Every
-/// other code (including `0`, generic `1`, and signal-kill `128+n`) stays
-/// retryable — those can be transient, and mislabelling them terminal would
-/// wrongly give up on a recoverable worker.
+/// other code (generic `1`, signal-kill `128+n`) stays retryable — those can be
+/// transient, and mislabelling them terminal would wrongly give up on a
+/// recoverable worker.
 pub(crate) fn classify_exit_code(exit_code: Option<i64>) -> Disposition {
     match exit_code {
+        Some(0) => Disposition::Terminal(DeploymentStatus::Completed),
         Some(126) | Some(127) => Disposition::Terminal(DeploymentStatus::CreateContainerError),
         _ => Disposition::Retry,
     }
@@ -184,8 +191,18 @@ mod tests {
     }
 
     #[test]
+    fn clean_exit_completes() {
+        // A successful exit (code 0) is terminal-Completed, never retried — a
+        // worker that finished must not be recreated in a loop.
+        assert_eq!(
+            classify_exit_code(Some(0)),
+            Disposition::Terminal(DeploymentStatus::Completed)
+        );
+    }
+
+    #[test]
     fn other_exit_codes_retry() {
-        assert_eq!(classify_exit_code(Some(0)), Disposition::Retry);
+        // Generic failures and signal kills stay retryable (could be transient).
         assert_eq!(classify_exit_code(Some(1)), Disposition::Retry);
         assert_eq!(classify_exit_code(Some(137)), Disposition::Retry);
         assert_eq!(classify_exit_code(None), Disposition::Retry);

--- a/src/runtime/docker/lifecycle.rs
+++ b/src/runtime/docker/lifecycle.rs
@@ -60,6 +60,26 @@ pub(crate) async fn apply(
 /// daemon — see the tests in this module.
 fn apply_unexpected_exits(deployment: &mut Deployment, exited: &[(String, Option<i64>)]) -> bool {
     for (container_id, exit_code) in exited {
+        let disposition = crate::hypervisor::classifier::classify_exit_code(*exit_code);
+
+        // A clean exit (code 0) is a *success*, not a crash: the worker finished
+        // its work. Converge to Completed without touching restart_count, so it
+        // is never recreated — recreating an exit-0 container every tick is the
+        // infinite pull/recreate loop this guards against.
+        if let Disposition::Terminal(status @ DeploymentStatus::Completed) = disposition {
+            deployment.emit_event(
+                "info",
+                format!(
+                    "Container {} exited cleanly (code 0); marking completed",
+                    &container_id[..container_id.len().min(12)]
+                ),
+                "docker",
+                Some("container_completed"),
+            );
+            deployment.status = status;
+            return true;
+        }
+
         deployment.restart_count += 1;
         deployment.emit_event(
             "error",
@@ -76,9 +96,7 @@ fn apply_unexpected_exits(deployment: &mut Deployment, exited: &[(String, Option
         // not-executable): the container can never start its program, so
         // retrying it up to MAX_RESTART_COUNT only delays the inevitable. Land
         // on the terminal status now.
-        if let Disposition::Terminal(status) =
-            crate::hypervisor::classifier::classify_exit_code(*exit_code)
-        {
+        if let Disposition::Terminal(status) = disposition {
             deployment.emit_event(
                 "error",
                 format!(
@@ -741,6 +759,27 @@ mod tests {
         assert!(!hit_bound);
         assert_eq!(deployment.restart_count, 1);
         assert_eq!(deployment.status, DeploymentStatus::Running);
+    }
+
+    /// A clean exit (code 0) is a success, not a crash: the worker is marked
+    /// Completed and `restart_count` is left untouched, so it is never recreated.
+    /// This is the production loop guard — a one-shot/`pg_dump`-style container
+    /// declared as a worker used to exit 0, get recreated, re-pull its image, and
+    /// loop forever, starving the reconcile cycle.
+    #[test]
+    fn clean_exit_completes_without_restart() {
+        let mut deployment = worker_running();
+        let exited = vec![("container-done".to_string(), Some(0))];
+        let stop = apply_unexpected_exits(&mut deployment, &exited);
+        assert!(
+            stop,
+            "a clean exit is terminal, reconciling stops this tick"
+        );
+        assert_eq!(deployment.status, DeploymentStatus::Completed);
+        assert_eq!(
+            deployment.restart_count, 0,
+            "a successful exit must not count as a crash"
+        );
     }
 
     /// Liveness gate: a container still running right after start may be


### PR DESCRIPTION
## Problem

A worker container that exits **0** (a successful, clean exit) was treated as a crash and recreated every reconcile tick, forever. `classify_exit_code` mapped `0` to `Retry`, so `apply_unexpected_exits` bumped `restart_count` and the scheduler recreated the container — which, under the default `image_pull_policy: Always`, re-pulled the image each time.

In production this manifested as a one-shot `pg_dump`-style container (declared as a worker) looping endlessly: pull image → run → exit 0 → recreate → pull → ... Each iteration did a full image pull plus the dump, saturating the reconcile cycle. Because all deployments of a namespace reconcile together, this starved every other deployment in the `kemeter` namespace (Grafana among them) of timely reconciliation.

## Fix

Treat exit code `0` as terminal **Completed**, never retryable:

- `classify_exit_code(Some(0))` now returns `Terminal(Completed)`.
- `apply_unexpected_exits` short-circuits a clean exit to `Completed` **without** incrementing `restart_count`, so the container is never recreated.

A worker that finished successfully converges to `Completed` (which the scheduler excludes from reconciliation) instead of looping. Non-zero exits keep their existing retry/fast-fail behaviour (126/127 still fail fast; generic 1, signal kills, and unknown codes stay retryable).

## Verification

Deployed to production and confirmed the loop stops:

| | before | after |
|---|---|---|
| postgres image pulls / 2 min | 13 | 0 |
| containers recreated / 2 min | continuous | 0 |
| deployments stuck in `creating` | 2 | 0 |

Plus a unit test (`clean_exit_completes_without_restart`) reproducing the loop: a container exiting 0 lands on `Completed` with `restart_count` untouched. Full suite green, `cargo fmt`/`clippy` clean.