### PR TITLE
e2e: close the firecracker and podman coverage gaps

### DIFF
--- a/tests/e2e/firecracker/setup.sh
+++ b/tests/e2e/firecracker/setup.sh
@@ -24,6 +24,18 @@ setup_fc() {
     echo "[fc-setup] /dev/kvm not accessible (need the kvm group)" >&2
     exit 1
   }
+
+  # Ring creates a TAP per microVM, which needs CAP_NET_ADMIN. Without it every
+  # boot fails on TUNSETIFF and the deployment lands in crash_loop_back_off —
+  # which a test can only report as "did not reach running in 60s", pointing at
+  # the runtime rather than at the missing capability. Fail fast and say so.
+  RING_BIN_PATH="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
+  if [ "$(id -u)" -ne 0 ] && ! getcap "$RING_BIN_PATH" 2>/dev/null | grep -q "cap_net_admin"; then
+    echo "[fc-setup] $RING_BIN_PATH lacks CAP_NET_ADMIN, so creating a TAP will fail" >&2
+    echo "           grant it with: sudo setcap cap_net_admin+ep $RING_BIN_PATH" >&2
+    echo "           (re-apply after every 'cargo build' — the capability is lost on rebuild)" >&2
+    exit 1
+  fi
   for cmd in curl; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "[fc-setup] missing: $cmd" >&2; exit 1; }
   done

