### PR TITLE
Hoist function-body use statements to module level

### DIFF
--- a/src/api/action/login.rs
+++ b/src/api/action/login.rs
@@ -96,6 +96,7 @@ pub(crate) struct LoginInput {
 #[cfg(test)]
 mod tests {
     use crate::api::server::tests::new_test_app;
+    use crate::models::token as token_model;
     use axum::http::StatusCode;
     use axum_test::{TestResponse, TestServer};
     use serde::Deserialize;
@@ -221,7 +222,6 @@ mod tests {
         // rotate on /tokens/{id} must 404 for a session row, so it is managed
         // only via /login and /logout. We mint a session directly on the pool
         // (so we hold its id) and prove every id-based token route rejects it.
-        use crate::models::token as token_model;
         let (pool, router) = crate::api::server::tests::new_test_app_with_pool().await;
         let server = TestServer::new(router).unwrap();
         let admin = login_token(&server).await;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -20,6 +20,8 @@ use clap::{Arg, ArgAction, ArgMatches, Command, ValueEnum};
 use rand::RngCore;
 use std::fs;
 use std::io::IsTerminal;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 pub(crate) fn command_config() -> Command {
@@ -376,7 +378,6 @@ fn write_secret_key_file(path: &str, key: &str) -> std::io::Result<()> {
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
 

--- a/src/models/deployments.rs
+++ b/src/models/deployments.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::fmt;
+use std::str::FromStr;
 
 pub(crate) const MAX_RESTART_COUNT: u32 = 5;
 
@@ -476,7 +477,6 @@ impl From<DeploymentRow> for Deployment {
             pending_events: vec![],
             parent_id: row.parent_id,
             network: row.network_mode.as_deref().and_then(|s| {
-                use std::str::FromStr;
                 NetworkMode::from_str(s)
                     .map(|mode| NetworkConfig { mode })
                     .map_err(|e| {
@@ -974,7 +974,6 @@ mod tests {
 
     #[test]
     fn network_mode_as_str_round_trips() {
-        use std::str::FromStr;
         for mode in [NetworkMode::Bridge, NetworkMode::Host] {
             assert_eq!(NetworkMode::from_str(mode.as_str()).unwrap(), mode);
         }

--- a/src/runtime/cloud_hypervisor/lifecycle.rs
+++ b/src/runtime/cloud_hypervisor/lifecycle.rs
@@ -10,13 +10,16 @@ use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, ex
 use crate::hypervisor::port_forwarder::{self, PortForwarder};
 use crate::hypervisor::virtiofs::{self, VirtiofsMount};
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
+use crate::models::health_check::HealthCheckStatus;
 use crate::models::volume::ResolvedMount;
 use crate::runtime::docker::tiny_id;
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 /// Resolved runtime configuration for Cloud Hypervisor.
@@ -492,7 +495,6 @@ impl CloudHypervisorLifecycle {
         tokio::spawn(async move {
             let stderr_task = stderr.map(|mut s| {
                 tokio::spawn(async move {
-                    use tokio::io::AsyncReadExt;
                     let mut buf = Vec::new();
                     let _ = s.read_to_end(&mut buf).await;
                     String::from_utf8_lossy(&buf).into_owned()
@@ -1273,8 +1275,6 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
                 + Send,
         >,
     > {
-        use futures::stream::{self, StreamExt};
-
         let instances = self.scan_instances(deployment_id, &[]).await;
         let filtered: Vec<String> = instances
             .into_iter()
@@ -1346,8 +1346,6 @@ impl RuntimeLifecycle for CloudHypervisorLifecycle {
         crate::models::health_check::HealthCheckStatus,
         Option<String>,
     ) {
-        use crate::models::health_check::HealthCheckStatus;
-
         let cid = cid_for_instance(instance_id);
         let argv = vec!["/bin/sh".to_string(), "-c".to_string(), command.to_string()];
         let timeout = std::time::Duration::from_secs(30);

--- a/src/runtime/containerd/image.rs
+++ b/src/runtime/containerd/image.rs
@@ -12,6 +12,7 @@
 use super::client::DEFAULT_SNAPSHOTTER;
 use crate::hypervisor::error::RuntimeError;
 use crate::runtime::docker::{ImagePullPolicy, ImageReference, parse_image_reference};
+use base64::Engine as _;
 use containerd_client::services::v1::GetImageRequest;
 use containerd_client::services::v1::ReadContentRequest;
 use containerd_client::services::v1::TransferRequest;
@@ -249,7 +250,6 @@ async fn pull_image(
     // the token endpoint, so this covers the common private-registry case.
     let mut headers = HashMap::new();
     if let Some((_, username, password)) = &image.auth {
-        use base64::Engine as _;
         let raw = format!("{}:{}", username, password);
         let encoded = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
         headers.insert("Authorization".to_string(), format!("Basic {}", encoded));

--- a/src/runtime/firecracker/lifecycle.rs
+++ b/src/runtime/firecracker/lifecycle.rs
@@ -14,12 +14,13 @@
 //! presence on disk (its `.sock`) is the source of truth for "is it running".
 
 use crate::config::server::FirecrackerConfig;
-use crate::hypervisor::cloud_init::GuestNet;
+use crate::hypervisor::cloud_init::{GuestMount, GuestNet};
 use crate::hypervisor::error::RuntimeError;
 use crate::hypervisor::host_net::{InstanceNet, cid_for_instance};
 use crate::hypervisor::lifecycle_trait::{Log, RuntimeLifecycle, classify_log, extract_date};
 use crate::hypervisor::port_forwarder::{self, PortForwarder};
 use crate::hypervisor::tap::TapDevice;
+use crate::hypervisor::volume_image as vol;
 use crate::hypervisor::vsock_client::{self, VsockError};
 use crate::models::deployments::{Deployment, DeploymentStatus, MAX_RESTART_COUNT};
 use crate::models::health_check::{HealthCheck, HealthCheckStatus};
@@ -29,6 +30,8 @@ use crate::runtime::firecracker::client::{
     BootSource, Drive, FirecrackerClient, MachineConfig, NetworkInterface, Vsock,
 };
 use async_trait::async_trait;
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
@@ -181,9 +184,6 @@ impl FirecrackerLifecycle {
         deployment: &Deployment,
         resolved_mounts: &[ResolvedMount],
     ) -> Result<Vec<crate::hypervisor::cloud_init::GuestMount>, String> {
-        use crate::hypervisor::cloud_init::GuestMount;
-        use crate::hypervisor::volume_image as vol;
-
         // /dev/vda is root and cidata takes the free letter after the last
         // volume, so volumes can use vdb..=vdy at most — 24 of them. Past that
         // the device letters would overflow into punctuation ('{', '|', …) and
@@ -794,9 +794,6 @@ impl FirecrackerLifecycle {
     /// tap: Firecracker holds the tap's backend fd while alive, so the tap
     /// can only be removed once the process has fully exited.
     async fn kill_pid(&self, pid: u32) {
-        use nix::sys::signal::{Signal, kill};
-        use nix::unistd::Pid;
-
         let target = Pid::from_raw(pid as i32);
         let _ = kill(target, Signal::SIGTERM);
         for i in 0..20 {


### PR DESCRIPTION
Moves `use` statements that were declared inside function bodies up to module level, keeping imports in one place per file.

Ten imports were hoisted across six files; the `#[cfg(unix)]` guard on `OpenOptionsExt` is preserved so non-unix builds are unaffected. Test-module imports (`use super::*;` and friends inside `#[cfg(test)]`) are left as-is, since that is the standard Rust idiom.

Files touched:
- `models/deployments.rs` — `std::str::FromStr`
- `commands/init.rs` — `std::os::unix::fs::OpenOptionsExt`
- `runtime/containerd/image.rs` — `base64::Engine`
- `runtime/firecracker/lifecycle.rs` — `GuestMount`, `volume_image`, `nix` signal/pid
- `runtime/cloud_hypervisor/lifecycle.rs` — `tokio::io::AsyncReadExt`, `futures::stream`, `HealthCheckStatus`
- `api/action/login.rs` — `token` (into the test module)

`cargo check` passes with no errors or unused-import warnings.