### PR TITLE
feat(dashboard): users list view

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -395,6 +395,21 @@ export function listWebhooks(): Promise<Webhook[]> {
   return request<Webhook[]>('/webhooks');
 }
 
+export interface User {
+  id: string;
+  username: string;
+  created_at: string;
+  updated_at: string | null;
+  status: string;
+  /** Last successful login; absent for an account that never signed in. */
+  login_at: string | null;
+}
+
+/** Requires the `users:read` scope. Password hashes are never returned. */
+export function listUsers(): Promise<User[]> {
+  return request<User[]>('/users');
+}
+
 export interface LogsQuery {
   tail?: number;
   since?: string;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
     { href: '/configs', label: 'Configs', icon: 'file' },
     { href: '/volumes', label: 'Volumes', icon: 'disc' },
     { href: '/webhooks', label: 'Webhooks', icon: 'webhook' },
+    { href: '/users', label: 'Users', icon: 'users' },
     { href: '/node', label: 'Node', icon: 'server' }
   ];
 
@@ -169,6 +170,19 @@
                   <circle cx="3.75" cy="11.5" r="2.25" />
                   <circle cx="12.25" cy="11.5" r="2.25" />
                   <path d="M6.85 6.2L4.9 9.55M9.15 6.2l1.95 3.35M6 11.5h4" />
+                </svg>
+              {:else if item.icon === 'users'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <circle cx="6" cy="5.5" r="2.5" />
+                  <path d="M1.75 13.5c0-2.35 1.9-3.75 4.25-3.75s4.25 1.4 4.25 3.75" />
+                  <path d="M11 3.4a2.5 2.5 0 0 1 0 4.7M12.4 9.9c1.25.45 2.1 1.5 2.1 3.1" />
                 </svg>
               {:else if item.icon === 'server'}
                 <svg

--- a/dashboard/src/routes/users/+page.svelte
+++ b/dashboard/src/routes/users/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import ResourceTable from '$lib/ResourceTable.svelte';
+  import { listUsers, type User } from '$lib/api';
+  import { formatDate } from '$lib/utils';
+
+  const columns = [
+    { label: 'Username' },
+    { label: 'Status' },
+    { label: 'Last login' },
+    { label: 'Created' }
+  ];
+</script>
+
+<ResourceTable
+  title="Users"
+  subtitle="Accounts that can authenticate against this Ring instance"
+  {columns}
+  load={listUsers}
+  key={(u: User) => u.id}
+>
+  {#snippet row(u: User)}
+    <tr>
+      <td class="mono">{u.username}</td>
+      <td>
+        <span class="status" class:active-badge={u.status === 'active'}>{u.status}</span>
+      </td>
+      <td class="muted">{u.login_at ? formatDate(u.login_at) : 'never'}</td>
+      <td class="muted">{formatDate(u.created_at)}</td>
+    </tr>
+  {/snippet}
+
+  {#snippet empty()}
+    <p>No users yet.</p>
+    <p class="muted">
+      Users are created over the API (<code>POST /users</code>). Listing them requires the
+      <code>users:read</code> scope.
+    </p>
+  {/snippet}
+</ResourceTable>
+
+<style>
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  .active-badge {
+    background: var(--success-bg);
+    color: var(--success);
+  }
+</style>


### PR DESCRIPTION
Adds a read-only Users page, built on the `ResourceTable` component.

## Changes

- `listUsers()` + `User` type in `api.ts`, typed after the `/users` response.
- New `/users` route and nav entry.

Read-only: no create/update/delete.

## Notes

- Accounts are not namespaced, so no namespace filter is rendered.
- `login_at` is optional and shows as `never` for an account that has never signed in.
- Listing requires the `users:read` scope; password hashes are not part of the response.

## Checks

`svelte-check`, `biome check` and `build` pass. Not exercised against a running server.