### PR TITLE
refactor(dashboard): extract repeated detail table cards

### DIFF
--- a/dashboard/src/lib/DeploymentLogs.svelte
+++ b/dashboard/src/lib/DeploymentLogs.svelte
@@ -31,11 +31,14 @@
   let logsStream: LogStreamHandle | null = null;
   let logsEl: HTMLDivElement | null = $state(null);
 
-  /** Incremented on every reload. A snapshot or stream that resolves after a
-   *  newer reload started belongs to a superseded deployment (or tail size) and
-   *  must not touch the state — otherwise a slow response for the previous
-   *  deployment could overwrite the current one's logs. */
-  let generation = 0;
+  /** Snapshot and stream have independent lifecycles — pausing invalidates the
+   *  stream but not a pending snapshot, and a reload restarts both — so they
+   *  get a counter each. A request whose generation is stale by the time it
+   *  resolves belongs to a superseded deployment (or tail size) and must not
+   *  touch the state: otherwise a slow response for the previous deployment
+   *  could overwrite the current one's logs. */
+  let snapshotGen = 0;
+  let streamGen = 0;
 
   function pushLog(entry: LogEntry) {
     logs.push(entry);
@@ -45,16 +48,21 @@
   }
 
   function stopStream() {
+    // Bump the generation even when there is no handle yet: a `startStream`
+    // still awaiting its ticket would otherwise resolve after this and keep
+    // delivering entries while the UI says it is paused.
+    streamGen++;
     if (logsStream) {
       logsStream.close();
       logsStream = null;
     }
   }
 
