### PR TITLE
Log silently swallowed failures and stop exiting on a missing auth context

### DIFF
--- a/src/api/action/namespace/delete.rs
+++ b/src/api/action/namespace/delete.rs
@@ -61,7 +61,15 @@ pub(crate) async fn delete(
     // is the last thing visible if the trail is consulted before retention
     // cleanup elsewhere — but since we just purged, this is intentionally
     // the sole surviving entry for the deleted namespace.
-    let _ = audit_log::delete_by_namespace(&pool, &name).await;
+    if let Err(e) = audit_log::delete_by_namespace(&pool, &name).await {
+        // Not fatal (the namespace is already gone), but a failed purge leaves
+        // orphaned audit rows behind, and a silent one makes that impossible to
+        // notice.
+        warn!(
+            "Failed to purge the audit trail of namespace '{}': {}",
+            name, e
+        );
+    }
     let _ = audit_log::record(
         &pool,
         Some(&auth.user.id),

--- a/src/config/auth.rs
+++ b/src/config/auth.rs
@@ -50,16 +50,34 @@ pub(crate) fn load_auth_config(context_name: String) -> AuthConfig {
         }
     };
 
-    match context_auth.get(&context_name) {
+    resolve_context_token(&context_auth, &context_name)
+}
+
+/// Pick a context's token out of a parsed auth.json.
+///
+/// Split out of [`load_auth_config`] so the missing-context branch is testable:
+/// the caller does the I/O, this does the decision.
+fn resolve_context_token(
+    context_auth: &HashMap<String, AuthToken>,
+    context_name: &str,
+) -> AuthConfig {
+    match context_auth.get(context_name) {
         Some(auth_token) => AuthConfig {
             token: auth_token.token.clone(),
         },
+        // Same contract as an unreadable or unparseable file: report and hand
+        // back an empty token, letting the caller decide what that means. This
+        // used to `process::exit(1)`, which made "no credentials" fatal here
+        // but merely empty there -- and broke `ring logout`, whose whole point
+        // is to be a successful no-op when there is nothing to log out of.
         None => {
-            eprintln!(
-                "Error: Context '{}' does not exist in a configuration file",
+            error!(
+                "No credentials for context '{}' in auth.json — run `ring login` or set RING_TOKEN",
                 context_name
             );
-            std::process::exit(1);
+            AuthConfig {
+                token: String::new(),
+            }
         }
     }
 }
@@ -96,5 +114,39 @@ mod tests {
             }
         });
         assert!(token.is_none());
+    }
+
+    #[test]
+    fn known_context_yields_its_token() {
+        let mut map = HashMap::new();
+        map.insert(
+            "default".to_string(),
+            AuthToken {
+                token: "abc123".to_string(),
+            },
+        );
+
+        assert_eq!(resolve_context_token(&map, "default").token, "abc123");
+    }
+
+    #[test]
+    fn unknown_context_yields_an_empty_token_instead_of_exiting() {
+        // Regression guard: this branch used to call `process::exit(1)`, which
+        // made `ring logout` impossible when auth.json existed without the
+        // current context -- logout is meant to be a no-op success there. It
+        // also meant this assertion could not be written at all, since it would
+        // have killed the test process.
+        let mut map = HashMap::new();
+        map.insert(
+            "default".to_string(),
+            AuthToken {
+                token: "abc123".to_string(),
+            },
+        );
+
+        assert!(
+            resolve_context_token(&map, "production").token.is_empty(),
+            "a missing context must yield an empty token, not terminate"
+        );
     }
 }

--- a/src/models/deployment_event.rs
+++ b/src/models/deployment_event.rs
@@ -115,6 +115,12 @@ pub(crate) async fn find_events_by_deployment_and_level(
     .await
 }
 
