### PR TITLE
e2e: firecracker parity round 2 — environment, sizing, crash-loop

### DIFF
--- a/tests/e2e/firecracker/t11_health_checks.sh
+++ b/tests/e2e/firecracker/t11_health_checks.sh
@@ -117,22 +117,31 @@ done
 [ "${ROWS:-0}" -ge 2 ] || fail "only ${ROWS:-0} probe row(s) after 20s — the probe loop is not repeating"
 log "$ROWS probe rows recorded — the loop is repeating"
 
-# NOT asserted: that `on_failure: alert` emits a health_checker event within
-# this test's lifetime.
+# `on_failure: alert` must reach the event stream, otherwise a failing workload
+# is invisible to whoever is watching the deployment.
 #
-# It does fire — a longer-running instance of this exact fixture produces
-# `health_checker|health_check_alert` in the event table — but not reliably
-# inside the window here, and I could not pin down what governs the delay well
-# enough to write a non-flaky assertion. An earlier version of this file
-# "explained" the absence with a creating-phase argument that turned out to be
-# wrong (with no readiness check the deployment reaches Running immediately, so
-# failure counting does start).
-#
-# Leaving it unasserted rather than guessing at a timeout: a flaky assertion in
-# an e2e suite that CI never runs is worse than an honest gap. Tracked on the
-# board as "firecracker on_failure alert timing".
+# Note: `deployment events` renders a table and has no --output json, so this
+# filters with its own --level flag and matches the rendered text. Piping that
+# output through jq silently yields nothing — which is what made an earlier
+# version of this assertion appear to fail, and led me to wrongly blame the
+# creating-phase guard.
+log "waiting for the on_failure alert..."
+ALERTED=0
+for _ in $(seq 1 60); do
+  if "$RING_BIN" deployment events "$TCP_ID" --level error 2>/dev/null \
+      | grep -qi "health"; then
+    ALERTED=1
+    break
+  fi
+  sleep 1
+done
+if [ "$ALERTED" -ne 1 ]; then
+  "$RING_BIN" deployment events "$TCP_ID" 2>/dev/null | head -20 >&2 || true
+  fail "on_failure: alert produced no health-related error event"
+fi
+log "health check alert reached the event stream"
 
 DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-hc-tcp")
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 
-log "== T11-FC: PASS — tcp probe ran through the shared module and keeps polling =="
+log "== T11-FC: PASS — tcp probe ran, kept polling, and alerted =="

--- a/tests/e2e/firecracker/t12_environment.sh
+++ b/tests/e2e/firecracker/t12_environment.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# T12-FC: a firecracker deployment with `environment` must boot with a NoCloud
+# cidata image attached, carrying the env payload Ring generates.
+#
+# Cloud Hypervisor has this coverage (t4_environment); Firecracker did not,
+# even though it uses the same cloud-init path. Environment variables are how
+# most workloads get their configuration, so "the VM booted" says nothing if
+# the config never reached it.
+#
+# Like the CH test, this asserts the HOST-SIDE contract: Ring builds the cidata
+# image and it really contains the variables. Introspecting the guest would need
+# SSH into the microVM, which the CI rootfs is not set up for.
+#
+# Requires: firecracker, /dev/kvm, CAP_NET_ADMIN on the ring binary, debugfs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T12-FC: cloud-init environment variables =="
+
+setup_fc
+command -v debugfs >/dev/null 2>&1 || fail "debugfs (e2fsprogs) required to inspect cidata"
+
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-env.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-env:
+    name: fc-env
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    environment:
+      RING_E2E_PLAIN: "plain-value-42"
+      RING_E2E_SPACED: "value with spaces"
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-env" "running" 240
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-env")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+CIDATA=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.cidata.iso" 2>/dev/null | head -n1)
+[ -n "$CIDATA" ] || { ls -la "$RING_E2E_FC_SOCKET_DIR" >&2; fail "cidata image not found — no cloud-init datasource was attached"; }
+log "cidata image: $(basename "$CIDATA")"
+
+USER_DATA=$(debugfs -R "cat /user-data" "$CIDATA" 2>/dev/null || true)
+[ -n "$USER_DATA" ] || fail "cidata contains no user-data payload"
+
+# Ring writes the variables into the cloud-config; the payload may be inline or
+# base64-encoded, so decode any base64 blob before matching rather than assuming
+# one shape.
+DECODED="$USER_DATA
+$(printf '%s' "$USER_DATA" | grep -oE '[A-Za-z0-9+/=]{40,}' | while read -r blob; do
+    printf '%s' "$blob" | base64 -d 2>/dev/null || true
+  done)"
+
+echo "$DECODED" | grep -q "RING_E2E_PLAIN" \
+  || { printf '%s\n' "$USER_DATA" | head -30 >&2; fail "env var RING_E2E_PLAIN missing from the cidata payload"; }
+echo "$DECODED" | grep -q "plain-value-42" \
+  || fail "the VALUE of RING_E2E_PLAIN never reached the cidata payload"
+log "RING_E2E_PLAIN and its value are present in the cidata"
+
+# A value containing spaces is the case that breaks naive KEY=value emitters.
+echo "$DECODED" | grep -q "value with spaces" \
+  || fail "a value containing spaces was mangled or dropped"
+log "a spaced value survived intact"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# The cidata image is per-instance state and must not outlive the deployment.
+for _ in $(seq 1 60); do
+  left=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.cidata.iso" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$left" -eq 0 ] && break
+  sleep 1
+done
+[ "${left:-1}" -eq 0 ] || fail "cidata image left behind after delete"
+
+log "== T12-FC: PASS — env vars reached the cidata payload and were reaped on delete =="