-  async function loadSnapshot(gen: number) {
+  async function loadSnapshot() {
     if (!id) {
       return;
     }
+    const gen = ++snapshotGen;
     logsLoading = true;
     logsError = null;
     try {
@@ -62,40 +70,47 @@
         tail: logsTail,
         container: logsContainerFilter || undefined
       });
-      if (gen !== generation) {
+      if (gen !== snapshotGen) {
         return;
       }
       logs = snap;
     } catch (e) {
-      if (gen !== generation) {
+      if (gen !== snapshotGen) {
         return;
       }
       logsError = e instanceof Error ? e.message : String(e);
     } finally {
-      if (gen === generation) {
+      // Only the newest snapshot clears the flag. A superseded one must leave it
+      // set, otherwise the viewer would report "no logs" while its replacement
+      // is still in flight. Since every generation bump here starts a new load,
+      // the flag is always cleared by someone.
+      if (gen === snapshotGen) {
         logsLoading = false;
       }
     }
   }
 
-  async function startStream(gen: number) {
+  async function startStream() {
     if (!id) {
       return;
     }
+    // stopStream() bumps streamGen, so read it after: this call owns whatever
+    // generation it leaves behind.
     stopStream();
+    const gen = streamGen;
     logsError = null;
     try {
       const handle = await streamLogs(
         id,
         { tail: logsTail, container: logsContainerFilter || undefined },
         (entry) => {
-          if (gen !== generation) {
+          if (gen !== streamGen) {
             return;
           }
           pushLog(entry);
         },
         () => {
-          if (gen !== generation) {
+          if (gen !== streamGen) {
             return;
           }
           // EventSource fires a generic Event on disconnect; surface a hint
@@ -104,16 +119,16 @@
           logsError = 'stream interrupted, reconnecting…';
         }
       );
-      if (gen !== generation) {
-        // A newer reload started while the ticket was in flight; this stream
-        // belongs to the previous deployment, so close it instead of letting
-        // it leak alongside the current one.
+      if (gen !== streamGen) {
+        // A newer reload started — or the user paused — while the ticket was in
+        // flight; this stream is already obsolete, so close it instead of
+        // letting it leak alongside (or instead of) the current one.
         handle.close();
         return;
       }
       logsStream = handle;
     } catch (e) {
-      if (gen !== generation) {
+      if (gen !== streamGen) {
         return;
       }
       logsError = e instanceof Error ? e.message : String(e);
@@ -122,24 +137,25 @@
 
   async function refreshLogs() {
     stopStream();
-    const gen = ++generation;
     // Don't clear `logs` here: emptying the array collapses the viewport,
     // which makes the page jump to the top because the scroll position
     // becomes out of range. Keep the old lines until the snapshot lands
     // and then swap atomically inside loadSnapshot().
-    await loadSnapshot(gen);
-    if (gen !== generation) {
+    const gen = snapshotGen + 1;
+    await loadSnapshot();
+    if (gen !== snapshotGen) {
+      // Another reload overtook this one; it will start its own stream.
       return;
     }
     if (logsFollow) {
-      await startStream(gen);
+      await startStream();
     }
   }
 
   async function toggleFollow() {
     logsFollow = !logsFollow;
     if (logsFollow) {
-      await startStream(++generation);
+      await startStream();
     } else {
       stopStream();
     }

--- a/dashboard/src/lib/DetailTableCard.svelte
+++ b/dashboard/src/lib/DetailTableCard.svelte
@@ -1,0 +1,109 @@
+<script lang="ts" generics="T">
+  /**
+   * One card of the deployment detail page: a titled header with a count, a
+   * table of rows, and a placeholder when there is nothing to show.
+   *
+   * The detail page repeats this shape for ports, volumes, environment and
+   * health checks — same header, same empty state, same table skeleton, only
+   * the columns and cells differ.
+   */
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title: string;
+    /** Column headers, in order. `align: 'right'` gets tabular numerals. */
+    columns: Array<{ label: string; align?: 'right' }>;
+    items: T[];
+    /** Shown in place of the table when `items` is empty. */
+    emptyText: string;
+    /** Stable key per item; falls back to the index when omitted. */
+    key?: (item: T, index: number) => string | number;
+    /** One `<tr>` per item. */
+    row: Snippet<[T]>;
+  }
+
+  let { title, columns, items, emptyText, key, row }: Props = $props();
+</script>
+
+<section class="card">
+  <header class="section-head">
+    <h2>{title}</h2>
+    <span class="count">{items.length}</span>
+  </header>
+  {#if items.length === 0}
+    <p class="muted pad">{emptyText}</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          {#each columns as col}
+            <th class:num={col.align === 'right'}>{col.label}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each items as item, i (key ? key(item, i) : i)}
+          {@render row(item)}
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  /* Structural rules the detail page defines for its own cards. Svelte scopes
+   * styles per component, so they don't reach this child's DOM — the ones this
+   * component's markup uses are repeated here rather than made global, keeping
+   * the page's scoping intact. */
+  .card {
+    margin-bottom: 1rem;
+  }
+  .section-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.85rem 1.125rem;
+    border-bottom: 1px solid var(--border);
+  }
+  h2 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .count {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .muted.pad {
+    padding: 1.25rem;
+  }
+
+  /* The detail page tables are denser than the global `app.css` ones (smaller
+   * type, tighter padding, muted headers). Repeated here for the same scoping
+   * reason as above — without them these tables would fall back to the global
+   * style and look nothing like the page's other cards.
+   *
+   * Only the `th` side lives here: the `<td>`s come from the caller's `row`
+   * snippet, so they are compiled into the page and keep its own `td` rules. */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th {
+    text-align: left;
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/dashboard/src/routes/deployments/[id]/+page.svelte
+++ b/dashboard/src/routes/deployments/[id]/+page.svelte
@@ -9,13 +9,16 @@
     listDeploymentEvents,
     type DeploymentDetail,
     type DeploymentEvent,
+    type DeploymentPort,
     type DeploymentStats,
+    type DeploymentVolume,
     type EnvValue,
     type HealthCheck,
     type HealthCheckResult
   } from '$lib/api';
   import CopyButton from '$lib/CopyButton.svelte';
   import DeploymentLogs from '$lib/DeploymentLogs.svelte';
+  import DetailTableCard from '$lib/DetailTableCard.svelte';
   import { getToken } from '$lib/auth';
   import { formatBytes, formatDate, timeAgo } from '$lib/utils';
 
@@ -170,6 +173,12 @@
   }
 
   let groupedEvents = $derived(groupConsecutive(events));
+
+  /** Environment as sorted `[key, value]` pairs — the card takes a list, and
+   *  sorting here keeps the ordering stable across re-renders. */
+  let envEntries = $derived<Array<[string, EnvValue]>>(
+    Object.entries(detail?.environment ?? {}).sort(([a], [b]) => a.localeCompare(b))
+  );
 </script>
 
 <svelte:head>
@@ -388,136 +397,85 @@
     {/if}
   </section>
 
-  <section class="card">
-    <header class="section-head">
-      <h2>Ports</h2>
-      <span class="count">{detail.ports.length}</span>
-    </header>
-    {#if detail.ports.length === 0}
-      <p class="muted pad">No ports published.</p>
-    {:else}
-      <table>
-        <thead>
-          <tr>
-            <th class="num">Published</th>
-            <th class="num">Target</th>
-            <th>Protocol</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each detail.ports as p}
-            <tr>
-              <td class="num mono">{p.published}</td>
-              <td class="num mono">{p.target}</td>
-              <td>{p.protocol ?? 'tcp'}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </section>
+  <DetailTableCard
+    title="Ports"
+    columns={[{ label: 'Published', align: 'right' }, { label: 'Target', align: 'right' }, { label: 'Protocol' }]}
+    items={detail.ports}
+    emptyText="No ports published."
+  >
+    {#snippet row(p: DeploymentPort)}
+      <tr>
+        <td class="num mono">{p.published}</td>
+        <td class="num mono">{p.target}</td>
+        <td>{p.protocol ?? 'tcp'}</td>
+      </tr>
+    {/snippet}
+  </DetailTableCard>
 
-  <section class="card">
-    <header class="section-head">
-      <h2>Volumes</h2>
-      <span class="count">{detail.volumes.length}</span>
-    </header>
-    {#if detail.volumes.length === 0}
-      <p class="muted pad">No volumes mounted.</p>
-    {:else}
-      <table>
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Source</th>
-            <th>Destination</th>
-            <th>Mode</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each detail.volumes as v}
-            <tr>
-              <td>{v.type}</td>
-              <td class="mono">{v.source ?? v.key ?? '—'}</td>
-              <td class="mono">{v.destination}</td>
-              <td>{v.permission}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </section>
+  <DetailTableCard
+    title="Volumes"
+    columns={[{ label: 'Type' }, { label: 'Source' }, { label: 'Destination' }, { label: 'Mode' }]}
+    items={detail.volumes}
+    emptyText="No volumes mounted."
+  >
+    {#snippet row(v: DeploymentVolume)}
+      <tr>
+        <td>{v.type}</td>
+        <td class="mono">{v.source ?? v.key ?? '\u2014'}</td>
+        <td class="mono">{v.destination}</td>
+        <td>{v.permission}</td>
+      </tr>
+    {/snippet}
+  </DetailTableCard>
 
-  <section class="card">
-    <header class="section-head">
-      <h2>Environment</h2>
-      <span class="count">{Object.keys(detail.environment).length}</span>
-    </header>
-    {#if Object.keys(detail.environment).length === 0}
-      <p class="muted pad">No environment variables.</p>
-    {:else}
-      <table>
-        <thead>
-          <tr>
-            <th>Key</th>
-            <th>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each Object.entries(detail.environment).sort(([a], [b]) => a.localeCompare(b)) as [k, v] (k)}
-            {@const disp = envDisplay(v)}
-            <tr>
-              <td class="mono">{k}</td>
-              <td class="mono">
-                {#if disp.kind === 'secret'}
-                  <span class="secret-tag">{disp.text}</span>
-                {:else}
-                  {disp.text}
-                {/if}
-              </td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </section>
+  <DetailTableCard
+    title="Environment"
+    columns={[{ label: 'Key' }, { label: 'Value' }]}
+    items={envEntries}
+    emptyText="No environment variables."
+    key={([k]) => k}
+  >
+    {#snippet row([k, v]: [string, EnvValue])}
+      {@const disp = envDisplay(v)}
+      <tr>
+        <td class="mono">{k}</td>
+        <td class="mono">
+          {#if disp.kind === 'secret'}
+            <span class="secret-tag">{disp.text}</span>
+          {:else}
+            {disp.text}
+          {/if}
+        </td>
+      </tr>
+    {/snippet}
+  </DetailTableCard>
 
-  <section class="card">
-    <header class="section-head">
-      <h2>Health checks</h2>
-      <span class="count">{detail.health_checks.length}</span>
-    </header>
-    {#if detail.health_checks.length === 0}
-      <p class="muted pad">No health checks configured.</p>
-    {:else}
-      <table>
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Target</th>
-            <th>Interval</th>
-            <th>Timeout</th>
-            <th class="num">Threshold</th>
-            <th>On failure</th>
-            <th>Readiness</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each detail.health_checks as hc}
-            <tr>
-              <td>{hc.type}</td>
-              <td class="mono">{hcSummary(hc)}</td>
-              <td>{hc.interval}</td>
-              <td>{hc.timeout}</td>
-              <td class="num mono">{hc.threshold}</td>
-              <td>{hc.on_failure}</td>
-              <td>{hc.readiness ? 'yes' : 'no'}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </section>
+  <DetailTableCard
+    title="Health checks"
+    columns={[
+      { label: 'Type' },
+      { label: 'Target' },
+      { label: 'Interval' },
+      { label: 'Timeout' },
+      { label: 'Threshold', align: 'right' },
+      { label: 'On failure' },
+      { label: 'Readiness' }
+    ]}
+    items={detail.health_checks}
+    emptyText="No health checks configured."
+  >
+    {#snippet row(hc: HealthCheck)}
+      <tr>
+        <td>{hc.type}</td>
+        <td class="mono">{hcSummary(hc)}</td>
+        <td>{hc.interval}</td>
+        <td>{hc.timeout}</td>
+        <td class="num mono">{hc.threshold}</td>
+        <td>{hc.on_failure}</td>
+        <td>{hc.readiness ? 'yes' : 'no'}</td>
+      </tr>
+    {/snippet}
+  </DetailTableCard>
 
   {#if detail.health_checks.length > 0}
     <section class="card">


### PR DESCRIPTION
Follow-up to #196. The ports, volumes, environment and health-check sections of the deployment detail page repeated the same shape — header with a count, empty-state line, table skeleton — with only the columns and cells differing. This extracts that shape into `DetailTableCard.svelte`.

The page drops from 902 to ~851 lines.

## Changes

- New `$lib/DetailTableCard.svelte`: card header with count, empty state, table skeleton. Callers pass columns and a `row` snippet.
- The four sections now use it; `envEntries` (sorted `[key, value]` pairs) is derived on the page since the card takes a list.

## Also fixes a bug from #196

The generation guard added in #196 used one counter for two independent lifecycles. Pausing the stream bumped it without starting a snapshot, so `logsLoading` was never cleared — the viewer stayed stuck loading with Reload disabled. Two counters now:

- `snapshotGen` — only a reload bumps it; only the newest snapshot clears the loading flag.
- `streamGen` — `stopStream()` bumps it even with no handle yet, so a stream still awaiting its ticket is closed on arrival instead of delivering entries while the UI says paused.

## Notes

Only the `th` side of the page's table rules moved into the component: the `<td>`s come from the caller's `row` snippet, so they compile into the page and keep its scoping. The compiler confirms this — leaving `td` rules in the component was reported as unused CSS.

## Checks

`svelte-check`, `biome check` and `build` pass, with no unused-CSS warnings. Not exercised against a running server.