### PR TITLE
fix(lint): satisfy clippy 1.97 lints

### DIFF
--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -333,7 +333,7 @@ impl Deployment {
         self.name = env_resolver(&self.name, env_vars);
         self.image = env_resolver(&self.image, env_vars);
 
-        for (_, value) in self.environment.iter_mut() {
+        for value in self.environment.values_mut() {
             if let EnvValue::Plain(s) = value {
                 *s = env_resolver(s, env_vars);
             }

--- a/src/runtime/docker/container.rs
+++ b/src/runtime/docker/container.rs
@@ -443,7 +443,7 @@ pub(crate) async fn create_container(
     let temporary_id = tiny_id();
     let container_name = format!(
         "{}_{}_{}",
-        &deployment.namespace, &deployment.name, temporary_id
+        deployment.namespace, deployment.name, temporary_id
     );
 
     let mut labels = HashMap::new();


### PR DESCRIPTION
Clippy 1.97 promotes two lints that fire on existing code, failing `cargo clippy --all-targets -- -D warnings` on every branch regardless of its contents.

- `src/commands/apply.rs`: `for (_, value) in map.iter_mut()` → `map.values_mut()` (`for_kv_map`)
- `src/runtime/docker/container.rs`: drop two redundant `&` in a `format!` argument (`useless_borrows_in_formatting`)

Behaviour is unchanged; both are mechanical rewrites suggested by clippy itself.

`main` is green only because it last ran on an older toolchain — re-running it today fails the same way.