### PR TITLE
feat(logging): structured JSON console logs via RING_LOG_FORMAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenTelemetry metric export (opt-in, push) via `[server.telemetry.metrics]`: periodically pushes the per-deployment resource gauges (CPU, memory, network, disk, PIDs, instance and restart counts, labelled `{deployment, namespace, runtime}`) over OTLP/gRPC, read from the same stats cache the Prometheus `/metrics` endpoint uses so no extra runtime round-trip is added. Endpoint, `service.name` and push interval are configurable
 - OpenTelemetry log export (opt-in, push) via `[server.telemetry.logs]`: bridges the server's log events to an OTLP/gRPC collector in addition to the console. Each telemetry signal (traces, metrics, logs) is independently toggled; all three degrade gracefully when the collector is unreachable
 - `network.mode: host` is now accepted on the Podman runtime, not just Docker: Podman shares the Docker-compatible lifecycle and honours `NetworkMode: host`, so the container binds the host's network stack directly (Cloud Hypervisor and Firecracker still reject host mode)
+- `RING_LOG_FORMAT=json` switches the console logger to structured JSON (one object per line) for log shippers and structured ingestion; the default stays human-readable text. Independent of OTLP log export
 
 ## [0.10.0] - 2026-07-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,6 +3772,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,12 +3791,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ sysinfo = "0.35.1"
 libc = "0.2"
 thiserror = "2.0.18"
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "registry"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "json", "registry"] }
 tokio-vsock = "0.7"
 rust-embed = "8"
 mime_guess = "2"

--- a/documentation/help/observe-and-debug.md
+++ b/documentation/help/observe-and-debug.md
@@ -214,6 +214,12 @@ RUST_LOG=ring=debug ring server start                    # all Ring components
 RUST_LOG=ring::scheduler=debug ring server start         # one component
 ```
 
+For structured ingestion, set `RING_LOG_FORMAT=json` to emit one JSON object per log line instead of the default human-readable text:
+
+```bash
+RING_LOG_FORMAT=json ring server start | jq 'select(.level == "ERROR")'
+```
+
 Under systemd:
 
 ```bash

--- a/documentation/reference/environment-variables.md
+++ b/documentation/reference/environment-variables.md
@@ -13,6 +13,7 @@ Variables Ring reads from the process environment. Set them in your shell, a sys
 | `RING_SCHEDULER_INTERVAL` | No | `10` | Scheduler tick interval in seconds. Overrides `[scheduler] interval` in `config.toml` |
 | `RING_VIRTIOFSD` | No | autodiscover | Path to the `virtiofsd` binary on the host. Ring tries `/usr/libexec/virtiofsd` then `/usr/lib/qemu/virtiofsd` if unset |
 | `RUST_LOG` | No | (off) | Log level for Ring's own output. Examples: `RUST_LOG=info`, `RUST_LOG=ring=debug`, `RUST_LOG=ring::scheduler=debug` |
+| `RING_LOG_FORMAT` | No | `text` | Console log format. `json` emits one structured JSON object per line (for log shippers and structured ingestion); any other value keeps the default human-readable text. Independent of OTLP log export (`[server.telemetry.logs]`), which can run alongside either format |
 
 ## Generating the secret key
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,29 @@ fn env_filter() -> tracing_subscriber::EnvFilter {
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
 }
 
+/// Build the console `fmt` layer, honouring `RING_LOG_FORMAT`. `json` emits one
+/// JSON object per event (for log shippers / structured ingestion); anything
+/// else (unset, `text`, `pretty`) keeps the default human-readable format. The
+/// layer is boxed so both formats share one return type. Each format carries its
+/// own `EnvFilter` so it filters independently of layer ordering (see
+/// [`env_filter`]).
+fn console_fmt_layer<S>() -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    use tracing_subscriber::layer::Layer;
+
+    match env::var("RING_LOG_FORMAT").as_deref() {
+        Ok("json") => tracing_subscriber::fmt::layer()
+            .json()
+            .with_filter(env_filter())
+            .boxed(),
+        _ => tracing_subscriber::fmt::layer()
+            .with_filter(env_filter())
+            .boxed(),
+    }
+}
+
 /// Initialise `tracing`. Always installs the console `fmt` layer; when
 /// `telemetry` is `Some` (server start) it also attaches whichever of the
 /// subscriber-layer signals — traces and logs — are enabled, returning a guard