--- a/tests/e2e/firecracker/setup.sh
+++ b/tests/e2e/firecracker/setup.sh
@@ -30,7 +30,7 @@ setup_fc() {
   # which a test can only report as "did not reach running in 60s", pointing at
   # the runtime rather than at the missing capability. Fail fast and say so.
   RING_BIN_PATH="${RING_BIN:-$(cd "$SCRIPT_DIR/../../.." && pwd)/target/debug/ring}"
-  if [ "$(id -u)" -ne 0 ] && ! getcap "$RING_BIN_PATH" 2>/dev/null | grep -q "cap_net_admin"; then
+  if [ "$(id -u)" -ne 0 ] && ! getcap "$RING_BIN_PATH" 2>/dev/null | grep -qE "cap_net_admin[^ ]*\+?e|cap_net_admin=.*e"; then
     echo "[fc-setup] $RING_BIN_PATH lacks CAP_NET_ADMIN, so creating a TAP will fail" >&2
     echo "           grant it with: sudo setcap cap_net_admin+ep $RING_BIN_PATH" >&2
     echo "           (re-apply after every 'cargo build' — the capability is lost on rebuild)" >&2

--- a/tests/e2e/firecracker/t10_replicas.sh
+++ b/tests/e2e/firecracker/t10_replicas.sh
@@ -2,7 +2,7 @@
 # T10-FC: apply a firecracker deployment with replicas=3 and assert the
 # scheduler converges to exactly 3 microVMs, each with its own API socket and
 # its own rootfs copy. Then re-apply with replicas=1 and assert the instance
-# count settles back to one, with every artifact reaped on delete.
+# count settles back to one, with sockets and rootfs images reaped on delete.
 #
 # Why this test exists: the Firecracker multi-instance path had no e2e coverage
 # at all, only Cloud Hypervisor's (t2_replicas / t9_scaledown). Everything below
@@ -107,13 +107,18 @@ log "API reports 3 instances"
 sed -i 's/replicas: 3/replicas: 1/' "$FIXTURE"
 "$RING_BIN" apply --file "$FIXTURE"
 
-# Deliberately waits for the settled count rather than a transitional one: with
-# a replacement, the socket count passes through several values before landing.
-wait_fc_socket_count 1 180
-log "converged to a single microVM"
+# A replacement makes the socket count pass through several values, and the
+# helper returns on the FIRST match — which could be a transient 1 while the old
+# deployment drains and before the replacement boots. So wait for the
+# replacement to be serving first, then require the count to hold at 1.
+wait_deployment_status "ring-e2e" "fc-scaled" "running" 180
 
-# The replacement is serving, not stuck mid-boot.
-wait_deployment_status "ring-e2e" "fc-scaled" "running" 120
+wait_fc_socket_count 1 180
+# Hold the observation: if the count were transient, a second VM appears here.
+sleep 5
+HELD=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+[ "$HELD" -eq 1 ] || fail "socket count did not settle at 1: now $HELD (observed a transitional value)"
+log "converged to a single microVM and held"
 
 ROOTFS_AFTER=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
 [ "$ROOTFS_AFTER" -eq 1 ] || fail "expected 1 rootfs image after converging down, got $ROOTFS_AFTER (surplus images leaked)"
@@ -126,4 +131,9 @@ DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-scaled")
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 wait_fc_socket_count 0 180
 
-log "== T10-FC: PASS — fanned out to 3 VMs, converged back to 1, all artifacts reaped =="
+# Sockets going away is not the same as artifacts going away: a leaked rootfs
+# image is invisible until the disk fills.
+ROOTFS_FINAL=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$ROOTFS_FINAL" -eq 0 ] || fail "expected no rootfs image after delete, got $ROOTFS_FINAL"
+
+log "== T10-FC: PASS — fanned out to 3 VMs, converged back to 1, sockets and rootfs images reaped =="

--- a/tests/e2e/firecracker/t10_replicas.sh
+++ b/tests/e2e/firecracker/t10_replicas.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# T10-FC: apply a firecracker deployment with replicas=3 and assert the
+# scheduler converges to exactly 3 microVMs, each with its own API socket and
+# its own rootfs copy. Then scale down to 1 and assert two of them are torn
+# down — the cleanup is per-instance, not per-deployment.
+#
+# Why this test exists: Firecracker used to boot the WHOLE deficit inside a
+# single reconciliation pass, unlike every other runtime, which creates one
+# instance per tick. That made any large jump in the target count (a raised
+# replica count, a re-clamped autoscaling decision) a burst of simultaneous VM
+# boots competing for host memory. It now converges one VM per pass, and this
+# test is what keeps that true — the multi-instance path had no Firecracker
+# coverage at all, only Cloud Hypervisor's (t2_replicas / t9_scaledown).
+#
+# Requires: firecracker binary, /dev/kvm, CAP_NET_ADMIN on the ring binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+# Wait until exactly <expected> Firecracker API sockets exist.
+# Usage: wait_fc_socket_count <expected> [timeout_seconds]
+wait_fc_socket_count() {
+  local expected="$1"
+  local timeout="${2:-180}"
+  local count=0
+  for _ in $(seq 1 "$timeout"); do
+    count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$count" -eq "$expected" ]; then
+      log "firecracker socket count = $expected as expected"
+      return 0
+    fi
+    sleep 1
+  done
+  ls -la "$RING_E2E_FC_SOCKET_DIR" >&2 || true
+  fail "expected $expected firecracker socket(s), got $count (timeout ${timeout}s)"
+}
+
+log "== T10-FC: replicas (3 microVMs per deployment) =="
+
+setup_fc
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-replicas.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-scaled:
+    name: fc-scaled
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 3
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+# Status flips to running as soon as the first VM boots, so reaching 'running'
+# is necessary but not sufficient — the socket count below is what proves the
+# fan-out actually happened.
+wait_deployment_status "ring-e2e" "fc-scaled" "running" 240
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-scaled")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# One VM boots per reconciliation pass, so three replicas take at least three
+# ticks. The ceiling is generous: a cold rootfs copy plus boot is a few seconds
+# each, and CI hosts are slower than a laptop.
+wait_fc_socket_count 3 240
+
+# Distinct sockets, not the same one counted three times: a shared socket would
+# mean the instances collided instead of fanning out.
+distinct_sockets=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" -printf "%f\n" | sort -u | wc -l | tr -d ' ')
+[ "$distinct_sockets" -eq 3 ] || fail "expected 3 distinct socket filenames, got $distinct_sockets"
+
+# Each microVM runs off its own rootfs copy; sharing one would corrupt all three.
+rootfs_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$rootfs_count" -ge 3 ] || fail "expected at least 3 per-instance rootfs images, got $rootfs_count"
+log "3 distinct sockets and $rootfs_count rootfs image(s) confirmed"
+
+# The API must agree with what is on disk.
+INSTANCES=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json | jq -r '.instances | length')
+[ "$INSTANCES" -eq 3 ] || fail "API reports $INSTANCES instance(s), expected 3"
+log "API reports 3 instances"
+
+# --- Scale down to 1 -------------------------------------------------------
+# Removing instances must reap exactly the surplus, leaving one VM running.
+sed -i 's/replicas: 3/replicas: 1/' "$FIXTURE"
+"$RING_BIN" apply --file "$FIXTURE"
+
+wait_fc_socket_count 1 180
+log "scaled down to a single microVM"
+
+# The survivor is still serving: the deployment stays running rather than
+# being torn down and rebuilt.
+wait_deployment_status "ring-e2e" "fc-scaled" "running" 120
+
+# Re-read the id: applying a changed manifest replaces the deployment row, so
+# the id captured before the scale-down no longer exists.
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-scaled")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after scale-down"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+wait_fc_socket_count 0 180
+
+log "== T10-FC: PASS — fanned out to 3 VMs, scaled down to 1, cleaned up =="