+/// Record a deployment event. Call at the point the thing actually happened.
+///
+/// Callers discard the result on purpose: failing to record an event must never
+/// break a deployment. The write failure is logged here, once, so a missing
+/// event is still visible in the server log instead of vanishing silently --
+/// the same contract as `audit_log::record`.
 pub(crate) async fn log_event(
     pool: &SqlitePool,
     deployment_id: String,
@@ -124,5 +130,14 @@ pub(crate) async fn log_event(
     reason: Option<&str>,
 ) -> Result<(), sqlx::Error> {
     let event = DeploymentEvent::new(deployment_id, level, message, component, reason);
-    create_event(pool, &event).await
+    let result = create_event(pool, &event).await;
+
+    if let Err(ref e) = result {
+        warn!(
+            "Failed to record deployment event ({} {} for deployment {}): {}",
+            event.level, event.component, event.deployment_id, e
+        );
+    }
+
+    result
 }

--- a/src/scheduler/event_worker.rs
+++ b/src/scheduler/event_worker.rs
@@ -67,7 +67,12 @@ async fn deliver_event(pool: &SqlitePool, event: &QueuedEvent) {
     // No subscriber for this kind: nothing to do, mark delivered so it doesn't
     // sit pending forever.
     if subscribers.is_empty() {
-        let _ = event_queue::mark_delivered(pool, &event.id).await;
+        if let Err(e) = event_queue::mark_delivered(pool, &event.id).await {
+            warn!(
+                "Failed to mark event {} ({}) delivered: {} — it stays pending and will be reprocessed",
+                event.id, event.kind, e
+            );
+        }
         return;
     }
 
@@ -94,20 +99,37 @@ async fn deliver_event(pool: &SqlitePool, event: &QueuedEvent) {
         }
     }
 
+    // Every branch below writes the event's terminal state. A silent failure
+    // here leaves the row `pending`, so the next tick redelivers an event the
+    // subscriber has already received -- a duplicate-webhook storm with nothing
+    // in the logs to explain it. Log loudly instead of swallowing.
     match first_error {
         None => {
-            let _ = event_queue::mark_delivered(pool, &event.id).await;
+            if let Err(e) = event_queue::mark_delivered(pool, &event.id).await {
+                warn!(
+                    "Failed to mark event {} ({}) delivered: {} — it stays pending and will be redelivered",
+                    event.id, event.kind, e
+                );
+            }
         }
         Some(err) => {
             let attempts = event.attempts + 1;
             if attempts >= MAX_ATTEMPTS {
-                let _ = event_queue::mark_dead(pool, &event.id, attempts, &err).await;
+                if let Err(e) = event_queue::mark_dead(pool, &event.id, attempts, &err).await {
+                    warn!(
+                        "Failed to dead-letter event {} ({}): {} — it stays pending and will be retried past its attempt limit",
+                        event.id, event.kind, e
+                    );
+                }
                 warn!(
                     "Event {} ({}) dead-lettered after {} attempts: {}",
                     event.id, event.kind, attempts, err
                 );
-            } else {
-                let _ = event_queue::reschedule(pool, &event.id, attempts, &err).await;
+            } else if let Err(e) = event_queue::reschedule(pool, &event.id, attempts, &err).await {
+                warn!(
+                    "Failed to reschedule event {} ({}): {} — the attempt counter did not advance",
+                    event.id, event.kind, e
+                );
             }
         }
     }


### PR DESCRIPTION
Three error paths that failed silently, plus a `process::exit` that made `ring logout` unusable in one case.

## `ring logout` could not run without a matching context

`load_auth_config` handled a missing file and unparseable JSON by returning an empty token, but called `process::exit(1)` when `auth.json` existed without the current context. `logout` is written to treat an empty token as a successful no-op (`if !auth.token.is_empty()`), so it never got the chance:

```bash
# auth.json exists, but holds no entry for the current context
ring logout   # before: exit 1, local credential left in place
              # after:  no-op success, as intended
```

All three paths now behave the same way: report and hand back an empty token. The decision moves to `resolve_context_token`, split out so the branch is testable at all — asserting it previously killed the test process.

## Webhook events could be redelivered forever

`event_worker` discarded the result of every state transition. If `mark_delivered` failed, the event stayed `pending` and the next tick redelivered it — a duplicate-webhook storm at the subscriber with nothing in the log to explain it. Same for `mark_dead` (retried past its attempt limit) and `reschedule` (attempt counter stuck).

## `deployment_event::log_event` swallowed its write failures

`audit_log::record` already logs failures internally and documents that callers discard the result. `log_event` had the same call pattern with no such logging, so its five call sites lost the error. Logging moved into the model, matching `audit_log`'s contract, so no call site can forget it.

## Not changed, deliberately

`load_auth_config` keeps returning `AuthConfig` rather than `Result`. Converting it would touch ~35 call sites, all CLI commands that terminate anyway, for no visible behaviour change. Ring has a single binary and no library boundary that the "never exit in library code" rule is protecting. Worth revisiting if a real library target appears.

The ~12 `let _ = audit_log::record(...)` are also untouched: the model logs the failure itself, which is a deliberate design, not an oversight.

## Testing

801 tests, clippy clean. Two new tests cover the previously unreachable missing-context branch.

The `process::exit` question was put to codex, which independently reached the same recommendation and found the `logout` bug.