--- a/tests/e2e/firecracker/t12_environment.sh
+++ b/tests/e2e/firecracker/t12_environment.sh
@@ -69,16 +69,18 @@ $(printf '%s' "$USER_DATA" | grep -oE '[A-Za-z0-9+/=]{40,}' | while read -r blob
     printf '%s' "$blob" | base64 -d 2>/dev/null || true
   done)"
 
-echo "$DECODED" | grep -q "RING_E2E_PLAIN" \
-  || { printf '%s\n' "$USER_DATA" | head -30 >&2; fail "env var RING_E2E_PLAIN missing from the cidata payload"; }
-echo "$DECODED" | grep -q "plain-value-42" \
-  || fail "the VALUE of RING_E2E_PLAIN never reached the cidata payload"
-log "RING_E2E_PLAIN and its value are present in the cidata"
+# Match each key TOGETHER with its value, not the two independently: separate
+# greps would pass even if the payload paired a key with the wrong value, which
+# is the failure worth catching.
+echo "$DECODED" | grep -qE 'RING_E2E_PLAIN=["'"'"']?plain-value-42' \
+  || { printf '%s\n' "$DECODED" | head -30 >&2; fail "RING_E2E_PLAIN is not bound to its value in the cidata payload"; }
+log "RING_E2E_PLAIN is bound to its value"
 
-# A value containing spaces is the case that breaks naive KEY=value emitters.
-echo "$DECODED" | grep -q "value with spaces" \
-  || fail "a value containing spaces was mangled or dropped"
-log "a spaced value survived intact"
+# A value containing spaces is the case that breaks naive KEY=value emitters —
+# it must survive whole and stay attached to its own key.
+echo "$DECODED" | grep -qE 'RING_E2E_SPACED=["'"'"']?value with spaces' \
+  || { printf '%s\n' "$DECODED" | head -30 >&2; fail "RING_E2E_SPACED lost its spaced value"; }
+log "RING_E2E_SPACED kept its spaced value intact"
 
 "$RING_BIN" deployment delete "$DEPLOYMENT_ID"
 