--- a/tests/e2e/firecracker/t10_replicas.sh
+++ b/tests/e2e/firecracker/t10_replicas.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 # T10-FC: apply a firecracker deployment with replicas=3 and assert the
 # scheduler converges to exactly 3 microVMs, each with its own API socket and
-# its own rootfs copy. Then scale down to 1 and assert two of them are torn
-# down — the cleanup is per-instance, not per-deployment.
+# its own rootfs copy. Then re-apply with replicas=1 and assert the instance
+# count settles back to one, with every artifact reaped on delete.
 #
-# Why this test exists: Firecracker used to boot the WHOLE deficit inside a
-# single reconciliation pass, unlike every other runtime, which creates one
-# instance per tick. That made any large jump in the target count (a raised
-# replica count, a re-clamped autoscaling decision) a burst of simultaneous VM
-# boots competing for host memory. It now converges one VM per pass, and this
-# test is what keeps that true — the multi-instance path had no Firecracker
-# coverage at all, only Cloud Hypervisor's (t2_replicas / t9_scaledown).
+# Why this test exists: the Firecracker multi-instance path had no e2e coverage
+# at all, only Cloud Hypervisor's (t2_replicas / t9_scaledown). Everything below
+# 2 replicas is single-VM behaviour that t1 already covers; fan-out, per-instance
+# artifact isolation and convergence back down were simply untested.
+#
+# What this does NOT prove, deliberately, so nobody reads more into a green run:
+#   * NOT that VMs are created one per reconciliation pass. This asserts the
+#     eventual count, which both the current one-per-pass implementation and the
+#     older boot-the-whole-deficit-at-once one satisfy. Proving the pacing needs
+#     observation of intermediate states, not a converged count.
+#   * NOT per-instance teardown. `ring apply` with a changed replica count
+#     REPLACES the deployment (new row, old one marked deleted) rather than
+#     resizing it in place, so what is exercised below is convergence after a
+#     replacement — the same thing t9_scaledown does on CH, and it documents the
+#     same caveat. The `current.len() > desired` branch in the runtime is not
+#     reached this way.
 #
 # Requires: firecracker binary, /dev/kvm, CAP_NET_ADMIN on the ring binary.
 
@@ -77,39 +86,44 @@ log "deployment id: $DEPLOYMENT_ID"
 # each, and CI hosts are slower than a laptop.
 wait_fc_socket_count 3 240
 
-# Distinct sockets, not the same one counted three times: a shared socket would
-# mean the instances collided instead of fanning out.
-distinct_sockets=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" -printf "%f\n" | sort -u | wc -l | tr -d ' ')
-[ "$distinct_sockets" -eq 3 ] || fail "expected 3 distinct socket filenames, got $distinct_sockets"
-
-# Each microVM runs off its own rootfs copy; sharing one would corrupt all three.
+# Each microVM runs off its own rootfs copy; sharing one would corrupt all
+# three. Exactly 3, not "at least 3": a looser bound would pass with leftovers
+# from failed starts, which is precisely the situation worth catching.
 rootfs_count=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
-[ "$rootfs_count" -ge 3 ] || fail "expected at least 3 per-instance rootfs images, got $rootfs_count"
-log "3 distinct sockets and $rootfs_count rootfs image(s) confirmed"
+[ "$rootfs_count" -eq 3 ] || fail "expected exactly 3 per-instance rootfs images, got $rootfs_count"
+log "3 sockets and 3 rootfs images confirmed"
 
 # The API must agree with what is on disk.
 INSTANCES=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json | jq -r '.instances | length')
 [ "$INSTANCES" -eq 3 ] || fail "API reports $INSTANCES instance(s), expected 3"
 log "API reports 3 instances"
 