@@ -57,8 +80,7 @@ fn init_tracing(
     use tracing_subscriber::layer::{Layer, SubscriberExt};
     use tracing_subscriber::util::SubscriberInitExt;
 
-    let fmt_layer = tracing_subscriber::fmt::layer().with_filter(env_filter());
-    let registry = tracing_subscriber::registry().with(fmt_layer);
+    let registry = tracing_subscriber::registry().with(console_fmt_layer());
 
     let Some(cfg) = telemetry else {
         registry.init();

--- a/tests/e2e/server/t19_json_logging.sh
+++ b/tests/e2e/server/t19_json_logging.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# T19-server: `RING_LOG_FORMAT=json` switches the console logger to structured
+# JSON (one object per line) instead of the default human-readable text.
+#
+# Invariants:
+#   1. With RING_LOG_FORMAT=json, the server still boots and becomes healthy.
+#   2. The startup log lines are valid JSON objects carrying the expected
+#      fields (timestamp, level, target, fields.message).
+#
+# The default (text) format is exercised by every other e2e test, which all run
+# without RING_LOG_FORMAT set, so there's no need to re-assert it here.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T19-server: JSON console logging =="
+
+# --- Invariant 1 + 2: JSON mode boots and emits parseable JSON ---
+export RING_LOG_FORMAT=json
+start_ring
+
+if ! curl -sf "${RING_URL}/healthz" > /dev/null 2>&1; then
+  fail "healthz did not answer with RING_LOG_FORMAT=json"
+fi
+log "server healthy with RING_LOG_FORMAT=json"
+
+# The startup banner is printed with plain println! (not the tracing subscriber),
+# so filter to the tracing lines: those start with '{' in JSON mode. Take the
+# first such line and assert it is valid JSON with the expected shape.
+JSON_LINE=$(grep -m1 '^{' "$RING_TEST_DIR/ring.log" || true)
+if [ -z "$JSON_LINE" ]; then
+  echo "[e2e] ring.log:" >&2
+  cat "$RING_TEST_DIR/ring.log" >&2
+  fail "no JSON log line found with RING_LOG_FORMAT=json"
+fi
+
+echo "$JSON_LINE" | python3 -c '
+import json, sys
+obj = json.loads(sys.stdin.read())
+for key in ("timestamp", "level", "target"):
+    assert key in obj, f"missing key {key!r} in {obj}"
+assert "message" in obj.get("fields", {}), f"missing fields.message in {obj}"
+print("ok:", obj["level"], obj["target"])
+' || fail "startup log line is not valid structured JSON: $JSON_LINE"
+log "startup logs are valid JSON objects"
+
+log "PASS T19-server: JSON console logging"


### PR DESCRIPTION
## What

Adds `RING_LOG_FORMAT=json` to emit the console logs as structured JSON (one object per line) instead of the default human-readable text. For log shippers and structured ingestion pipelines.

This is independent of OTLP log export (`[server.telemetry.logs]`), which can run alongside either console format.

## Example

```bash
RING_LOG_FORMAT=json ring server start | jq 'select(.level == "ERROR")'
```

```json
{"timestamp":"2026-07-07T12:06:36Z","level":"INFO","fields":{"message":"Starting server..."},"target":"ring::commands::server"}
```

Unset (or any value other than `json`) keeps the existing text format, so nothing changes by default.

## Changes

- `main.rs`: `console_fmt_layer()` picks the JSON or text `fmt` layer from `RING_LOG_FORMAT`; `json` feature enabled on `tracing-subscriber`
- New e2e `tests/e2e/server/t19_json_logging.sh`: boots the server in JSON mode and asserts the log lines parse as JSON with the expected fields
- Docs: `environment-variables.md` (new row), `observe-and-debug.md` (usage with `jq`)

## Test

```
./tests/e2e/server/t19_json_logging.sh   # PASS
```