### PR TITLE
feat(dashboard): volumes list view

### DIFF
--- a/dashboard/src/lib/ResourceTable.svelte
+++ b/dashboard/src/lib/ResourceTable.svelte
@@ -1,0 +1,175 @@
+<script lang="ts" generics="T">
+  /**
+   * The list-page shell shared by every resource listing: header with
+   * refresh-meta, optional namespace filter, error / empty / table states,
+   * plus the load-and-poll lifecycle.
+   *
+   * Pages own their columns and cells (via the `row` snippet) and nothing
+   * else — everything that was duplicated verbatim across the secrets and
+   * configs pages lives here instead.
+   */
+  import { onDestroy, onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { getToken } from '$lib/auth';
+  import { timeAgo } from '$lib/utils';
+
+  interface Props {
+    title: string;
+    subtitle: string;
+    /** Column headers, in order. `align: 'right'` gets tabular numerals. */
+    columns: Array<{ label: string; align?: 'right' }>;
+    /** Fetches the full list; re-run on refresh and on every poll tick. */
+    load: () => Promise<T[]>;
+    /** Stable key per item, for keyed `{#each}`. */
+    key: (item: T) => string;
+    /** Reads the namespace of an item. Omit for resources without one — the
+     *  filter bar is then never rendered. */
+    namespaceOf?: (item: T) => string;
+    /** Poll interval in ms; `0` disables polling. */
+    pollMs?: number;
+    /** One `<tr>` per item. */
+    row: Snippet<[T]>;
+    /** Shown when the list comes back empty. */
+    empty: Snippet;
+  }
+
+  let {
+    title,
+    subtitle,
+    columns,
+    load,
+    key,
+    namespaceOf,
+    pollMs = 5000,
+    row,
+    empty
+  }: Props = $props();
+
+  let items = $state<T[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let nsFilter = $state<string>('');
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  export async function refresh(): Promise<void> {
+    try {
+      items = await load();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  function syncUrl(): void {
+    const params = new URLSearchParams();
+    if (nsFilter) {
+      params.set('namespace', nsFilter);
+    }
+    const qs = params.toString();
+    history.replaceState(null, '', `${$page.url.pathname}${qs ? `?${qs}` : ''}`);
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      goto('/login');
+      return;
+    }
+    nsFilter = $page.url.searchParams.get('namespace') ?? '';
+    void refresh();
+    if (pollMs > 0) {
+      poll = setInterval(() => void refresh(), pollMs);
+    }
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function countIn(ns: string): number {
+    return namespaceOf ? items.filter((i) => namespaceOf(i) === ns).length : 0;
+  }
+
+  let namespaces = $derived(
+    namespaceOf
+      ? Array.from(new Set(items.map(namespaceOf))).sort((a, b) => a.localeCompare(b))
+      : []
+  );
+  let filtered = $derived(
+    namespaceOf && nsFilter ? items.filter((i) => namespaceOf(i) === nsFilter) : items
+  );
+</script>
+
+<svelte:head><title>Ring · {title}</title></svelte:head>
+
+<header class="page-header">
+  <div>
+    <h1>{title}</h1>
+    <p class="subtitle">{subtitle}</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && items.length > 0}
+  {#if namespaces.length > 1}
+    <div class="filter-bar">
+      <label for="ns-filter">Namespace</label>
+      <select id="ns-filter" bind:value={nsFilter} onchange={syncUrl}>
+        <option value="">All ({items.length})</option>
+        {#each namespaces as ns}
+          <option value={ns}>{ns} ({countIn(ns)})</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          {#each columns as col}
+            <th class:num={col.align === 'right'}>{col.label}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each filtered as item (key(item))}
+          {@render row(item)}
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && items.length === 0 && !errorMsg}
+  <div class="empty">
+    {@render empty()}
+  </div>
+{/if}
+
+<style>
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -353,6 +353,33 @@ export function listConfigs(): Promise<Config[]> {
   return request<Config[]>('/configs');
 }
 
+export interface Volume {
+  id: string;
+  created_at: string;
+  /** Absent until the volume is updated. */
+  updated_at: string | null;
+  namespace: string;
+  name: string;
+  /** Bytes. `null` when the backend doesn't report a size. */
+  size: number | null;
+  backend_type: string;
+  host_path: string;
+  /** Unlike `Config.labels` (a free-form string), the volumes endpoint
+   *  returns a real object. */
+  labels: Record<string, string>;
+}
+
+/** Lists volumes, optionally narrowed server-side to given namespaces. The
+ *  endpoint expects a repeated `namespace[]` parameter. */
+export function listVolumes(namespaces: string[] = []): Promise<Volume[]> {
+  const params = new URLSearchParams();
+  for (const ns of namespaces) {
+    params.append('namespace[]', ns);
+  }
+  const qs = params.toString();
+  return request<Volume[]>(`/volumes${qs ? `?${qs}` : ''}`);
+}
+
 export interface LogsQuery {
   tail?: number;
   since?: string;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
     { href: '/namespaces', label: 'Namespaces', icon: 'folder' },
     { href: '/secrets', label: 'Secrets', icon: 'key' },
     { href: '/configs', label: 'Configs', icon: 'file' },
+    { href: '/volumes', label: 'Volumes', icon: 'disc' },
     { href: '/node', label: 'Node', icon: 'server' }
   ];
 
@@ -140,6 +141,19 @@
                 >
                   <path d="M3 1.5h6L13 5.5V14a.5.5 0 0 1-.5.5h-9A.5.5 0 0 1 3 14V1.5z" />
                   <path d="M9 1.5V5.5h4" />
+                </svg>
+              {:else if item.icon === 'disc'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <ellipse cx="8" cy="4" rx="5.5" ry="2.25" />
+                  <path d="M2.5 4v8c0 1.24 2.46 2.25 5.5 2.25s5.5-1.01 5.5-2.25V4" />
+                  <path d="M2.5 8c0 1.24 2.46 2.25 5.5 2.25s5.5-1.01 5.5-2.25" />
                 </svg>
               {:else if item.icon === 'server'}
                 <svg

--- a/dashboard/src/routes/configs/+page.svelte
+++ b/dashboard/src/routes/configs/+page.svelte
@@ -1,55 +1,18 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import ResourceTable from '$lib/ResourceTable.svelte';
   import { listConfigs, type Config } from '$lib/api';
-  import { getToken } from '$lib/auth';
-  import { formatDate, timeAgo } from '$lib/utils';
+  import { formatDate } from '$lib/utils';
 
-  let configs = $state<Config[]>([]);
-  let loading = $state(true);
-  let errorMsg = $state<string | null>(null);
-  let lastFetch = $state<Date | null>(null);
-  let poll: ReturnType<typeof setInterval> | null = null;
-  let nsFilter = $state<string>('');
   let expanded = $state<Set<string>>(new Set());
 
-  async function refresh() {
-    try {
-      configs = await listConfigs();
-      errorMsg = null;
-    } catch (e) {
-      errorMsg = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-      lastFetch = new Date();
-    }
-  }
-
-  function syncUrl(): void {
-    const params = new URLSearchParams();
-    if (nsFilter) {
-      params.set('namespace', nsFilter);
-    }
-    const qs = params.toString();
-    history.replaceState(null, '', `${$page.url.pathname}${qs ? `?${qs}` : ''}`);
-  }
-
-  onMount(() => {
-    if (!getToken()) {
-      goto('/login');
-      return;
-    }
-    nsFilter = $page.url.searchParams.get('namespace') ?? '';
-    void refresh();
-    poll = setInterval(() => void refresh(), 5000);
-  });
-
-  onDestroy(() => {
-    if (poll) {
-      clearInterval(poll);
-    }
-  });
+  const columns = [
+    { label: '' },
+    { label: 'Name' },
+    { label: 'Namespace' },
+    { label: 'Size', align: 'right' as const },
+    { label: 'Labels' },
+    { label: 'Created' }
+  ];
 
   function toggle(id: string) {
     // Clone before mutating: Svelte 5 reactivity tracks the reference, not the
@@ -73,112 +36,60 @@
     }
     return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
   }
-
-  let namespaces = $derived(
-    Array.from(new Set(configs.map((c) => c.namespace))).sort((a, b) => a.localeCompare(b))
-  );
-  let filtered = $derived(nsFilter ? configs.filter((c) => c.namespace === nsFilter) : configs);
 </script>
 
-<svelte:head><title>Ring · Configs</title></svelte:head>
-
-<header class="page-header">
-  <div>
-    <h1>Configs</h1>
-    <p class="subtitle">Free-form configuration blobs mounted into deployments</p>
-  </div>
-  <div class="header-actions">
-    {#if lastFetch}
-      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+<ResourceTable
+  title="Configs"
+  subtitle="Free-form configuration blobs mounted into deployments"
+  {columns}
+  load={listConfigs}
+  key={(c: Config) => c.id}
+  namespaceOf={(c: Config) => c.namespace}
+>
+  {#snippet row(c: Config)}
+    {@const open = expanded.has(c.id)}
+    <tr>
+      <td class="caret-cell">
+        <button
+          type="button"
+          class="caret"
+          aria-expanded={open}
+          aria-controls={`config-${c.id}-data`}
+          aria-label={open ? 'Collapse config data' : 'Expand config data'}
+          onclick={() => toggle(c.id)}
+        >
+          {open ? '▾' : '▸'}
+        </button>
+      </td>
+      <td class="mono">{c.name}</td>
+      <td>
+        <a class="ns-link" href="/configs?namespace={c.namespace}">{c.namespace}</a>
+      </td>
+      <td class="num mono">{byteSize(c.data)}</td>
+      <td class="mono small">{c.labels || '—'}</td>
+      <td class="muted">{formatDate(c.created_at)}</td>
+    </tr>
+    {#if open}
+      <tr class="data-row" id={`config-${c.id}-data`}>
+        <td></td>
+        <td colspan="5">
+          <pre class="data">{c.data}</pre>
+        </td>
+      </tr>
     {/if}
-    <button class="btn-secondary" onclick={refresh} disabled={loading}>
-      {loading ? 'loading…' : 'Refresh'}
-    </button>
-  </div>
-</header>
+  {/snippet}
 
-{#if errorMsg}
-  <div class="alert">
-    <strong>error</strong> {errorMsg}
-  </div>
-{/if}
-
-{#if !loading && configs.length > 0}
-  {#if namespaces.length > 1}
-    <div class="filter-bar">
-      <label for="ns-filter">Namespace</label>
-      <select id="ns-filter" bind:value={nsFilter} onchange={syncUrl}>
-        <option value="">All ({configs.length})</option>
-        {#each namespaces as ns}
-          <option value={ns}>{ns} ({configs.filter((c) => c.namespace === ns).length})</option>
-        {/each}
-      </select>
-    </div>
-  {/if}
-
-  <section class="card">
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          <th>Name</th>
-          <th>Namespace</th>
-          <th class="num">Size</th>
-          <th>Labels</th>
-          <th>Created</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each filtered as c (c.id)}
-          {@const open = expanded.has(c.id)}
-          <tr>
-            <td class="caret-cell">
-              <button
-                type="button"
-                class="caret"
-                aria-expanded={open}
-                aria-controls={`config-${c.id}-data`}
-                aria-label={open ? 'Collapse config data' : 'Expand config data'}
-                onclick={() => toggle(c.id)}
-              >
-                {open ? '▾' : '▸'}
-              </button>
-            </td>
-            <td class="mono">{c.name}</td>
-            <td>
-              <a class="ns-link" href="/configs?namespace={c.namespace}">{c.namespace}</a>
-            </td>
-            <td class="num mono">{byteSize(c.data)}</td>
-            <td class="mono small">{c.labels || '—'}</td>
-            <td class="muted">{formatDate(c.created_at)}</td>
-          </tr>
-          {#if open}
-            <tr class="data-row" id={`config-${c.id}-data`}>
-              <td></td>
-              <td colspan="5">
-                <pre class="data">{c.data}</pre>
-              </td>
-            </tr>
-          {/if}
-        {/each}
-      </tbody>
-    </table>
-  </section>
-{/if}
-
-{#if !loading && configs.length === 0 && !errorMsg}
-  <div class="empty">
+  {#snippet empty()}
     <p>No configs yet.</p>
     <p class="muted">
       Configs are created over the API (<code>POST /configs</code>) and mounted into deployments via
       the <code>config:</code> field in your manifest.
     </p>
-  </div>
-{/if}
+  {/snippet}
+</ResourceTable>
 
 <style>
-  td.num,
-  th.num {
+  td.num {
     text-align: right;
     font-variant-numeric: tabular-nums;
   }

--- a/dashboard/src/routes/secrets/+page.svelte
+++ b/dashboard/src/routes/secrets/+page.svelte
@@ -1,133 +1,44 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import ResourceTable from '$lib/ResourceTable.svelte';
   import { listSecrets, type Secret } from '$lib/api';
-  import { getToken } from '$lib/auth';
-  import { formatDate, timeAgo } from '$lib/utils';
+  import { formatDate } from '$lib/utils';
 
-  let secrets = $state<Secret[]>([]);
-  let loading = $state(true);
-  let errorMsg = $state<string | null>(null);
-  let lastFetch = $state<Date | null>(null);
-  let poll: ReturnType<typeof setInterval> | null = null;
-  let nsFilter = $state<string>('');
-
-  async function refresh() {
-    try {
-      secrets = await listSecrets();
-      errorMsg = null;
-    } catch (e) {
-      errorMsg = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-      lastFetch = new Date();
-    }
-  }
-
-  function syncUrl(): void {
-    const params = new URLSearchParams();
-    if (nsFilter) {
-      params.set('namespace', nsFilter);
-    }
-    const qs = params.toString();
-    history.replaceState(null, '', `${$page.url.pathname}${qs ? `?${qs}` : ''}`);
-  }
-
-  onMount(() => {
-    if (!getToken()) {
-      goto('/login');
-      return;
-    }
-    nsFilter = $page.url.searchParams.get('namespace') ?? '';
-    void refresh();
-    poll = setInterval(() => void refresh(), 5000);
-  });
-
-  onDestroy(() => {
-    if (poll) {
-      clearInterval(poll);
-    }
-  });
-
-  let namespaces = $derived(
-    Array.from(new Set(secrets.map((s) => s.namespace))).sort((a, b) => a.localeCompare(b))
-  );
-  let filtered = $derived(nsFilter ? secrets.filter((s) => s.namespace === nsFilter) : secrets);
+  const columns = [
+    { label: 'Name' },
+    { label: 'Namespace' },
+    { label: 'Created' },
+    { label: 'Updated' }
+  ];
 </script>
 
-<svelte:head><title>Ring · Secrets</title></svelte:head>
+<ResourceTable
+  title="Secrets"
+  subtitle="AES-256-GCM encrypted values, scoped per namespace"
+  {columns}
+  load={listSecrets}
+  key={(s: Secret) => s.id}
+  namespaceOf={(s: Secret) => s.namespace}
+>
+  {#snippet row(s: Secret)}
+    <tr>
+      <td class="mono">{s.name}</td>
+      <td>
+        <a class="ns-link" href="/secrets?namespace={s.namespace}">{s.namespace}</a>
+      </td>
+      <td class="muted">{formatDate(s.created_at)}</td>
+      <td class="muted">{s.updated_at ? formatDate(s.updated_at) : '—'}</td>
+    </tr>
+  {/snippet}
 
-<header class="page-header">
-  <div>
-    <h1>Secrets</h1>
-    <p class="subtitle">AES-256-GCM encrypted values, scoped per namespace</p>
-  </div>
-  <div class="header-actions">
-    {#if lastFetch}
-      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
-    {/if}
-    <button class="btn-secondary" onclick={refresh} disabled={loading}>
-      {loading ? 'loading…' : 'Refresh'}
-    </button>
-  </div>
-</header>
-
-{#if errorMsg}
-  <div class="alert">
-    <strong>error</strong> {errorMsg}
-  </div>
-{/if}
-
-{#if !loading && secrets.length > 0}
-  {#if namespaces.length > 1}
-    <div class="filter-bar">
-      <label for="ns-filter">Namespace</label>
-      <select id="ns-filter" bind:value={nsFilter} onchange={syncUrl}>
-        <option value="">All ({secrets.length})</option>
-        {#each namespaces as ns}
-          <option value={ns}>{ns} ({secrets.filter((s) => s.namespace === ns).length})</option>
-        {/each}
-      </select>
-    </div>
-  {/if}
-
-  <section class="card">
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Namespace</th>
-          <th>Created</th>
-          <th>Updated</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each filtered as s (s.id)}
-          <tr>
-            <td class="mono">{s.name}</td>
-            <td>
-              <a class="ns-link" href="/secrets?namespace={s.namespace}">{s.namespace}</a>
-            </td>
-            <td class="muted">{formatDate(s.created_at)}</td>
-            <td class="muted">{s.updated_at ? formatDate(s.updated_at) : '—'}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </section>
-{/if}
-
-{#if !loading && secrets.length === 0 && !errorMsg}
-  <div class="empty">
+  {#snippet empty()}
     <p>No secrets yet.</p>
     <p class="muted">
       Create one with <code>ring secret create &lt;name&gt; --namespace &lt;ns&gt; --value
       &lt;value&gt;</code>. The value is encrypted before being stored and is never returned by the
       API.
     </p>
-  </div>
-{/if}
+  {/snippet}
+</ResourceTable>
 
 <style>
   .ns-link {

--- a/dashboard/src/routes/volumes/+page.svelte
+++ b/dashboard/src/routes/volumes/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import ResourceTable from '$lib/ResourceTable.svelte';
+  import { listVolumes, type Volume } from '$lib/api';
+  import { formatBytes, formatDate } from '$lib/utils';
+
+  const columns = [
+    { label: 'Name' },
+    { label: 'Namespace' },
+    { label: 'Size', align: 'right' as const },
+    { label: 'Backend' },
+    { label: 'Host path' },
+    { label: 'Labels' },
+    { label: 'Created' }
+  ];
+
+  /** `key=value` pairs, matching how the configs page renders its labels. */
+  function labelText(labels: Record<string, string>): string {
+    const pairs = Object.entries(labels);
+    if (pairs.length === 0) {
+      return '—';
+    }
+    return pairs.map(([k, v]) => `${k}=${v}`).join(', ');
+  }
+</script>
+
+<ResourceTable
+  title="Volumes"
+  subtitle="Persistent storage attached to deployments, scoped per namespace"
+  {columns}
+  load={() => listVolumes()}
+  key={(v: Volume) => v.id}
+  namespaceOf={(v: Volume) => v.namespace}
+>
+  {#snippet row(v: Volume)}
+    <tr>
+      <td class="mono">{v.name}</td>
+      <td>
+        <a class="ns-link" href="/volumes?namespace={v.namespace}">{v.namespace}</a>
+      </td>
+      <td class="num mono">{v.size === null ? '—' : formatBytes(v.size)}</td>
+      <td><span class="status">{v.backend_type}</span></td>
+      <td class="mono small path">{v.host_path}</td>
+      <td class="mono small">{labelText(v.labels)}</td>
+      <td class="muted">{formatDate(v.created_at)}</td>
+    </tr>
+  {/snippet}
+
+  {#snippet empty()}
+    <p>No volumes yet.</p>
+    <p class="muted">
+      Volumes are created over the API (<code>POST /volumes</code>) and attached to deployments via
+      the <code>volumes:</code> field in your manifest.
+    </p>
+  {/snippet}
+</ResourceTable>
+
+<style>
+  td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  td.small {
+    font-size: 0.78rem;
+  }
+  /* Host paths can be long; keep them from stretching the table. */
+  td.path {
+    max-width: 18rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ns-link {
+    color: var(--fg-0);
+    font-weight: 500;
+  }
+  .ns-link:hover {
+    color: var(--accent);
+  }
+</style>


### PR DESCRIPTION
Adds a read-only Volumes page to the dashboard, and extracts the list-page shell that secrets and configs already duplicated.

## Changes

- `ResourceTable.svelte`: shared list-page shell (load + poll, header, namespace filter, error/empty states, table). Pages supply columns and cells via snippets.
- `listVolumes()` + `Volume` type in `api.ts`, typed after the `/volumes` response.
- New `/volumes` route and nav entry.
- Secrets and configs migrated onto the component.

Read-only: no create/update/delete. Write paths come later.

## Notes

- Volume labels come back as an object, unlike the free-form string configs use.
- Configs keeps its expandable data rows, which exercises the snippet API beyond a plain table.

## Checks

`svelte-check`, `biome check` and `build` pass. The page has not been exercised against a running server yet — worth a look when reviewing.