-# --- Scale down to 1 -------------------------------------------------------
-# Removing instances must reap exactly the surplus, leaving one VM running.
+# --- Converge back down to 1 -----------------------------------------------
+# Re-applying with a lower replica count REPLACES the deployment (see the note
+# at the top): the old row is marked deleted and a new one created. What is
+# asserted here is that the host converges to exactly one live VM and does not
+# strand the other two — leaked sockets and rootfs images would accumulate
+# silently until the disk filled.
 sed -i 's/replicas: 3/replicas: 1/' "$FIXTURE"
 "$RING_BIN" apply --file "$FIXTURE"
 
+# Deliberately waits for the settled count rather than a transitional one: with
+# a replacement, the socket count passes through several values before landing.
 wait_fc_socket_count 1 180
-log "scaled down to a single microVM"
+log "converged to a single microVM"
 
-# The survivor is still serving: the deployment stays running rather than
-# being torn down and rebuilt.
+# The replacement is serving, not stuck mid-boot.
 wait_deployment_status "ring-e2e" "fc-scaled" "running" 120
 
-# Re-read the id: applying a changed manifest replaces the deployment row, so
-# the id captured before the scale-down no longer exists.
+ROOTFS_AFTER=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$ROOTFS_AFTER" -eq 1 ] || fail "expected 1 rootfs image after converging down, got $ROOTFS_AFTER (surplus images leaked)"
+log "surplus rootfs images reaped"
+
+# The id changed with the replacement, so the pre-apply one no longer resolves.
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-scaled")
-[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after scale-down"
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find the active deployment after re-apply"
 
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 wait_fc_socket_count 0 180
 
-log "== T10-FC: PASS — fanned out to 3 VMs, scaled down to 1, cleaned up =="
+log "== T10-FC: PASS — fanned out to 3 VMs, converged back to 1, all artifacts reaped =="

--- a/tests/e2e/firecracker/t11_health_checks.sh
+++ b/tests/e2e/firecracker/t11_health_checks.sh
@@ -90,8 +90,13 @@ SUCCESS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json \
 # the one that matters here: a runtime whose probes never run at all.
 MSG=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json | jq -r '.[0].message // ""')
 log "first probe message: $MSG"
+# Only the two `TCP connection ...` messages are accepted: those come from
+# `health_probes::tcp_probe`. The scheduler's own outer timeout produces
+# "Health check timed out", which a regression hanging before `TcpStream::connect`
+# could also produce — accepting it would let this assertion pass without a
+# connect ever being attempted.
 case "$MSG" in
-  *"TCP connection failed"* | *"TCP connection timed out"* | *"Health check timed out"*)
+  *"TCP connection failed"* | *"TCP connection timed out"*)
     log "probe message confirms the shared health_probes module ran"
     ;;
   *"not supported"* | *"Could not resolve instance address"*)

--- a/tests/e2e/firecracker/t11_health_checks.sh
+++ b/tests/e2e/firecracker/t11_health_checks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# T11-FC: validate that tcp/http health checks actually run on the Firecracker
+# T11-FC: validate that tcp health checks actually run on the Firecracker
 # runtime, through the shared `hypervisor::health_probes` module.
 #
 # Firecracker implements neither `execute_health_check` nor the probes: it
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/../lib.sh"
 # shellcheck source=./setup.sh
 source "$SCRIPT_DIR/setup.sh"
 
-log "== T11-FC: health checks (tcp + http failure path) =="
+log "== T11-FC: health checks (tcp failure path) =="
 
 setup_fc
 start_ring
@@ -80,9 +80,14 @@ SUCCESS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json \
   | jq '[.[] | select(.status=="success")] | length')
 [ "${SUCCESS:-0}" -eq 0 ] || fail "expected zero successful probes on a closed port, got $SUCCESS"
 
-# The load-bearing assertion: the message must come from health_probes::tcp_probe.
-# "not supported" would mean the default trait impl bailed out, i.e. Firecracker's
-# `instance_address` never resolved and no probe was actually attempted.
+# The load-bearing assertion: a connect was actually attempted against a
+# resolved guest address, rather than the probe bailing out early.
+#
+# What this does and does not prove: "TCP connection failed" means the host
+# reached the point of connecting, so `instance_address` resolved and the shared
+# probe ran. It does NOT prove a packet reached the guest — a refused connect
+# can also come from host routing or TAP state. The failure it does rule out is
+# the one that matters here: a runtime whose probes never run at all.
 MSG=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json | jq -r '.[0].message // ""')
 log "first probe message: $MSG"
 case "$MSG" in
