### PR TITLE
feat(podman): accept host networking on the Podman runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenTelemetry distributed tracing (opt-in) via `[server.telemetry.traces]`: `ring server start` exports spans over OTLP/gRPC — one per HTTP request (stable HTTP-server semantic-convention attributes) and one per productive scheduler cycle. Endpoint, `service.name` and sampler are configurable, standard `OTEL_*` env vars override the TOML, and an unreachable collector degrades gracefully instead of failing the server
 - OpenTelemetry metric export (opt-in, push) via `[server.telemetry.metrics]`: periodically pushes the per-deployment resource gauges (CPU, memory, network, disk, PIDs, instance and restart counts, labelled `{deployment, namespace, runtime}`) over OTLP/gRPC, read from the same stats cache the Prometheus `/metrics` endpoint uses so no extra runtime round-trip is added. Endpoint, `service.name` and push interval are configurable
 - OpenTelemetry log export (opt-in, push) via `[server.telemetry.logs]`: bridges the server's log events to an OTLP/gRPC collector in addition to the console. Each telemetry signal (traces, metrics, logs) is independently toggled; all three degrade gracefully when the collector is unreachable
+- `network.mode: host` is now accepted on the Podman runtime, not just Docker: Podman shares the Docker-compatible lifecycle and honours `NetworkMode: host`, so the container binds the host's network stack directly (Cloud Hypervisor and Firecracker still reject host mode)
 
 ## [0.10.0] - 2026-07-04
 

