### PR TITLE
Always list all container states so finished jobs are visible

### DIFF
--- a/src/runtime/docker/instances.rs
+++ b/src/runtime/docker/instances.rs
@@ -2,17 +2,25 @@ use bollard::Docker;
 use bollard::models::ContainerSummaryStateEnum;
 use bollard::query_parameters::ListContainersOptionsBuilder;
 
-fn build_list_options(status: &str) -> bollard::query_parameters::ListContainersOptions {
-    // Always list every container and filter by state client-side (see
-    // `matches_status`). We deliberately do NOT push a server-side `status`
-    // filter:
-    // Podman's Docker-compatible API rejects `restarting` (it has no such
-    // state) and fails the whole request, which `list_*` then swallows into an
-    // empty Vec — making the scheduler believe a deployment has 0 live
-    // instances and spawn one new container every tick, unbounded. Listing all
-    // and filtering in-process behaves identically on Docker and Podman.
-    let all = !matches!(status, "all");
-    ListContainersOptionsBuilder::new().all(all).build()
+fn build_list_options(_status: &str) -> bollard::query_parameters::ListContainersOptions {
+    // Always list every container (`all = true`) and filter by state
+    // client-side (see `matches_status`). We deliberately do NOT push a
+    // server-side `status` filter: Podman's Docker-compatible API rejects
+    // `restarting` (it has no such state) and fails the whole request, which
+    // `list_*` then swallows into an empty Vec — making the scheduler believe a
+    // deployment has 0 live instances and spawn one new container every tick,
+    // unbounded. Listing all and filtering in-process behaves identically on
+    // Docker and Podman.
+    //
+    // `all` MUST be unconditional: with `all = false` Docker returns running
+    // containers only, so a `status = "all"` lookup misses every Exited
+    // container. The job path (`handle_job_deployment`) relies on
+    // `list_instances("all")` to find its finished container and converge to
+    // Completed; without exited containers it sees zero instances and recreates
+    // one every tick forever (a pg_dump job looping thousands of times). A
+    // previous change tied `all` to the filter, which silently reintroduced
+    // exactly that unbounded loop.
+    ListContainersOptionsBuilder::new().all(true).build()
 }
 
 /// Whether a container counts as a live instance for the given filter.
@@ -181,5 +189,22 @@ mod tests {
             "exited"
         ));
         assert!(!matches_status(None, "exited"));
+    }
+
+    // Regression guard for the unbounded job-recreation loop: the Docker list
+    // flag MUST be `all = true` for EVERY filter, including "all". With it tied
+    // to the filter, `list_instances("all")` returned running containers only,
+    // so a finished (Exited) job container was invisible — `handle_job_deployment`
+    // then saw zero instances and recreated one every tick, forever (thousands
+    // of pg_dump containers piled up in production). Listing is exhaustive;
+    // `matches_status` does the state filtering client-side.
+    #[test]
+    fn list_options_always_request_all_states() {
+        for filter in ["all", "active", "running", "exited", "created"] {
+            assert!(
+                build_list_options(filter).all,
+                "build_list_options({filter:?}) must set all=true so exited containers are visible",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

`build_list_options` set the Docker `list_containers` `all` flag conditionally:

```rust
let all = !matches!(status, "all");
```

For a `status = "all"` lookup this yields `all = false`, so Docker returns **running containers only**. Every exited container is invisible to that listing — the opposite of what the function's own comment promises ("Always list every container and filter by state client-side").

This breaks the job path. `handle_job_deployment` calls `list_instances(deployment.id, "all")` to find its container and converge to `Completed`. A `pg_dump` backup job (`kind: job`, `replicas: 1`) exits ~0.5s after starting; on the next scheduler tick there are zero *running* containers, so the inverted flag makes the listing empty even though the finished container is right there with a matching `ring_deployment` label. Ring concludes the job has no instance, recreates a new container, and sets `Running` — every tick, forever.

In production this looped ~30 backup deployments and piled up **~8900 Exited(0) `postgres:18-alpine` containers**, saturating the reconcile cycle (which slowed everything else, including unrelated redeploys).

Regression from a Podman fix (`605a25c`, 2026-06-19) that correctly stopped a different loop but tied `all` to the filter.

## Fix

Make the flag unconditional:

```rust
ListContainersOptionsBuilder::new().all(true).build()
```

Listing is exhaustive; `matches_status` already does per-state filtering client-side (including `"all"`, `"active"`, `"exited"`, ...), so this restores the intended behaviour without reintroducing the Podman `created`-container regression (that fix lives in `matches_status`'s `active` arm, untouched here).

## Verification

- New regression test `list_options_always_request_all_states` asserts `all == true` for every filter. Confirmed it **fails** when the buggy expression is restored and **passes** with the fix.
- Deployed to production: container recreation stopped immediately (0 recreations post-deploy vs ~30/cycle before), and the Exited-container count stopped growing.
- Full suite green, `cargo fmt`/`clippy` clean.

Follow-ups (out of scope): reap accumulated exited job containers; consider making `list_instances("all").first()` pick the most-recent container explicitly rather than relying on Docker list order.