@@ -97,17 +102,7 @@ case "$MSG" in
     ;;
 esac
 
-# Deliberately NOT asserted here: that `on_failure: alert` emits an event.
-# `health_checker` suppresses failure counting and `on_failure` actions while a
-# deployment is still in its creating phase (see the `!creating_phase` guard in
-# src/scheduler/health_checker.rs), and this rootfs never brings up a service,
-# so the deployment does not leave that phase within the test's lifetime. That
-# gate is runtime-agnostic scheduler behaviour and belongs in its own test, not
-# in a Firecracker probe test — asserting it here would be testing the health
-# checker through the wrong door.
-#
-# Repeated probes are still worth checking: the loop must keep running rather
-# than record one row and stop.
+# The probe loop must keep running rather than record one row and stop.
 log "checking the probe loop keeps running..."
 for _ in $(seq 1 20); do
   ROWS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json 2>/dev/null | jq 'length')
@@ -116,6 +111,21 @@ for _ in $(seq 1 20); do
 done
 [ "${ROWS:-0}" -ge 2 ] || fail "only ${ROWS:-0} probe row(s) after 20s — the probe loop is not repeating"
 log "$ROWS probe rows recorded — the loop is repeating"
+
+# NOT asserted: that `on_failure: alert` emits a health_checker event within
+# this test's lifetime.
+#
+# It does fire — a longer-running instance of this exact fixture produces
+# `health_checker|health_check_alert` in the event table — but not reliably
+# inside the window here, and I could not pin down what governs the delay well
+# enough to write a non-flaky assertion. An earlier version of this file
+# "explained" the absence with a creating-phase argument that turned out to be
+# wrong (with no readiness check the deployment reaches Running immediately, so
+# failure counting does start).
+#
+# Leaving it unasserted rather than guessing at a timeout: a flaky assertion in
+# an e2e suite that CI never runs is worse than an honest gap. Tracked on the
+# board as "firecracker on_failure alert timing".
 
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-hc-tcp")
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"

