### PR TITLE
test(e2e): run the firecracker suite by default and reap its leaked VMs

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -7,10 +7,16 @@
 #   tests/e2e/run.sh podman             # run only Podman tests
 #   tests/e2e/run.sh containerd         # run only containerd tests (root + CNI)
 #   tests/e2e/run.sh cloud-hypervisor   # run only Cloud Hypervisor tests
+#   tests/e2e/run.sh firecracker        # run only Firecracker tests
 #
 # The containerd suite is not in the default set: it needs access to the
 # root-owned containerd socket and CNI plugins, so run it explicitly
 # (e.g. `sudo -E tests/e2e/run.sh containerd`).
+#
+# Both micro-VM suites are in the default set and gate themselves the same way:
+# each setup.sh exits non-zero with an install hint when its VMM binary or
+# /dev/kvm is missing, so a host without them reports a clear failure rather
+# than silently skipping coverage.
 #
 # The script doesn't `set -e` on the loop so a single failing test does not
 # abort the rest of the run; the summary at the end reports pass/fail per
@@ -21,7 +27,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SUITES=("server" "docker" "podman" "cloud-hypervisor")
+SUITES=("server" "docker" "podman" "cloud-hypervisor" "firecracker")
 
 # Restrict to the suite the user named, if any.
 if [ "$#" -gt 0 ]; then
@@ -31,6 +37,23 @@ fi
 cleanup_between_tests() {
   pkill -9 -f "target/debug/ring server" 2>/dev/null || true
   pkill -9 -f "cloud-hypervisor --api-socket" 2>/dev/null || true
+  # Firecracker VMs from a test that died before its own EXIT trap ran. Without
+  # this a leaked VM keeps its tap and its /30, and the next test that hashes to
+  # the same network slot fails on a name that is already taken.
+  #
+  # Scoped to the suite's own socket directory (`mktemp -d -t
+  # ring-e2e-fc-sockets-XXXXXX`, see firecracker/setup.sh) rather than every
+  # `firecracker` process: unlike a container runtime's daemon, a microVM on
+  # this host may well belong to something other than the test suite.
+  pkill -9 -f "firecracker --api-sock ${TMPDIR:-/tmp}/ring-e2e-fc-sockets-" 2>/dev/null || true
+  # Note: killing the VM does not remove its tap, which is persistent. The
+  # firecracker suite reaps those itself (setup.sh snapshots `ring-*` before the
+  # run and deletes what appeared, via an EXIT trap). One gap remains: if a test
+  # is killed hard enough to skip its trap, the leaked tap is already present
+  # when the next test snapshots, so it is treated as pre-existing and never
+  # reaped. Deleting every `ring-*` here would close it but could take down a
+  # tap belonging to a concurrent Ring — the tap name is a hash of the instance
+  # id, with nothing in it to tell a test VM from a real one.
   pkill -9 -f "virtiofsd --socket-path" 2>/dev/null || true
   pkill -9 -f "socat.*TCP4-LISTEN" 2>/dev/null || true
   if command -v docker > /dev/null 2>&1; then


### PR DESCRIPTION
The `firecracker` e2e suite (9 scenarios) existed but was not in the default set of `tests/e2e/run.sh`, so it only ran when named explicitly. Unlike the containerd exclusion — which is documented and justified by its root/CNI requirements — this one was neither. Cloud Hypervisor is in the default set with the same shape of prerequisites (`/dev/kvm` plus a VMM binary, each `setup.sh` exiting non-zero with an install hint when they are missing), so Firecracker joins it. A host lacking the prerequisites now reports a clear failure instead of silently skipping the least mature runtime's coverage.

`cleanup_between_tests` also did not reap Firecracker VMs. A test killed before its own EXIT trap runs leaves a live VM holding its tap and its /30, and the next test that hashes to the same network slot then fails on a name already taken. Verified on a host with firecracker and `/dev/kvm`: interrupting a test does leave `firecracker` processes behind, and the added `pkill` reaps them.

The kill is scoped to the suite's own socket directory (`ring-e2e-fc-sockets-*`) rather than every `firecracker` process. The existing kills in this function are unscoped, but a container runtime's daemon is not comparable to a microVM: one running on this host may well belong to something other than the test suite.

**One gap is left open and documented in place.** Killing a VM does not remove its tap, which is persistent. The suite already reaps those itself — `setup.sh` snapshots `ring-*` interfaces before the run and deletes what appeared, via an EXIT trap — but if a test is killed hard enough to skip that trap, the leaked tap is already present when the next test snapshots, so it is treated as pre-existing and never reaped. Deleting every `ring-*` from `run.sh` would close it, at the risk of taking down a tap belonging to a concurrent Ring: the tap name is a hash of the instance id, with nothing in it to tell a test VM from a real one. Not worth trading a leaked interface for a broken workload.

## Tests

`bash -n` clean. Ran the Firecracker suite on a host with the prerequisites: the tests fail there for lack of `CAP_NET_ADMIN` on the test binary (`setcap cap_net_admin+ep` needs interactive sudo), which is an environment limit rather than a code one. What the run did confirm is that the error path is correct end to end — `TapDevice::create` reports the exact remedy, the failure classifies as retryable, `restart_count` climbs toward its bound, and no tap is leaked across repeated failures.
