### PR TITLE
feat(dashboard): webhooks list view

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -380,6 +380,21 @@ export function listVolumes(namespaces: string[] = []): Promise<Volume[]> {
   return request<Volume[]>(`/volumes${qs ? `?${qs}` : ''}`);
 }
 
+export interface Webhook {
+  id: string;
+  url: string;
+  /** Event names this webhook subscribes to. */
+  events: string[];
+  created_at: string;
+  /** Set once revoked; the webhook then stops receiving deliveries. */
+  revoked_at: string | null;
+}
+
+/** Webhooks are not namespaced. The HMAC secret is never returned by the API. */
+export function listWebhooks(): Promise<Webhook[]> {
+  return request<Webhook[]>('/webhooks');
+}
+
 export interface LogsQuery {
   tail?: number;
   since?: string;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
     { href: '/secrets', label: 'Secrets', icon: 'key' },
     { href: '/configs', label: 'Configs', icon: 'file' },
     { href: '/volumes', label: 'Volumes', icon: 'disc' },
+    { href: '/webhooks', label: 'Webhooks', icon: 'webhook' },
     { href: '/node', label: 'Node', icon: 'server' }
   ];
 
@@ -154,6 +155,20 @@
                   <ellipse cx="8" cy="4" rx="5.5" ry="2.25" />
                   <path d="M2.5 4v8c0 1.24 2.46 2.25 5.5 2.25s5.5-1.01 5.5-2.25V4" />
                   <path d="M2.5 8c0 1.24 2.46 2.25 5.5 2.25s5.5-1.01 5.5-2.25" />
+                </svg>
+              {:else if item.icon === 'webhook'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <circle cx="8" cy="4.25" r="2.25" />
+                  <circle cx="3.75" cy="11.5" r="2.25" />
+                  <circle cx="12.25" cy="11.5" r="2.25" />
+                  <path d="M6.85 6.2L4.9 9.55M9.15 6.2l1.95 3.35M6 11.5h4" />
                 </svg>
               {:else if item.icon === 'server'}
                 <svg

--- a/dashboard/src/routes/webhooks/+page.svelte
+++ b/dashboard/src/routes/webhooks/+page.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import ResourceTable from '$lib/ResourceTable.svelte';
+  import { listWebhooks, type Webhook } from '$lib/api';
+  import { formatDate } from '$lib/utils';
+
+  const columns = [
+    { label: 'URL' },
+    { label: 'Events' },
+    { label: 'Status' },
+    { label: 'Created' }
+  ];
+</script>
+
+<ResourceTable
+  title="Webhooks"
+  subtitle="HTTP endpoints notified when deployment events occur"
+  {columns}
+  load={listWebhooks}
+  key={(w: Webhook) => w.id}
+>
+  {#snippet row(w: Webhook)}
+    <tr class:revoked={w.revoked_at !== null}>
+      <td class="mono url">{w.url}</td>
+      <td>
+        {#if w.events.length === 0}
+          <span class="muted">all events</span>
+        {:else}
+          <span class="events">
+            {#each w.events as ev}
+              <span class="status">{ev}</span>
+            {/each}
+          </span>
+        {/if}
+      </td>
+      <td>
+        {#if w.revoked_at}
+          <span class="status revoked-badge" title={`Revoked ${formatDate(w.revoked_at)}`}>
+            revoked
+          </span>
+        {:else}
+          <span class="status active-badge">active</span>
+        {/if}
+      </td>
+      <td class="muted">{formatDate(w.created_at)}</td>
+    </tr>
+  {/snippet}
+
+  {#snippet empty()}
+    <p>No webhooks yet.</p>
+    <p class="muted">
+      Webhooks are created over the API (<code>POST /webhooks</code>). Each delivery is signed with
+      an HMAC secret that is shown once at creation and never returned again.
+    </p>
+  {/snippet}
+</ResourceTable>
+
+<style>
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  /* URLs can be long; keep them from stretching the table. */
+  td.url {
+    max-width: 26rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.82rem;
+  }
+  .events {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  .active-badge {
+    background: var(--success-bg);
+    color: var(--success);
+  }
+  .revoked-badge {
+    background: var(--bg-3);
+    color: var(--fg-3);
+  }
+  /* A revoked webhook is inert — de-emphasise the whole row. */
+  tr.revoked td.url {
+    text-decoration: line-through;
+    color: var(--fg-3);
+  }
+</style>


### PR DESCRIPTION
Adds a read-only Webhooks page, built on the `ResourceTable` component introduced with the volumes view.

## Changes

- `listWebhooks()` + `Webhook` type in `api.ts`, typed after the `/webhooks` response.
- New `/webhooks` route and nav entry.

Read-only: no create/delete. Deliveries (`/webhooks/{id}/events`) are not covered here either.

## Notes

- Webhooks are not namespaced, so the shared component renders no namespace filter for this page — the first consumer to exercise that path.
- Revoked webhooks stay listed and are marked as such rather than hidden.
- The HMAC secret is never returned by the API and is not handled by the dashboard.

## Checks

`svelte-check`, `biome check` and `build` pass. Not exercised against a running server.