### PR TITLE
feat(dashboard): tokens list view

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -410,6 +410,27 @@ export function listUsers(): Promise<User[]> {
   return request<User[]>('/users');
 }
 
+export interface Token {
+  id: string;
+  name: string;
+  /** Leading characters of the clear token (e.g. `ring_pat_a1b2c3`), enough to
+   *  identify it. The secret itself is only ever returned at creation. */
+  token_prefix: string;
+  scopes: string[];
+  /** Empty means the token is valid in every namespace. */
+  namespaces: string[];
+  created_at: string;
+  expire_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+/** Lists the caller's own personal access tokens — never another user's, and
+ *  never login sessions. Requires the `admin` scope. */
+export function listTokens(): Promise<Token[]> {
+  return request<Token[]>('/tokens');
+}
+
 export interface LogsQuery {
   tail?: number;
   since?: string;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
     { href: '/volumes', label: 'Volumes', icon: 'disc' },
     { href: '/webhooks', label: 'Webhooks', icon: 'webhook' },
     { href: '/users', label: 'Users', icon: 'users' },
+    { href: '/tokens', label: 'Tokens', icon: 'token' },
     { href: '/node', label: 'Node', icon: 'server' }
   ];
 
@@ -183,6 +184,18 @@
                   <circle cx="6" cy="5.5" r="2.5" />
                   <path d="M1.75 13.5c0-2.35 1.9-3.75 4.25-3.75s4.25 1.4 4.25 3.75" />
                   <path d="M11 3.4a2.5 2.5 0 0 1 0 4.7M12.4 9.9c1.25.45 2.1 1.5 2.1 3.1" />
+                </svg>
+              {:else if item.icon === 'token'}
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="1.75" y="4.75" width="12.5" height="6.5" rx="2" />
+                  <path d="M4.5 8h.01M7 8h.01M9.5 8h.01M12 8h.01" />
                 </svg>
               {:else if item.icon === 'server'}
                 <svg

--- a/dashboard/src/routes/tokens/+page.svelte
+++ b/dashboard/src/routes/tokens/+page.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import ResourceTable from '$lib/ResourceTable.svelte';
+  import { listTokens, type Token } from '$lib/api';
+  import { formatDate } from '$lib/utils';
+
+  const columns = [
+    { label: 'Name' },
+    { label: 'Prefix' },
+    { label: 'Scopes' },
+    { label: 'Namespaces' },
+    { label: 'Status' },
+    { label: 'Last used' },
+    { label: 'Expires' }
+  ];
+
+  type State = 'active' | 'revoked' | 'expired';
+
+  /** Mirrors `Token::is_active()` on the server: revoked wins over expired, and
+   *  an unparseable expiry is treated as expired (fail closed) rather than
+   *  shown as active. */
+  function stateOf(t: Token): State {
+    if (t.revoked_at) {
+      return 'revoked';
+    }
+    if (!t.expire_at) {
+      return 'active';
+    }
+    const exp = new Date(t.expire_at).getTime();
+    if (Number.isNaN(exp)) {
+      return 'expired';
+    }
+    return exp <= Date.now() ? 'expired' : 'active';
+  }
+</script>
+
+<ResourceTable
+  title="Tokens"
+  subtitle="Your personal access tokens — only yours are ever listed"
+  {columns}
+  load={listTokens}
+  key={(t: Token) => t.id}
+>
+  {#snippet row(t: Token)}
+    {@const state = stateOf(t)}
+    <tr class:inert={state !== 'active'}>
+      <td>{t.name}</td>
+      <td class="mono small">{t.token_prefix}…</td>
+      <td>
+        {#if t.scopes.length === 0}
+          <span class="muted">none</span>
+        {:else}
+          <span class="chips">
+            {#each t.scopes as scope}
+              <span class="status">{scope}</span>
+            {/each}
+          </span>
+        {/if}
+      </td>
+      <td>
+        {#if t.namespaces.length === 0}
+          <span class="muted">all</span>
+        {:else}
+          <span class="chips">
+            {#each t.namespaces as ns}
+              <span class="status">{ns}</span>
+            {/each}
+          </span>
+        {/if}
+      </td>
+      <td>
+        {#if state === 'revoked'}
+          <span class="status revoked-badge" title={`Revoked ${formatDate(t.revoked_at)}`}>
+            revoked
+          </span>
+        {:else if state === 'expired'}
+          <span class="status expired-badge">expired</span>
+        {:else}
+          <span class="status active-badge">active</span>
+        {/if}
+      </td>
+      <td class="muted">{t.last_used_at ? formatDate(t.last_used_at) : 'never'}</td>
+      <td class="muted">{t.expire_at ? formatDate(t.expire_at) : '—'}</td>
+    </tr>
+  {/snippet}
+
+  {#snippet empty()}
+    <p>No tokens yet.</p>
+    <p class="muted">
+      Create one with <code>ring token create &lt;name&gt;</code>. The token value is shown once at
+      creation and never returned again.
+    </p>
+  {/snippet}
+</ResourceTable>
+
+<style>
+  td.mono {
+    font-family: var(--font-mono);
+  }
+  td.small {
+    font-size: 0.78rem;
+  }
+  .chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  .active-badge {
+    background: var(--success-bg);
+    color: var(--success);
+  }
+  .expired-badge {
+    background: var(--warning-bg);
+    color: var(--warning);
+  }
+  .revoked-badge {
+    background: var(--bg-3);
+    color: var(--fg-3);
+  }
+  /* A revoked or expired token can't authenticate — de-emphasise the row. */
+  tr.inert td:first-child {
+    color: var(--fg-3);
+  }
+</style>


### PR DESCRIPTION
Adds a read-only Tokens page, built on the `ResourceTable` component. Last of the four read-only resource views.

## Changes

- `listTokens()` + `Token` type in `api.ts`, typed after the `/tokens` response.
- New `/tokens` route and nav entry.

Read-only: no create, revoke or rotate.

## Notes

- The endpoint is self-scoped: it returns only the caller's own personal access tokens, and never login sessions. The page is therefore "my tokens", not an admin view.
- Token state is derived client-side from `revoked_at` / `expire_at`, mirroring `Token::is_active()`: revoked takes precedence over expired, and an unparseable expiry is treated as expired rather than shown as active.
- Only `token_prefix` is displayed; the secret is returned once at creation and never again.

## Checks

`svelte-check`, `biome check` and `build` pass. Not exercised against a running server.