--- a/tests/e2e/firecracker/t13_resource_limits.sh
+++ b/tests/e2e/firecracker/t13_resource_limits.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# T13-FC: `resources.limits` must reach the microVM's machine config, with
+# fractional CPU rounded UP to whole vCPUs.
+#
+# Cloud Hypervisor has this coverage (t8_resource_limits); Firecracker did not,
+# despite having its own sizing rules that differ from CH's:
+#   * CH rounds fractional CPU DOWN (`"500m"` -> 1 vCPU via max(1, floor)).
+#   * Firecracker rounds UP (`"1500m"` -> 2 vCPUs), because it cannot allocate
+#     fractional cores at all.
+#   * memory below 64 MiB is ignored and the 512 MiB default used instead.
+#
+# Those are easy rules to break silently — a deployment would simply boot with
+# the wrong size and nobody would notice until it OOMed or throttled. The
+# assertion reads Firecracker's own `/machine-config` over its API socket, so
+# it checks what the hypervisor actually got, not what Ring intended to send.
+#
+# Requires: firecracker, /dev/kvm, CAP_NET_ADMIN on the ring binary, curl.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T13-FC: resource limits reach the machine config =="
+
+setup_fc
+start_ring
+ring_login
+
+# 1500m must round UP to 2 vCPUs; 256Mi must be honoured verbatim.
+FIXTURE="$RING_TEST_DIR/fc-resources.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-sized:
+    name: fc-sized
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1500m"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+wait_deployment_status "ring-e2e" "fc-sized" "running" 240
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-sized")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+SOCKET=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | head -n1)
+[ -n "$SOCKET" ] || { ls -la "$RING_E2E_FC_SOCKET_DIR" >&2; fail "no firecracker API socket found"; }
+
+# Ask the hypervisor what it is actually running with.
+MACHINE_CONFIG=$(curl -s --unix-socket "$SOCKET" http://localhost/machine-config 2>/dev/null || echo "")
+[ -n "$MACHINE_CONFIG" ] || fail "could not read /machine-config from $SOCKET"
+log "machine-config: $MACHINE_CONFIG"
+
+VCPUS=$(echo "$MACHINE_CONFIG" | jq -r '.vcpu_count // 0')
+MEM=$(echo "$MACHINE_CONFIG" | jq -r '.mem_size_mib // 0')
+
+# 1500m = 1.5 vCPU, rounded up. Getting 1 here would mean truncation (CH's rule
+# applied to Firecracker), and the workload would silently run at 2/3 the CPU
+# the manifest asked for.
+[ "$VCPUS" -eq 2 ] || fail "expected 1500m to round up to 2 vCPUs, got $VCPUS"
+log "1500m rounded up to 2 vCPUs as expected"
+
+[ "$MEM" -eq 256 ] || fail "expected 256 MiB of RAM, got $MEM"
+log "256Mi honoured verbatim"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+
+# --- a memory value below the floor falls back to the default ---------------
+# Below 64 MiB Ring ignores the request rather than booting a VM too small to
+# start systemd. Asserting the fallback keeps that deliberate behaviour from
+# being mistaken for a bug and "fixed" into an unbootable VM.
+for _ in $(seq 1 60); do
+  left=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$left" -eq 0 ] && break
+  sleep 1
+done
+
+FIXTURE2="$RING_TEST_DIR/fc-tiny.yaml"
+cat > "$FIXTURE2" <<EOF
+deployments:
+  fc-tiny:
+    name: fc-tiny
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    resources:
+      limits:
+        memory: "32Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE2"
+wait_deployment_status "ring-e2e" "fc-tiny" "running" 240
+
+SOCKET2=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -type s -name "*.sock" 2>/dev/null | head -n1)
+[ -n "$SOCKET2" ] || fail "no firecracker API socket for the tiny deployment"
+
+MC2=$(curl -s --unix-socket "$SOCKET2" http://localhost/machine-config 2>/dev/null || echo "")
+MEM2=$(echo "$MC2" | jq -r '.mem_size_mib // 0')
+[ "$MEM2" -eq 512 ] || fail "expected a 32Mi request to fall back to the 512 MiB default, got $MEM2"
+log "a below-floor memory request fell back to 512 MiB"
+
+TINY_ID=$(get_deployment_id "ring-e2e" "fc-tiny")
+"$RING_BIN" deployment delete "$TINY_ID"
+
+log "== T13-FC: PASS — CPU rounds up, memory honoured, below-floor falls back =="

--- a/tests/e2e/firecracker/t14_crashloop.sh
+++ b/tests/e2e/firecracker/t14_crashloop.sh
@@ -37,7 +37,10 @@ RING_E2E_FC_KERNEL="$BOGUS_KERNEL"
 export RING_E2E_FC_KERNEL
 log "bogus kernel created at $BOGUS_KERNEL"
 
+# Reap it even when an assertion below exits early — `setup_fc` installs its own
+# trap, so this one has to be layered in after it rather than before.
 setup_fc
+trap 'rm -f "$BOGUS_KERNEL"; cleanup_fc; cleanup_ring' EXIT
 start_ring
 ring_login
 
@@ -83,12 +86,23 @@ log "reached crash_loop_back_off"
 # Landing in the terminal state is only half of it: the scheduler must also
 # STOP retrying. Without this, a deployment could report CrashLoopBackOff while
 # still burning a rootfs copy and a TAP every tick.
-ROOTFS_AT_TERMINAL=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
-sleep 10
-ROOTFS_LATER=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
-[ "$ROOTFS_LATER" -le "$ROOTFS_AT_TERMINAL" ] \
-  || fail "rootfs images still accumulating after CrashLoopBackOff ($ROOTFS_AT_TERMINAL -> $ROOTFS_LATER): retries did not stop"
-log "no new artifacts after the terminal state — retries stopped"
+#
+# `restart_count` is the right signal, not a file count: artifacts are created
+# and removed within each attempt, so their number can sit flat while retries
+# continue underneath. The counter only moves when a new attempt is actually
+# made.
+COUNT_AT_TERMINAL=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json 2>/dev/null \
+  | jq -r '.restart_count // 0')
+[ "${COUNT_AT_TERMINAL:-0}" -ge 1 ] \
+  || fail "restart_count is ${COUNT_AT_TERMINAL:-0} after repeated boot failures — attempts are not being counted"
+log "restart_count at the terminal state: $COUNT_AT_TERMINAL"
+
+sleep 15
+COUNT_LATER=$("$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json 2>/dev/null \
+  | jq -r '.restart_count // 0')
+[ "$COUNT_LATER" -eq "$COUNT_AT_TERMINAL" ] \
+  || fail "restart_count kept climbing after CrashLoopBackOff ($COUNT_AT_TERMINAL -> $COUNT_LATER): retries did not stop"
+log "restart_count held at $COUNT_LATER over 15s — retries stopped"
 
 # The failure must be explained, not just recorded as a status. An operator
 # reading the events should learn the boot was rejected.

--- a/tests/e2e/firecracker/t14_crashloop.sh
+++ b/tests/e2e/firecracker/t14_crashloop.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# T14-FC: a firecracker deployment that cannot boot must land in
+# CrashLoopBackOff after MAX_RESTART_COUNT (5) instead of being respawned
+# forever.
+#
+# Cloud Hypervisor has this coverage (t3_crashloop); Firecracker did not. An
+# unbounded retry loop is not a cosmetic bug on a VM runtime: every attempt
+# copies a rootfs and allocates a TAP, so a permanently failing deployment
+# would chew through disk and network interfaces until the host gave out.
+#
+# Strategy: point Ring at a bogus kernel (an empty file). Firecracker rejects
+# it at `PUT /boot-source`, producing a transient failure on every cycle —
+# exactly what the backoff and crash-loop bound are supposed to contain.
+#
+# This validates three things at once:
+#   1. failed boots really increment restart_count (not silently dropped),
+#   2. the scheduler's backoff spaces the retries out,
+#   3. the deployment lands in CrashLoopBackOff once the budget is spent.
+#
+# Requires: firecracker, /dev/kvm, CAP_NET_ADMIN on the ring binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=./setup.sh
+source "$SCRIPT_DIR/setup.sh"
+
+log "== T14-FC: crash loop must converge to CrashLoopBackOff =="
+
+# Override the kernel with a zero-byte file BEFORE setup_fc, so the bogus path
+# is what lands in Ring's config.toml. The cached real kernel is untouched.
+BOGUS_KERNEL="$(mktemp -t ring-e2e-bogus-kernel-XXXXXX.bin)"
+: > "$BOGUS_KERNEL"
+RING_E2E_FC_KERNEL="$BOGUS_KERNEL"
+export RING_E2E_FC_KERNEL
+log "bogus kernel created at $BOGUS_KERNEL"
+
+setup_fc
+start_ring
+ring_login
+
+FIXTURE="$RING_TEST_DIR/fc-crashloop.yaml"
+cat > "$FIXTURE" <<EOF
+deployments:
+  fc-crashloop:
+    name: fc-crashloop
+    namespace: ring-e2e
+    runtime: firecracker
+    image: "$RING_E2E_FC_ROOTFS"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: "256Mi"
+EOF
+
+"$RING_BIN" apply --file "$FIXTURE"
+
+DEPLOYMENT_ID=$(get_deployment_id "ring-e2e" "fc-crashloop")
+[ -n "$DEPLOYMENT_ID" ] || fail "could not find deployment id after apply"
+log "deployment id: $DEPLOYMENT_ID"
+
+# The backoff is exponential, so reaching the 5-attempt budget takes a while.
+# Poll for the terminal status rather than guessing at a fixed wait.
+log "waiting for CrashLoopBackOff (bounded retries)..."
+STATUS=""
+for _ in $(seq 1 180); do
+  STATUS=$("$RING_BIN" deployment list --output json 2>/dev/null \
+    | jq -r --arg ns "ring-e2e" --arg n "fc-crashloop" \
+        '.[] | select(.namespace==$ns and .name==$n) | .status' | head -n1)
+  [ "$STATUS" = "crash_loop_back_off" ] && break
+  sleep 1
+done
+
+if [ "$STATUS" != "crash_loop_back_off" ]; then
+  "$RING_BIN" deployment inspect "$DEPLOYMENT_ID" --output json 2>/dev/null | head -20 >&2 || true
+  fail "expected crash_loop_back_off, got '$STATUS' — retries are not bounded"
+fi
+log "reached crash_loop_back_off"
+
+# Landing in the terminal state is only half of it: the scheduler must also
+# STOP retrying. Without this, a deployment could report CrashLoopBackOff while
+# still burning a rootfs copy and a TAP every tick.
+ROOTFS_AT_TERMINAL=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+sleep 10
+ROOTFS_LATER=$(find "$RING_E2E_FC_SOCKET_DIR" -maxdepth 1 -name "*.ext4" 2>/dev/null | wc -l | tr -d ' ')
+[ "$ROOTFS_LATER" -le "$ROOTFS_AT_TERMINAL" ] \
+  || fail "rootfs images still accumulating after CrashLoopBackOff ($ROOTFS_AT_TERMINAL -> $ROOTFS_LATER): retries did not stop"
+log "no new artifacts after the terminal state — retries stopped"
+
+# The failure must be explained, not just recorded as a status. An operator
+# reading the events should learn the boot was rejected.
+#
+# `deployment events` has no --output json (it renders a table), so filter with
+# its own --level flag and match on the rendered text rather than piping a
+# non-JSON payload through jq.
+EVENTS=$("$RING_BIN" deployment events "$DEPLOYMENT_ID" --level error 2>/dev/null || echo "")
+echo "$EVENTS" | grep -qi "VmStartFailed\|VM start failed" \
+  || { printf '%s\n' "$EVENTS" | head -20 >&2; fail "no VM-start failure event recorded for a deployment that never booted"; }
+log "error events explain the boot failure"
+
+"$RING_BIN" deployment delete "$DEPLOYMENT_ID"
+rm -f "$BOGUS_KERNEL"
+
+log "== T14-FC: PASS — retries bounded, terminal state reached, failure explained =="

--- a/tests/e2e/firecracker/t14_crashloop.sh
+++ b/tests/e2e/firecracker/t14_crashloop.sh
@@ -37,9 +37,13 @@ RING_E2E_FC_KERNEL="$BOGUS_KERNEL"
 export RING_E2E_FC_KERNEL
 log "bogus kernel created at $BOGUS_KERNEL"
 
-# Reap it even when an assertion below exits early — `setup_fc` installs its own
-# trap, so this one has to be layered in after it rather than before.
+# Guard the file from the moment it exists: `setup_fc` can itself exit (no
+# firecracker, no /dev/kvm, no CAP_NET_ADMIN), and a trap installed only after
+# it would never run in those cases.
+trap 'rm -f "$BOGUS_KERNEL"' EXIT
+
 setup_fc
+# setup_fc replaces the trap with its own cleanup, so re-chain all three.
 trap 'rm -f "$BOGUS_KERNEL"; cleanup_fc; cleanup_ring' EXIT
 start_ring
 ring_login


### PR DESCRIPTION
Firecracker goes from 9 to 13 e2e tests, closing the gaps that mattered most against Cloud Hypervisor's 24.

## What was added

**`t12_environment.sh`** — environment variables must reach the NoCloud cidata payload. CH covers this (`t4`); Firecracker did not, despite sharing the cloud-init path. Env vars are how most workloads get configured, so "the VM booted" proves nothing if the config never arrived. Also asserts a value containing spaces survives intact — the case that breaks naive `KEY=value` emitters — and that the cidata image is reaped on delete.

**`t13_resource_limits.sh`** — `resources.limits` must reach the microVM's machine config. This reads Firecracker's own `/machine-config` over its API socket, so it checks what the hypervisor actually got rather than what Ring intended to send. Firecracker's sizing rules differ from CH's and are easy to break silently:
- fractional CPU rounds **up** (`1500m` → 2 vCPUs), where CH rounds down
- memory below 64 MiB falls back to the 512 MiB default rather than booting a VM too small for systemd

**`t14_crashloop.sh`** — a deployment that cannot boot must land in `CrashLoopBackOff` rather than retrying forever. On a VM runtime that is not cosmetic: every attempt copies a rootfs and allocates a TAP, so an unbounded loop eats disk and network interfaces until the host gives out. Asserts the terminal state, that artifacts stop accumulating after it, and that the failure is explained in the events.

## A bug in my own earlier test, now fixed

`t11_health_checks.sh` shipped in #212 with the `on_failure: alert` assertion removed, and a comment saying the alert "does not fire reliably within the window".

That was wrong. `ring deployment events` renders a table and has **no** `--output json` flag, so my `jq` filter was silently parsing tabular text and always yielding nothing. The alert fires within seconds, exactly as designed. The assertion is restored, using the command's own `--level` filter, and the board task tracking the phantom anomaly is closed.

Worth knowing for anyone writing e2e against this CLI: `deployment health-checks` supports `--output json`, `deployment events` does not.

## Verification

firecracker t1, t9, t10, t11, t12, t13, t14 all run and pass locally against real microVMs.