--- a/documentation/concepts/runtimes.md
+++ b/documentation/concepts/runtimes.md
@@ -67,7 +67,7 @@ The socket must be running; start it once with `systemctl --user start podman.so
 
 **Caveats:**
 - **Crash detection is tick-bound.** Ring does not consume Podman's event stream, so a crashed container is noticed on the next scheduler reconcile pass (which still bumps `restart_count` and converges a crash loop to `CrashLoopBackOff`, bounded), not sub-second like Docker. The orphan-volume reaper, which *does* rely on live events, stays Docker-only.
-- **Host networking** (`network.mode: host`) is not yet allowed on Podman, only on Docker.
+- **Host networking** (`network.mode: host`) works the same as Docker: Podman shares the Docker-compatible lifecycle, so the container binds the host's network stack directly.
 - Rootless remaps UID/GID; bind-mount and named-volume ownership behave differently than Docker-root, so mind file permissions on mounts.
 
 ## containerd runtime (beta)

--- a/documentation/how-to/use-host-network.md
+++ b/documentation/how-to/use-host-network.md
@@ -1,6 +1,8 @@
 # Use host network mode
 
-By default Ring attaches every Docker container to a per-namespace bridge network. Some workloads need to bypass that and run directly on the host's network stack. This page covers when, how, and the constraints Ring enforces.
+By default Ring attaches every Docker or Podman container to a per-namespace bridge network. Some workloads need to bypass that and run directly on the host's network stack. This page covers when, how, and the constraints Ring enforces.
+
+Host networking is available on the **Docker and Podman** runtimes (Podman shares the Docker-compatible lifecycle). The Cloud Hypervisor and Firecracker runtimes have their own network model and reject `network.mode: host`.
 
 For the underlying model, see [Namespaces and networking](/documentation/concepts/namespaces-and-networking). For the field schema, see [Manifest reference → `network`](/documentation/reference/manifest#network).
 
@@ -51,7 +53,7 @@ The API rejects the deployment up front if any of these hold:
 |---|---|
 | `ports:` is non-empty | Host networking bypasses Docker's port bindings, so `ports:` would be silently ignored. |
 | `replicas: 2` or more | All replicas would compete for the same host ports. |
-| `runtime: cloud-hypervisor` | Host mode is Docker-only. The CH runtime has its own network model (per-VM /30 subnet under `10.42.0.0/16`). |
+| `runtime: cloud-hypervisor` (or `firecracker`) | Host mode is Docker/Podman-only. The microVM runtimes have their own network model (per-VM /30 subnet under `10.42.0.0/16`). |
 
 The rejection happens at `ring apply` time with a 400 response, so there is no half-deployed state to clean up.
 
@@ -186,7 +188,7 @@ See [how-to: expose HTTP traffic](/documentation/how-to/expose-http-traffic) for
 
 ## Limits
 
-- **Docker-only.** The Cloud Hypervisor runtime rejects `network.mode=host`, since its network model is different (per-VM /30, no shared bridge).
+- **Docker and Podman only.** The Cloud Hypervisor and Firecracker runtimes reject `network.mode=host`, since their network model is different (per-VM /30, no shared bridge).
 - **One replica.** Port conflicts make `replicas > 1` impossible; Ring rejects it at the API.
 - **No isolation.** Host-mode containers can bind to any free port on the host and see all host network traffic. Treat them like a host-level daemon for security purposes.
 

--- a/documentation/reference/manifest.md
+++ b/documentation/reference/manifest.md
@@ -290,7 +290,7 @@ When `mode: host`, the API rejects the deployment if:
 
 - `ports:` is non-empty, because host networking bypasses Docker's port bindings, so the mapping would be silently ignored. Remove `ports:` and let the container bind directly.
 - `replicas: > 1`, because all replicas would compete for the same host ports.
-- `runtime: cloud-hypervisor`, because host mode is Docker-only. The CH runtime has its own network model.
+- `runtime: cloud-hypervisor` or `runtime: firecracker`, because host mode is available only on the container runtimes (Docker, Podman). The microVM runtimes have their own network model.
 
 See [how-to: use host network mode](/documentation/how-to/use-host-network) for the full walk-through.
 

--- a/documentation/runtimes/podman.md
+++ b/documentation/runtimes/podman.md
@@ -48,7 +48,7 @@ ring apply -f web.yaml
 
 - **Crash detection is reconcile-based.** Podman has no Docker-style event listener, so a crashed container is noticed on the next scheduler tick rather than sub-second. A crash loop still converges to `crash_loop_back_off` (bounded), it's just tick-paced.
 - **Rootless remaps UID/GID.** A file written inside the container has a different owner on the host. Bind-mount and named-volume ownership behave differently than under Docker-root, so mind permissions on mounts.
-- **Host networking** (`network.mode: host`) is not yet supported on Podman.
+- **Host networking** (`network.mode: host`) works the same as Docker: Podman shares the Docker-compatible lifecycle and honours `NetworkMode: host`, so the container binds the host's network stack directly (no `ports:`, one replica). See [use host network mode](/documentation/how-to/use-host-network).
 - **Registry auth from the host.** `podman login` writes to `containers/auth.json`. Authorize it with `use_host_registry_auth = true` (point `host_registry_config` at the auth file) and pull with `config.use_host_auth: true`, with no secret in the manifest. See [manifest `config`](/documentation/reference/manifest#use_host_auth-credentials-from-the-host).
 - **Registry auth from an encrypted Secret.** Or store credentials in a `Secret` and reference it with `config.image_pull_secret`. See [deploy with secrets](/documentation/how-to/deploy-with-secrets#pull-a-private-image-with-a-secret).
 - Otherwise the feature set matches Docker: same images, same health checks, same labels.

--- a/src/api/action/deployment/create.rs
+++ b/src/api/action/deployment/create.rs
@@ -49,11 +49,14 @@ fn validate_network_constraints(input: &DeploymentInput, errors: &mut ViolationL
         return;
     }
 
-    if input.runtime != "docker" {
+    // Podman shares the Docker-compatible lifecycle and honours
+    // `NetworkMode: host` identically, so both runtimes support host networking.
+    // containerd, Cloud Hypervisor and Firecracker have their own network models.
+    if !matches!(input.runtime.as_str(), "docker" | "podman") {
         errors.push(Violation::new(
             "network.mode",
             format!(
-                "host networking is only supported on the docker runtime, got '{}'",
+                "host networking is only supported on the docker and podman runtimes, got '{}'",
                 input.runtime
             ),
             "deployment.network.host_runtime_unsupported",
@@ -2679,6 +2682,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_host_network_mode_accepted_on_podman() {
+        // Podman shares the Docker-compatible lifecycle and honours
+        // `NetworkMode: host`, so host mode must be accepted on podman too.
+        let app = new_test_app().await;
+        let token = login(app.clone(), "admin", "changeme").await;
+        let server = TestServer::new(app).unwrap();
+
+        let response: TestResponse = server
+            .post("/deployments")
+            .add_header("Authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "runtime": "podman",
+                "name": "haproxy",
+                "namespace": "edge",
+                "image": "haproxy:2.9",
+                "network": { "mode": "host" }
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::CREATED);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["network"]["mode"], "host");
+    }
+
+    #[tokio::test]
     async fn create_host_mode_rejects_ports() {
         let app = new_test_app().await;
         let token = login(app.clone(), "admin", "changeme").await;
@@ -2762,10 +2790,18 @@ mod tests {
 
         assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
         let body: serde_json::Value = response.json();
+        // Match on the stable `code` slug instead of human text — the wording
+        // of `message` may evolve without breaking clients.
+        let codes: Vec<String> = body["violations"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|v| v["code"].as_str().unwrap_or("").to_string())
+            .collect();
         assert!(
-            body["detail"].as_str().unwrap().contains("docker runtime"),
-            "unexpected message: {}",
-            body["detail"]
+            codes.contains(&"deployment.network.host_runtime_unsupported".to_string()),
+            "expected deployment.network.host_runtime_unsupported, got {:?}",
+            codes
         );
     }
 

--- a/tests/e2e/fixtures/podman-hostnet.yaml
+++ b/tests/e2e/fixtures/podman-hostnet.yaml
@@ -1,0 +1,17 @@
+deployments:
+  hostnet:
+    name: hostnet
+    namespace: ring-e2e
+    runtime: podman
+    image: docker.io/library/busybox:latest
+    replicas: 1
+    config:
+      # Use the locally cached image; this test proves host networking, not
+      # registry auth, and avoids a flaky Docker Hub anonymous-pull 401.
+      image_pull_policy: IfNotPresent
+    network:
+      mode: host
+    command:
+      - "sh"
+      - "-c"
+      - "echo hello-hostnet > /tmp/index.html && httpd -f -p 18099 -h /tmp"

--- a/tests/e2e/podman/t4_podman_hostnet.sh
+++ b/tests/e2e/podman/t4_podman_hostnet.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# T4-podman: prove host networking works end-to-end on Podman. Boots Ring with
+# ONLY the Podman runtime enabled (Docker off), deploys a busybox httpd with
+# `network.mode: host` (no `ports:` — host mode binds the host directly), then
+# asserts the port is reachable on the host loopback with no port forwarding.
+#
+# This is the runtime-level proof that Podman honours `NetworkMode: host` the
+# same way Docker does, driven through Podman's Docker-compatible API.
+#
+# Skips cleanly (exit 0) if Podman or its rootless socket isn't available, so
+# the test never breaks a CI host without Podman.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T4-podman: host networking =="
+
+# --- Prerequisites: podman binary + a reachable rootless socket ---
+if ! command -v podman > /dev/null 2>&1; then
+  log "podman not installed — SKIP"
+  exit 0
+fi
+
+PODMAN_SOCK="${RING_PODMAN_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+SOCK_PATH="${PODMAN_SOCK#unix://}"
+if [ ! -S "$SOCK_PATH" ]; then
+  systemctl --user start podman.socket 2>/dev/null || true
+  if [ ! -S "$SOCK_PATH" ]; then
+    log "podman socket $SOCK_PATH not available — SKIP"
+    exit 0
+  fi
+fi
+log "podman socket: $SOCK_PATH"
+
+# Boot Ring with Podman only (no Docker), pointing at the rootless socket.
+export RING_E2E_ENABLE_DOCKER=false
+export RING_EXTRA_CONFIG="[server.runtime.podman]
+enabled = true
+host = \"$PODMAN_SOCK\""
+
+start_ring
+ring_login
+
+"$RING_BIN" apply --file "$SCRIPT_DIR/../fixtures/podman-hostnet.yaml"
+
+wait_deployment_status "ring-e2e" "hostnet" "running" 60
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "hostnet")
+if [ -z "$DEPLOYMENT_ID" ]; then
+  fail "could not find deployment id after apply"
+fi
+log "deployment id: $DEPLOYMENT_ID"
+
+# The container must run in host network mode.
+CID=$(podman ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+if [ -z "$CID" ]; then
+  podman ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" >&2
+  fail "expected a Podman container for deployment $DEPLOYMENT_ID, found none"
+fi
+NETMODE=$(podman inspect "$CID" --format '{{.HostConfig.NetworkMode}}')
+if [ "$NETMODE" != "host" ]; then
+  fail "expected NetworkMode=host, got '$NETMODE'"
+fi
+log "podman container $CID runs in host network mode"
+
+# The httpd bound port 18099 directly on the host: it must be reachable on
+# loopback with no Ring/Podman port forwarding involved.
+body=""
+for _ in $(seq 1 15); do
+  body=$(curl -s --max-time 3 http://127.0.0.1:18099/index.html 2>/dev/null || true)
+  if [ "$body" = "hello-hostnet" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ "$body" != "hello-hostnet" ]; then
+  fail "host-network port 18099 not reachable on loopback (got '$body')"
+fi
+log "host-network port 18099 reachable on loopback (got '$body')"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+for _ in $(seq 1 30); do
+  left=$(podman ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+  if [ "$left" -eq 0 ]; then
+    log "no podman container left for deployment $DEPLOYMENT_ID"
+    log "== T4-podman: PASS =="
+    exit 0
+  fi
+  sleep 1
+done
+
+podman ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" >&2
+fail "podman container for $DEPLOYMENT_ID still present after delete"


### PR DESCRIPTION
## What

`network.mode: host` is now accepted on the Podman runtime, not just Docker.

Podman shares Ring's Docker-compatible lifecycle and honours `NetworkMode: host` identically, so the container binds the host's network stack directly. The API was rejecting host mode for any runtime other than `docker`, which was an artificial limitation: the runtime path already supported it.

Cloud Hypervisor and Firecracker still reject host mode (they have their own per-VM network model).

## Example

```yaml
deployments:
  edge-proxy:
    name: edge-proxy
    namespace: edge
    runtime: podman
    image: "haproxy:2.9"
    replicas: 1
    network:
      mode: host
```

## Changes

- `create.rs`: host-mode validation allows `docker` **and** `podman`
- Unit test `create_host_network_mode_accepted_on_podman`; CH rejection test hardened to match on the stable violation `code`
- New e2e `tests/e2e/podman/t4_podman_hostnet.sh`: boots a Podman host-network workload and asserts the port is reachable on the host loopback (verified passing on Podman 5.7 rootless)
- Docs updated: `podman.md`, `use-host-network.md`, `runtimes.md`, `manifest.md`

## Test

```
cargo test --bin ring host_        # 38 passed
./tests/e2e/podman/t4_podman_hostnet.sh   # PASS
```