--- a/tests/e2e/firecracker/t11_health_checks.sh
+++ b/tests/e2e/firecracker/t11_health_checks.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# T11-FC: validate that tcp/http health checks actually run on the Firecracker
+# runtime, through the shared `hypervisor::health_probes` module.
+#
+# Firecracker implements neither `execute_health_check` nor the probes: it
+# relies on the trait's default implementation, which resolves the guest via
+# the runtime's `instance_address` override and then calls the shared probe. So
+# nothing here is Firecracker-specific code — which is exactly why it needs a
+# test. Nothing proved that wiring held on this runtime; the equivalent Cloud
+# Hypervisor coverage (t15/t17) says nothing about it.
+#
+# Like the CH test, this exercises the FAILURE path on purpose: the CI rootfs
+# runs no service on a known port, so we cannot assert a successful probe. What
+# we can assert is that a probe REALLY RAN — rows recorded, and a message
+# produced by the shared probe module rather than a "not supported" stub.
+#
+# Requires: firecracker binary, /dev/kvm, CAP_NET_ADMIN on the ring binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T11-FC: health checks (tcp + http failure path) =="
+
+setup_fc
+start_ring
+ring_login
+
+# Port 9999: nothing in the guest listens there, so the probe must fail rather
+# than flake. `on_failure: alert` keeps the VM alive — a restart action would
+# race the assertions below.
+FIXTURE="$RING_TEST_DIR/fc-hc.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-hc-tcp:
+    name: fc-hc-tcp
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    health_checks:
+      - type: tcp
+        port: 9999
+        interval: "2s"
+        timeout: "2s"
+        threshold: 2
+        on_failure: alert
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-hc-tcp" "running" 240
+
+TCP_ID=$(get_deployment_id "ring-e2e" "fc-hc-tcp")
+[ -n "$TCP_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $TCP_ID"
+
+# A probe row appearing at all is the first thing to prove: it means the
+# scheduler's health-check loop reached this runtime.
+log "waiting for probe rows to appear..."
+ATTEMPTS=0
+for _ in $(seq 1 40); do
+  ATTEMPTS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json 2>/dev/null | jq 'length')
+  [ "${ATTEMPTS:-0}" -ge 1 ] && break
+  sleep 1
+done
+[ "${ATTEMPTS:-0}" -ge 1 ] || fail "no health-check rows recorded for $TCP_ID — the probe pipeline never ran"
+log "$ATTEMPTS probe row(s) recorded"
+
+# The port is closed, so no probe may report success. A success here would mean
+# the probe is not really connecting to the guest.
+SUCCESS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json \
+  | jq '[.[] | select(.status=="success")] | length')
+[ "${SUCCESS:-0}" -eq 0 ] || fail "expected zero successful probes on a closed port, got $SUCCESS"
+
+# The load-bearing assertion: the message must come from health_probes::tcp_probe.
+# "not supported" would mean the default trait impl bailed out, i.e. Firecracker's
+# `instance_address` never resolved and no probe was actually attempted.
+MSG=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json | jq -r '.[0].message // ""')
+log "first probe message: $MSG"
+case "$MSG" in
+  *"TCP connection failed"* | *"TCP connection timed out"* | *"Health check timed out"*)
+    log "probe message confirms the shared health_probes module ran"
+    ;;
+  *"not supported"* | *"Could not resolve instance address"*)
+    fail "probe did not run: '$MSG' — instance_address or the default impl is broken on firecracker"
+    ;;
+  *)
+    fail "unexpected probe message: '$MSG'"
+    ;;
+esac
+
+# Deliberately NOT asserted here: that `on_failure: alert` emits an event.
+# `health_checker` suppresses failure counting and `on_failure` actions while a
+# deployment is still in its creating phase (see the `!creating_phase` guard in
+# src/scheduler/health_checker.rs), and this rootfs never brings up a service,
+# so the deployment does not leave that phase within the test's lifetime. That
+# gate is runtime-agnostic scheduler behaviour and belongs in its own test, not
+# in a Firecracker probe test — asserting it here would be testing the health
+# checker through the wrong door.
+#
+# Repeated probes are still worth checking: the loop must keep running rather
+# than record one row and stop.
+log "checking the probe loop keeps running..."
+for _ in $(seq 1 20); do
+  ROWS=$("$RING_BIN" deployment health-checks "$TCP_ID" --output json 2>/dev/null | jq 'length')
+  [ "${ROWS:-0}" -ge 2 ] && break
+  sleep 1
+done
+[ "${ROWS:-0}" -ge 2 ] || fail "only ${ROWS:-0} probe row(s) after 20s — the probe loop is not repeating"
+log "$ROWS probe rows recorded — the loop is repeating"
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-hc-tcp")
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+log "== T11-FC: PASS — tcp probe ran through the shared module and keeps polling =="

--- a/tests/e2e/podman/t5_podman_volumes_env.sh
+++ b/tests/e2e/podman/t5_podman_volumes_env.sh
@@ -43,6 +43,18 @@ host = \"$PODMAN_SOCK\""
 start_ring
 ring_login
 
+# The shared cleanup trap in lib.sh reaps containers through the `docker` CLI,
+# which does not see this suite's rootless Podman socket. Without this, a test
+# that fails an assertion below leaves its container running and the next run
+# starts dirty.
+cleanup_podman_leftovers() {
+  # `ring_deployment` is the only label Ring sets (src/runtime/docker/container.rs),
+  # so match on its presence rather than on a namespace that is not labelled.
+  podman ps -aq --filter "label=ring_deployment" 2>/dev/null \
+    | xargs -r podman rm -f >/dev/null 2>&1 || true
+}
+trap 'cleanup_podman_leftovers; cleanup_ring' EXIT
+
 # The mount source must be readable by the rootless user's mapped uid, so keep
 # it inside the test dir rather than somewhere root-owned.
 BIND_SRC="$RING_TEST_DIR/podman-bind"
@@ -89,10 +101,17 @@ log "bind mount readable inside the container"
 
 # Read-only was requested, so a write must be refused. Without this the mount
 # could be silently rw and nobody would notice until data was corrupted.
+#
+# A non-zero exit is not enough on its own — an exec transport failure would
+# look identical — so the file must also be absent afterwards.
 if podman exec "$CONTAINER" sh -c 'echo x > /data/should-fail' 2>/dev/null; then
   fail "the ro bind mount accepted a write"
 fi
-log "ro permission enforced"
+if podman exec "$CONTAINER" test -e /data/should-fail 2>/dev/null; then
+  fail "the write was reported as refused but the file exists — the mount is not ro"
+fi
+[ ! -e "$BIND_SRC/should-fail" ] || fail "the write reached the host directory — the mount is not ro"
+log "ro permission enforced (write refused, no file created)"
 
 # --- the environment variable reached the process --------------------------
 ENV_VALUE=$(podman exec "$CONTAINER" printenv RING_E2E_MARKER 2>/dev/null || echo "")

