### PR TITLE
feat(server): graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `network.mode: host` is now accepted on the Podman runtime, not just Docker: Podman shares the Docker-compatible lifecycle and honours `NetworkMode: host`, so the container binds the host's network stack directly (Cloud Hypervisor and Firecracker still reject host mode)
 - `RING_LOG_FORMAT=json` switches the console logger to structured JSON (one object per line) for log shippers and structured ingestion; the default stays human-readable text. Independent of OTLP log export
 
+### Changed
+- `ring server start` shuts down gracefully on `SIGTERM` / `Ctrl-C`: it stops accepting new API connections, drains in-flight HTTP requests, tears down the scheduler, and exits on its own instead of being killed abruptly. Managed workloads keep running and are reconciled again on restart
+
 ## [0.10.0] - 2026-07-04
 
 ### Added

--- a/documentation/how-to/run-as-service.md
+++ b/documentation/how-to/run-as-service.md
@@ -63,6 +63,12 @@ sudo journalctl -u ring -f
 
 The systemd `Environment=` directive bakes the value into the unit file, which usually ends up in version control. A separate `EnvironmentFile=` keeps `RING_SECRET_KEY` out of git and lets you `chmod 0600` it.
 
+### Graceful shutdown
+
+On `SIGTERM` (what `systemctl stop` sends) or `Ctrl-C` (`SIGINT`), Ring stops accepting new API connections, lets in-flight HTTP requests finish, tears down the scheduler, and exits on its own. Workloads it manages are **not** stopped: they keep running under their container runtime, and the scheduler reconciles them again when Ring restarts.
+
+systemd's default `TimeoutStopSec` (90s) is ample; the drain normally completes in well under a second. No `ExecStop=` or `KillSignal=` override is needed. If you run a custom unit, keep the default `KillSignal=SIGTERM`.
+
 ## Docker Compose
 
 If Ring itself runs as a container:

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -246,9 +246,46 @@ pub(crate) async fn start(
             return;
         }
     };
-    if let Err(e) = axum::serve(listener, app).await {
+    if let Err(e) = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+    {
         error!("API server stopped unexpectedly: {}", e);
     }
+    info!("API server shut down gracefully");
+}
+
+/// Resolves when the process receives a shutdown signal: Ctrl-C (SIGINT) on any
+/// platform, or SIGTERM on Unix (what `systemctl stop` and container runtimes
+/// send). Handing this to `axum::serve(...).with_graceful_shutdown(...)` stops
+/// accepting new connections and lets in-flight requests finish before the
+/// server returns, instead of dropping them on an abrupt exit.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            error!("failed to install Ctrl-C handler: {}", e);
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => error!("failed to install SIGTERM handler: {}", e),
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+
+    info!("shutdown signal received, draining in-flight requests");
 }
 
 #[cfg(test)]

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -394,17 +394,24 @@ pub(crate) async fn execute(
         intentional_shutdowns,
     ));
 
-    if let Err(e) = api_server_handler.await {
-        eprintln!("API server task failed: {}", e);
+    // The API server owns the shutdown signal (SIGTERM / Ctrl-C): it drains
+    // in-flight HTTP requests, then its task returns. That is our cue to bring
+    // the whole process down. The scheduler, event worker and Docker listener
+    // are daemon loops with no critical buffered state — each reconcile step
+    // persists to the DB transactionally, so aborting them between ticks is
+    // safe. We abort them rather than awaiting, since their loops never return
+    // on their own and would otherwise hang the process after the API is gone.
+    match api_server_handler.await {
+        Ok(()) => info!("API server task ended, shutting down scheduler"),
+        Err(e) => eprintln!("API server task failed: {}", e),
     }
-    if let Err(e) = scheduler_handler.await {
-        eprintln!("Scheduler task failed: {}", e);
+
+    scheduler_handler.abort();
+    if let Some(handler) = event_listener_handler {
+        handler.abort();
     }
-    if let Some(handler) = event_listener_handler
-        && let Err(e) = handler.await
-    {
-        eprintln!("Docker event listener task failed: {}", e);
-    }
+
+    info!("ring server stopped");
 }
 
 /// Current Unix time in seconds, or `0` if the clock is before the epoch

--- a/tests/e2e/server/t20_graceful_shutdown.sh
+++ b/tests/e2e/server/t20_graceful_shutdown.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# T20-server: the server shuts down gracefully on SIGTERM (what systemctl stop
+# and container runtimes send) instead of being killed abruptly.
+#
+# Invariants:
+#   1. On SIGTERM, the process exits on its own within a few seconds (the API
+#      drains, the scheduler is torn down, the binary returns) — it does NOT
+#      hang waiting on the scheduler's infinite loop.
+#   2. The shutdown path is logged: the API drains in-flight requests, then the
+#      process reports it stopped.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T20-server: graceful shutdown on SIGTERM =="
+
+# Docker isn't needed for this test; run server-only with Podman if present,
+# else fall back to Docker (default). The shutdown path is runtime-agnostic.
+start_ring
+
+if ! curl -sf "${RING_URL}/healthz" > /dev/null 2>&1; then
+  fail "server not healthy before shutdown test"
+fi
+
+# --- Invariant 1: SIGTERM makes the process exit on its own, quickly ---
+log "sending SIGTERM to pid $RING_PID"
+kill -TERM "$RING_PID"
+
+exited=false
+for _ in $(seq 1 20); do   # up to ~10s
+  if ! kill -0 "$RING_PID" 2>/dev/null; then
+    exited=true
+    break
+  fi
+  sleep 0.5
+done
+
+if [ "$exited" != "true" ]; then
+  echo "[e2e] ring.log:" >&2
+  tail -n 40 "$RING_TEST_DIR/ring.log" >&2
+  # Don't leave it running for the trap to reap ambiguously.
+  kill -9 "$RING_PID" 2>/dev/null || true
+  fail "server did not exit within 10s of SIGTERM (graceful shutdown hung)"
+fi
+# Reap the exit status so the cleanup trap doesn't try to kill a dead pid.
+wait "$RING_PID" 2>/dev/null || true
+log "server exited on its own after SIGTERM"
+
+# --- Invariant 2: the shutdown was logged as graceful ---
+if ! grep -q "shut down gracefully" "$RING_TEST_DIR/ring.log"; then
+  echo "[e2e] ring.log:" >&2
+  tail -n 40 "$RING_TEST_DIR/ring.log" >&2
+  fail "expected 'shut down gracefully' in the log"
+fi
+if ! grep -q "ring server stopped" "$RING_TEST_DIR/ring.log"; then
+  echo "[e2e] ring.log:" >&2
+  tail -n 40 "$RING_TEST_DIR/ring.log" >&2
+  fail "expected 'ring server stopped' in the log"
+fi
+log "shutdown path logged (API drained, process stopped)"
+
+# The pid is already gone; blank RING_PID so the cleanup trap skips it.
+RING_PID=""
+
+log "PASS T20-server: graceful shutdown on SIGTERM"


### PR DESCRIPTION
## What

`ring server start` now shuts down gracefully instead of being killed abruptly.

On `SIGTERM` (what `systemctl stop` and container runtimes send) or `Ctrl-C` (`SIGINT`), the server:
1. stops accepting new API connections,
2. lets in-flight HTTP requests finish (`axum`'s `with_graceful_shutdown`),
3. tears down the scheduler and background workers,
4. exits on its own.

Managed workloads are **not** stopped — they keep running under their container runtime and are reconciled again on restart.

## Why

Two gaps before this change:
- `axum::serve(...)` had no shutdown signal, so in-flight requests were dropped on exit.
- Even once the API returned, the process awaited the scheduler's infinite loop, so the binary **hung** and only died on `SIGKILL`.

Now the API task owning the signal is the cue to bring the whole process down; the daemon loops (scheduler, event worker, Docker listener) are aborted since they persist state transactionally each tick and have nothing to flush.

## Changes

- `src/api/server.rs`: `shutdown_signal()` (SIGTERM on Unix + Ctrl-C everywhere) wired into `with_graceful_shutdown`
- `src/commands/server.rs`: process exits when the API task returns, aborting the daemon loops instead of awaiting them forever
- New e2e `tests/e2e/server/t20_graceful_shutdown.sh`: SIGTERM makes the process exit on its own within seconds, with the drain path logged
- Docs: `run-as-service.md` gains a "Graceful shutdown" section (systemd `TimeoutStopSec` note)

## Test

```
./tests/e2e/server/t20_graceful_shutdown.sh   # PASS
cargo test --bin ring                         # 748 passed
```

Verified live: SIGTERM drains the API and the process exits in ~45ms with the full shutdown log trail.