--- a/tests/e2e/podman/t5_podman_volumes_env.sh
+++ b/tests/e2e/podman/t5_podman_volumes_env.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# T5-podman: bind volumes and environment variables must reach the container on
+# the Podman runtime, not just on Docker.
+#
+# Podman shares Docker's lifecycle code, which is exactly why this was never
+# tested: the shared path is assumed to behave identically. It mostly does, but
+# "mostly" is what a rootless daemon breaks — bind mounts cross a user-namespace
+# boundary under Podman, and a path that mounts fine as root can arrive empty or
+# unreadable rootless. Asserting the container actually SEES the file (rather
+# than that Ring asked for the mount) is the point.
+#
+# Skips cleanly when Podman or its rootless socket is unavailable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+log "== T5-podman: bind volume + environment =="
+
+if ! command -v podman > /dev/null 2>&1; then
+  log "podman not installed — SKIP"
+  exit 0
+fi
+
+PODMAN_SOCK="${RING_PODMAN_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+SOCK_PATH="${PODMAN_SOCK#unix://}"
+if [ ! -S "$SOCK_PATH" ]; then
+  systemctl --user start podman.socket 2>/dev/null || true
+  if [ ! -S "$SOCK_PATH" ]; then
+    log "podman socket $SOCK_PATH not available — SKIP"
+    exit 0
+  fi
+fi
+log "podman socket: $SOCK_PATH"
+
+export RING_E2E_ENABLE_DOCKER=false
+export RING_EXTRA_CONFIG="[server.runtime.podman]
+enabled = true
+host = \"$PODMAN_SOCK\""
+
+start_ring
+ring_login
+
+# The mount source must be readable by the rootless user's mapped uid, so keep
+# it inside the test dir rather than somewhere root-owned.
+BIND_SRC="$RING_TEST_DIR/podman-bind"
+mkdir -p "$BIND_SRC"
+echo "mounted-from-host" > "$BIND_SRC/marker.txt"
+chmod -R a+rX "$BIND_SRC"
+
+FIXTURE="$RING_TEST_DIR/podman-vol-env.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  podman-vol-env:
+    name: podman-vol-env
+    namespace: ring-e2e
+    runtime: podman
+    image: docker.io/library/busybox:latest
+    replicas: 1
+    command: ["sh", "-c", "sleep 3600"]
+    environment:
+      RING_E2E_MARKER: "env-value-42"
+    volumes:
+      - type: bind
+        source: $BIND_SRC
+        destination: /data
+        driver: local
+        permission: ro
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "podman-vol-env" "running" 90
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "podman-vol-env")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CONTAINER=$(podman ps -q --filter "label=ring_deployment=$DEPLOYMENT_ID" | head -n1)
+[ -n "$CONTAINER" ] || fail "no running podman container for deployment $DEPLOYMENT_ID"
+log "container: $CONTAINER"
+
+# --- the bind mount is visible from inside the container -------------------
+CONTENT=$(podman exec "$CONTAINER" cat /data/marker.txt 2>/dev/null || echo "")
+[ "$CONTENT" = "mounted-from-host" ] \
+  || fail "bind mount not readable in the container: got '$CONTENT'"
+log "bind mount readable inside the container"
+
+# Read-only was requested, so a write must be refused. Without this the mount
+# could be silently rw and nobody would notice until data was corrupted.
+if podman exec "$CONTAINER" sh -c 'echo x > /data/should-fail' 2>/dev/null; then
+  fail "the ro bind mount accepted a write"
+fi
+log "ro permission enforced"
+
+# --- the environment variable reached the process --------------------------
+ENV_VALUE=$(podman exec "$CONTAINER" printenv RING_E2E_MARKER 2>/dev/null || echo "")
+[ "$ENV_VALUE" = "env-value-42" ] \
+  || fail "environment variable not set in the container: got '$ENV_VALUE'"
+log "environment variable present inside the container"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+for _ in $(seq 1 30); do
+  left=$(podman ps -aq --filter "label=ring_deployment=$DEPLOYMENT_ID" | wc -l | tr -d ' ')
+  if [ "$left" -eq 0 ]; then
+    log "== T5-podman: PASS — bind mount, ro flag and env all reached the container =="
+    exit 0
+  fi
+  sleep 1
+done
+
+podman ps -a --filter "label=ring_deployment=$DEPLOYMENT_ID" >&2
+fail "podman container for $DEPLOYMENT_ID still present after delete"

--- a/tests/e2e/podman/t5_podman_volumes_env.sh
+++ b/tests/e2e/podman/t5_podman_volumes_env.sh
@@ -48,9 +48,11 @@ ring_login
 # that fails an assertion below leaves its container running and the next run
 # starts dirty.
 cleanup_podman_leftovers() {
-  # `ring_deployment` is the only label Ring sets (src/runtime/docker/container.rs),
-  # so match on its presence rather than on a namespace that is not labelled.
-  podman ps -aq --filter "label=ring_deployment" 2>/dev/null \
+  # Scoped to the `ring-e2e_` name prefix as well as the label, mirroring the
+  # docker cleanup in lib.sh. The `ring_deployment` label alone is on EVERY Ring
+  # container, so filtering on it by itself would let this test destroy a
+  # developer's unrelated workloads on their normal rootless socket.
+  podman ps -aq --filter "label=ring_deployment" --filter "name=^ring-e2e_" 2>/dev/null \
     | xargs -r podman rm -f >/dev/null 2>&1 || true
 }
 trap 'cleanup_podman_leftovers; cleanup_ring' EXIT


### PR DESCRIPTION
Closes coverage gaps on the runtimes nobody was testing. Every test here was run against real microVMs and containers.

## The gap

e2e tests per runtime before this branch: docker 45, cloud-hypervisor 24, **firecracker 9**, containerd 6, **podman 4**.

## What was added

**`t10_replicas.sh` (firecracker)** — fan out to 3 microVMs, assert 3 sockets and exactly 3 rootfs copies, converge back to 1, assert the surplus images are reaped, then delete and assert sockets *and* rootfs images reach zero.

**`t11_health_checks.sh` (firecracker)** — Firecracker implements neither `execute_health_check` nor the probes; it relies on the trait default resolving the guest through its `instance_address` override. Nothing proved that held. The test requires the probe message to come from `health_probes::tcp_probe` specifically, and asserts the loop keeps polling.

**`t5_podman_volumes_env.sh` (podman)** — bind mount readable *inside* the container, `ro` refusing a write (verified by absence of the file both in the container and on the host), and an environment variable reaching the process. Podman shares Docker's lifecycle, which is why this went untested — but bind mounts cross a user-namespace boundary when rootless.

**`setup.sh` (firecracker)** — fail fast when the binary lacks an *effective* `CAP_NET_ADMIN`. Without it every boot fails on `TUNSETIFF` and the deployment lands in `crash_loop_back_off`, which a test can only report as "did not reach running in 60s" — pointing at the runtime instead of the missing capability.

## What these tests deliberately do NOT prove

Stated in each header so a green run is not over-read:

- **t10 does not prove one-VM-per-reconciliation-pass.** It asserts the eventual count, which both the current implementation and the pre-#211 one satisfy. Proving the pacing needs intermediate-state observation.
- **t10 does not exercise per-instance teardown.** `ring apply` with a changed replica count replaces the deployment rather than resizing it, so the `current.len() > desired` branch is not reached — the same caveat CH's `t9_scaledown` documents.
- **t11 does not prove guest reachability.** A refused connect proves the probe ran and a connect was attempted; it does not prove a packet reached the guest.
- **t11 does not assert the `on_failure: alert` event.** It does fire, but not reliably within the test window, and I could not determine what governs the delay. Documented in the file and tracked on the board rather than asserted with a guessed timeout.

## Not added

A containerd metrics test: `setup.sh` there requires root, so it could not be executed, and shipping an unrun test is worse than shipping none. Tracked on the board with the wider podman/containerd gap.

## Verification

firecracker t1–t6, t8, t10, t11 and podman t1, t2, t4, t5 all pass locally against real VMs and containers. 824 unit tests unchanged.

Reviewed by codex over three rounds. It caught that t10 overstated what it proved, that my creating-phase explanation for the missing alert was factually wrong, that t11 accepted a scheduler-generated timeout message which would let a hang pass, and that my first cleanup trap would have deleted a developer's unrelated Ring containers. All fixed; final verdict was merge-approved.
